### PR TITLE
feat: improve transaction history filtering and status display

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -65,6 +65,7 @@
   "sent_label": "Sent",
   "received_label": "Received",
   "pending_label": "Pending",
+  "failed_label": "Failed",
   "loading_transactions_error_prefix": "Error loading transactions: ",
   
   "lightning_address_title": "Lightning Address",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -65,6 +65,7 @@
   "sent_label": "Enviado",
   "received_label": "Recibido",
   "pending_label": "Pendiente",
+  "failed_label": "Fallida",
   "loading_transactions_error_prefix": "Error cargando transacciones: ",
   
   "lightning_address_title": "Dirección Lightning",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -65,6 +65,7 @@
   "sent_label": "Enviado",
   "received_label": "Recebido",
   "pending_label": "Pendente",
+  "failed_label": "Falhada",
   "loading_transactions_error_prefix": "Erro ao carregar transações: ",
   
   "lightning_address_title": "Endereço Lightning",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -448,6 +448,12 @@ abstract class AppLocalizations {
   /// **'Pendiente'**
   String get pending_label;
 
+  /// No description provided for @failed_label.
+  ///
+  /// In es, this message translates to:
+  /// **'Fallida'**
+  String get failed_label;
+
   /// No description provided for @loading_transactions_error_prefix.
   ///
   /// In es, this message translates to:

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -184,6 +184,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get pending_label => 'Pending';
 
   @override
+  String get failed_label => 'Failed';
+
+  @override
   String get loading_transactions_error_prefix =>
       'Error loading transactions: ';
 

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -186,6 +186,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get pending_label => 'Pendiente';
 
   @override
+  String get failed_label => 'Fallida';
+
+  @override
   String get loading_transactions_error_prefix =>
       'Error cargando transacciones: ';
 

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -186,6 +186,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get pending_label => 'Pendente';
 
   @override
+  String get failed_label => 'Falhada';
+
+  @override
   String get loading_transactions_error_prefix =>
       'Erro ao carregar transações: ';
 

--- a/lib/models/transaction_info.dart
+++ b/lib/models/transaction_info.dart
@@ -69,9 +69,11 @@ class TransactionInfo {
       
       // Determinar status
       TransactionStatus status = TransactionStatus.completed;
-      if (json['pending'] == true) {
+      
+      // Check both 'pending' boolean field and 'status' string field
+      if (json['pending'] == true || json['status'] == 'pending') {
         status = TransactionStatus.pending;
-      } else if (json['failed'] == true) {
+      } else if (json['failed'] == true || json['status'] == 'failed') {
         status = TransactionStatus.failed;
       }
 

--- a/lib/screens/7history_screen.dart
+++ b/lib/screens/7history_screen.dart
@@ -142,8 +142,6 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
         return _transactions.where((tx) => tx.isIncoming).toList();
       case TransactionFilter.outgoing:
         return _transactions.where((tx) => tx.isOutgoing).toList();
-      case TransactionFilter.pending:
-        return _transactions.where((tx) => tx.isPending).toList();
       case TransactionFilter.all:
       default:
         return _transactions;
@@ -401,8 +399,6 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
         return Icons.arrow_downward;
       case TransactionFilter.outgoing:
         return Icons.arrow_upward;
-      case TransactionFilter.pending:
-        return Icons.access_time;
     }
   }
 
@@ -414,16 +410,14 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
         return AppLocalizations.of(context)!.received_label;
       case TransactionFilter.outgoing:
         return AppLocalizations.of(context)!.sent_label;
-      case TransactionFilter.pending:
-        return AppLocalizations.of(context)!.pending_label;
     }
   }
 
   /// Determine appropriate icon for transaction based on status and type
   IconData _getTransactionIcon(TransactionInfo transaction) {
-    // Show clock icon for pending transactions regardless of type
+    // Show pending icon for pending transactions regardless of type
     if (transaction.isPending) {
-      return Icons.schedule;
+      return Icons.access_time;
     }
     
     // Show error icon for failed transactions
@@ -437,6 +431,35 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
     } else {
       return Icons.arrow_upward_rounded;
     }
+  }
+
+  /// Get transaction status label based on status and type
+  String _getTransactionStatusLabel(TransactionInfo transaction) {
+    if (transaction.isPending) {
+      return AppLocalizations.of(context)!.pending_label;
+    }
+    
+    if (transaction.isFailed) {
+      return AppLocalizations.of(context)!.failed_label;
+    }
+    
+    // For completed transactions, show direction
+    return transaction.isIncoming 
+        ? AppLocalizations.of(context)!.received_label 
+        : AppLocalizations.of(context)!.sent_label;
+  }
+
+  /// Get transaction status for details modal
+  String _getTransactionStatus(TransactionInfo transaction) {
+    if (transaction.isPending) {
+      return AppLocalizations.of(context)!.pending_label;
+    }
+    
+    if (transaction.isFailed) {
+      return AppLocalizations.of(context)!.failed_label;
+    }
+    
+    return AppLocalizations.of(context)!.valid_status;
   }
 
   /// Determine appropriate color for transaction based on status and type
@@ -455,7 +478,7 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
     if (transaction.isIncoming) {
       return Colors.green;
     } else {
-      return Colors.orange;
+      return Colors.red;
     }
   }
 
@@ -702,7 +725,7 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        transaction.isIncoming ? AppLocalizations.of(context)!.received_label : AppLocalizations.of(context)!.sent_label,
+                        _getTransactionStatusLabel(transaction),
                         style: const TextStyle(
                           color: Colors.white,
                           fontSize: 18,
@@ -712,7 +735,7 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
                       Text(
                         transaction.displayAmount,
                         style: TextStyle(
-                          color: transaction.isIncoming ? Colors.green : Colors.orange,
+                          color: _getTransactionIconColor(transaction),
                           fontSize: 24,
                           fontWeight: FontWeight.w700,
                         ),
@@ -731,7 +754,7 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
               _buildDetailRow('Hash', transaction.paymentHash!, copyable: true),
             if (transaction.fee != null)
               _buildDetailRow('Fee', '${transaction.fee} msat'),
-            _buildDetailRow(AppLocalizations.of(context)!.invoice_status_label, transaction.isPending ? AppLocalizations.of(context)!.pending_label : AppLocalizations.of(context)!.valid_status),
+            _buildDetailRow(AppLocalizations.of(context)!.invoice_status_label, _getTransactionStatus(transaction)),
             
             const SizedBox(height: 16),
             
@@ -802,5 +825,4 @@ enum TransactionFilter {
   all,
   incoming,
   outgoing,
-  pending,
 }


### PR DESCRIPTION
- Remove pending filter and show pending/failed transactions in corresponding filters

- Fix transaction status parsing to detect server 'status' field correctly

- Update transaction colors: outgoing transactions now show in red

- Add failed transaction labels for ES/EN/PT localizations

- Fix transaction details modal to show correct status (Pending/Failed)

- Update transaction icons: pending transactions use access_time icon