### PR TITLE
add universal bottom padding to prevent system UI overlapping

### DIFF
--- a/lib/screens/9receive_screen.dart
+++ b/lib/screens/9receive_screen.dart
@@ -13,6 +13,7 @@ import '../services/transaction_detector.dart';
 import '../models/lightning_invoice.dart';
 import '../models/wallet_info.dart';
 import '../l10n/generated/app_localizations.dart';
+import '../widgets/universal_screen_wrapper.dart';
 import '7ln_address_screen.dart';
 
 class ReceiveScreen extends StatefulWidget {
@@ -101,32 +102,36 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
           ),
         ),
         child: SafeArea(
-          child: Column(
-            children: [
-              // Header with navigation
-              _buildHeader(),
-              
-              // Main content
-              Expanded(
-                child: Consumer3<LNAddressProvider, WalletProvider, AuthProvider>(
-                  builder: (context, lnAddressProvider, walletProvider, authProvider, child) {
-                    final isMobile = MediaQuery.of(context).size.width < 768;
-                    return SingleChildScrollView(
-                      padding: EdgeInsets.symmetric(
-                        horizontal: isMobile ? 24.0 : 32.0,
-                        vertical: 16.0,
-                      ),
-                      child: Column(
-                        children: [
-                          SizedBox(height: isMobile ? 8 : 12),
-                          _buildMainContent(lnAddressProvider, walletProvider),
-                        ],
-                      ),
-                    );
-                  },
+          child: withBottomPadding(
+            context,
+            Column(
+              children: [
+                // Header with navigation
+                _buildHeader(),
+                
+                // Main content
+                Expanded(
+                  child: Consumer3<LNAddressProvider, WalletProvider, AuthProvider>(
+                    builder: (context, lnAddressProvider, walletProvider, authProvider, child) {
+                      final isMobile = MediaQuery.of(context).size.width < 768;
+                      return SingleChildScrollView(
+                        padding: EdgeInsets.symmetric(
+                          horizontal: isMobile ? 24.0 : 32.0,
+                          vertical: 16.0,
+                        ),
+                        child: Column(
+                          children: [
+                            SizedBox(height: isMobile ? 8 : 12),
+                            _buildMainContent(lnAddressProvider, walletProvider),
+                          ],
+                        ),
+                      );
+                    },
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
+            extraPadding: 24.0,
           ),
         ),
       ),

--- a/lib/widgets/universal_screen_wrapper.dart
+++ b/lib/widgets/universal_screen_wrapper.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+// Función helper para agregar padding inferior para evitar overlapping
+Widget withBottomPadding(BuildContext context, Widget child, {double extraPadding = 16.0}) {
+  final bottomInsets = MediaQuery.of(context).viewPadding.bottom;
+  
+  return Padding(
+    padding: EdgeInsets.only(
+      bottom: bottomInsets + extraPadding,
+    ),
+    child: child,
+  );
+}


### PR DESCRIPTION
fix #13 

Add universal bottom padding solution to prevent content overlapping with system navigation bars

  - Create withBottomPadding() helper function for dynamic margin calculation
  - Use MediaQuery.viewPadding.bottom to detect system bar height automatically
  - Apply solution to ReceiveScreen to fix overlapping issues
  - Preserve existing SingleChildScrollView functionality in all screens
  - Ensure responsive design across different device sizes
  - Maintain original screen layouts and animations
