### PR TITLE
enable Nostr Zaps by default for Lightning Addresses

### DIFF
--- a/lib/models/ln_address.dart
+++ b/lib/models/ln_address.dart
@@ -119,6 +119,7 @@ class LNAddress {
     int minAmount = 1,
     int maxAmount = 2100000000,
     int commentChars = 500,
+    bool zapsEnabled = true,
     String? successUrl,
     String? webhookHeaders,
     String? webhookBody,
@@ -130,6 +131,7 @@ class LNAddress {
       'min': minAmount,
       'comment_chars': commentChars,
       'username': username,
+      'zaps': zapsEnabled,
     };
     
     if (successUrl != null && successUrl.startsWith('https://')) {

--- a/lib/providers/ln_address_provider.dart
+++ b/lib/providers/ln_address_provider.dart
@@ -362,6 +362,7 @@ class LNAddressProvider extends ChangeNotifier {
     required String username,
     required String walletId,
     String? description,
+    bool zapsEnabled = true,
   }) async {
     _setCreating(true);
     _error = null;
@@ -386,6 +387,7 @@ class LNAddressProvider extends ChangeNotifier {
         username: username,
         walletId: walletId,
         description: description,
+        zapsEnabled: zapsEnabled,
       );
 
       _allAddresses.add(newAddress);

--- a/lib/screens/7ln_address_screen.dart
+++ b/lib/screens/7ln_address_screen.dart
@@ -1003,6 +1003,7 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
       username: _usernameController.text.trim().toLowerCase(),
       walletId: _selectedWalletId!,
       description: 'Lightning Address for ${selectedWallet.name}',
+      zapsEnabled: true,
     );
 
     if (success && mounted) {

--- a/lib/services/ln_address_service.dart
+++ b/lib/services/ln_address_service.dart
@@ -279,6 +279,7 @@ class LNAddressService {
     required String username,
     required String walletId,
     String? description,
+    bool zapsEnabled = true,
   }) async {
     try {
       _debugLog('[LN_ADDRESS_SERVICE] ⚡ Creating Lightning Address: $username for wallet $walletId');
@@ -310,6 +311,7 @@ class LNAddressService {
         minAmount: 1,
         maxAmount: 2100000000,
         commentChars: 500,
+        zapsEnabled: zapsEnabled,
       );
 
       _debugLog('[LN_ADDRESS_SERVICE] Payload to create:');


### PR DESCRIPTION
Enable Nostr Zaps by default when creating Lightning Addresses

  Previously, LaChispa did not send the 'zaps' parameter when creating
  Lightning Addresses, relying on server defaults which could disable
  Nostr Zaps functionality.

  Changes:
  - Add zapsEnabled parameter to LNAddress.createPayload() method
  - Update LNAddressService to send 'zaps: true' in creation requests
  - Modify LNAddressProvider to include zapsEnabled in createLNAddress()
  - Set zapsEnabled to true by default for optimal Nostr integration
  - Keep UI simple without user toggle - zaps always enabled
