### PR TITLE
language selector in welcome screen now shows all 7 languages

### DIFF
--- a/lib/providers/language_provider.dart
+++ b/lib/providers/language_provider.dart
@@ -157,7 +157,7 @@ class LanguageProvider extends ChangeNotifier {
       }
     }).toList();
     
-    // Sort alphabetically by language name
+    // Sort alphabetically by language name  
     languages.sort((a, b) => a['name']!.compareTo(b['name']!));
     return languages;
   }

--- a/lib/screens/1welcome_screen.dart
+++ b/lib/screens/1welcome_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'dart:math' as math;
 import 'dart:async';
 import '2start_screen.dart';
+import '18language_selection_screen.dart';
 import '../l10n/generated/app_localizations.dart';
 import '../providers/language_provider.dart';
 
@@ -176,24 +177,29 @@ class _WelcomeScreenState extends State<WelcomeScreen>
             
             // Main content
             SafeArea(
-              child: Stack(
+              child: Column(
                 children: [
-                  // Language selector in top right corner
-                  Positioned(
-                    top: 16,
-                    right: 24,
-                    child: _buildLanguageSelector(),
+                  // Top bar with language selector
+                  Padding(
+                    padding: const EdgeInsets.all(24.0),
+                    child: Row(
+                      children: [
+                        const Spacer(),
+                        _buildLanguageSelector(),
+                      ],
+                    ),
                   ),
                   
                   // Main content
-                  Padding(
+                  Expanded(
+                    child: Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 24),
                     child: SingleChildScrollView(
                       child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
+                        mainAxisAlignment: MainAxisAlignment.start,
                         crossAxisAlignment: CrossAxisAlignment.center,
                         children: [
-                        const SizedBox(height: 80),
+                        const SizedBox(height: 20),
                     
                     // Logo and Title with animation
                     AnimatedBuilder(
@@ -354,6 +360,7 @@ class _WelcomeScreenState extends State<WelcomeScreen>
                         ],
                       ),
                     ),
+                    ),
                   ),
                 ],
               ),
@@ -461,8 +468,16 @@ class _WelcomeScreenState extends State<WelcomeScreen>
   Widget _buildLanguageSelector() {
     return Consumer<LanguageProvider>(
       builder: (context, languageProvider, child) {
-        return GestureDetector(
-          onTap: () => _showLanguageSelector(context, languageProvider),
+        return InkWell(
+          onTap: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (context) => const LanguageSelectionScreen(),
+              ),
+            );
+          },
+          borderRadius: BorderRadius.circular(20),
           child: Container(
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
             decoration: BoxDecoration(
@@ -501,120 +516,6 @@ class _WelcomeScreenState extends State<WelcomeScreen>
     );
   }
 
-  void _showLanguageSelector(BuildContext context, LanguageProvider languageProvider) {
-    showModalBottomSheet(
-      context: context,
-      backgroundColor: Colors.transparent,
-      builder: (context) => Container(
-        decoration: const BoxDecoration(
-          color: Color(0xFF1A1D47),
-          borderRadius: BorderRadius.only(
-            topLeft: Radius.circular(24),
-            topRight: Radius.circular(24),
-          ),
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            // Handle bar
-            Container(
-              margin: const EdgeInsets.only(top: 12),
-              width: 40,
-              height: 4,
-              decoration: BoxDecoration(
-                color: Colors.white.withValues(alpha: 0.3),
-                borderRadius: BorderRadius.circular(2),
-              ),
-            ),
-            
-            // Header
-            Container(
-              padding: const EdgeInsets.all(24),
-              child: Row(
-                children: [
-                  const Icon(
-                    Icons.language,
-                    color: Color(0xFF4C63F7),
-                    size: 24,
-                  ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: Text(
-                      AppLocalizations.of(context)!.language_selector_title,
-                      style: const TextStyle(
-                        color: Colors.white,
-                        fontSize: 20,
-                        fontWeight: FontWeight.w600,
-                        fontFamily: 'Inter',
-                      ),
-                    ),
-                  ),
-                  IconButton(
-                    onPressed: () => Navigator.pop(context),
-                    icon: Icon(
-                      Icons.close,
-                      color: Colors.white.withValues(alpha: 0.7),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            
-            // Language options
-            ...languageProvider.getAvailableLanguages().map((language) {
-              final isSelected = languageProvider.currentLocale.languageCode == language['code'];
-              
-              return Container(
-                margin: const EdgeInsets.symmetric(horizontal: 24, vertical: 4),
-                decoration: BoxDecoration(
-                  color: isSelected 
-                    ? const Color(0xFF2D3FE7).withValues(alpha: 0.2)
-                    : Colors.transparent,
-                  borderRadius: BorderRadius.circular(12),
-                  border: isSelected 
-                    ? Border.all(color: const Color(0xFF2D3FE7), width: 1)
-                    : null,
-                ),
-                child: ListTile(
-                  contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                  leading: Text(
-                    language['flag']!,
-                    style: const TextStyle(fontSize: 24),
-                  ),
-                  title: Text(
-                    language['name']!,
-                    style: TextStyle(
-                      color: Colors.white,
-                      fontSize: 16,
-                      fontWeight: isSelected ? FontWeight.w600 : FontWeight.w500,
-                      fontFamily: 'Inter',
-                    ),
-                  ),
-                  trailing: isSelected 
-                    ? const Icon(
-                        Icons.check,
-                        color: Color(0xFF4C63F7),
-                        size: 20,
-                      )
-                    : null,
-                  onTap: () async {
-                    await languageProvider.changeLanguage(
-                      Locale(language['code']!, ''),
-                    );
-                    if (mounted) {
-                      Navigator.pop(context);
-                    }
-                  },
-                ),
-              );
-            }).toList(),
-            
-            const SizedBox(height: 32),
-          ],
-        ),
-      ),
-    );
-  }
 }
 
 class Particle {


### PR DESCRIPTION
fix #25

- Fix language selector button functionality in welcome screen
- Move language selector out of Stack to prevent touch event interference
- Update navigation to use LanguageSelectionScreen instead of modal
- Improve content positioning for better visual balance
- Add support for all 7 languages: Spanish, English, Portuguese, German, French, Italian, Russian