### PR TITLE
implement complete fiat currency support in transaction history

### DIFF
--- a/lib/screens/7history_screen.dart
+++ b/lib/screens/7history_screen.dart
@@ -748,18 +748,26 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
     showModalBottomSheet(
       context: context,
       backgroundColor: Colors.transparent,
-      builder: (context) => Container(
-        decoration: const BoxDecoration(
-          color: Color(0xFF1A1D47),
-          borderRadius: BorderRadius.only(
-            topLeft: Radius.circular(20),
-            topRight: Radius.circular(20),
+      isScrollControlled: true,
+      builder: (context) => DraggableScrollableSheet(
+        initialChildSize: 0.7,
+        maxChildSize: 0.9,
+        minChildSize: 0.5,
+        builder: (context, scrollController) => Container(
+          decoration: const BoxDecoration(
+            color: Color(0xFF1A1D47),
+            borderRadius: BorderRadius.only(
+              topLeft: Radius.circular(20),
+              topRight: Radius.circular(20),
+            ),
           ),
-        ),
-        padding: const EdgeInsets.all(24),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
+          child: SingleChildScrollView(
+            controller: scrollController,
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Row(
               children: [
@@ -864,7 +872,10 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
                 child: Text(AppLocalizations.of(context)!.cancel_button),
               ),
             ),
-          ],
+                ],
+              ),
+            ),
+          ),
         ),
       ),
     );

--- a/lib/screens/9receive_screen.dart
+++ b/lib/screens/9receive_screen.dart
@@ -1407,14 +1407,29 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
       print('[RECEIVE_SCREEN] Generando factura: $amountInSats sats');
       print('[RECEIVE_SCREEN] Server: $serverUrl');
       print('[RECEIVE_SCREEN] Wallet: ${wallet.name}');
+      print('[RECEIVE_SCREEN] Original currency: $_selectedCurrency');
+      print('[RECEIVE_SCREEN] Original amount: $amount');
+      print('[RECEIVE_SCREEN] Original rate: ${_selectedCurrency != 'sats' ? (amountInSats / amount) : 'N/A'}');
 
-      // Generate invoice with amount in satoshis
+      // Prepare memo with fiat info as fallback for LNBits limitations
+      String? finalMemo;
+      if (_noteController.text.trim().isNotEmpty) {
+        finalMemo = _noteController.text.trim();
+      } else if (_selectedCurrency != 'sats') {
+        // Use fiat amount as memo when no custom note (fallback for LNBits)
+        finalMemo = '${amount.toStringAsFixed(amount.truncateToDouble() == amount ? 0 : 2)} $_selectedCurrency';
+      }
+
+      // Generate invoice with amount in satoshis and original fiat information
       final invoice = await _invoiceService.createInvoice(
         serverUrl: serverUrl,
         adminKey: wallet.adminKey,
         amount: amountInSats,
-        memo: _noteController.text.trim().isNotEmpty ? _noteController.text.trim() : null,
+        memo: finalMemo,
         comment: _noteController.text.trim().isNotEmpty ? _noteController.text.trim() : null,
+        originalFiatCurrency: _selectedCurrency != 'sats' ? _selectedCurrency : null,
+        originalFiatAmount: _selectedCurrency != 'sats' ? amount : null,
+        originalFiatRate: _selectedCurrency != 'sats' ? (amountInSats / amount) : null,
       );
 
       // Update state

--- a/lib/services/wallet_service.dart
+++ b/lib/services/wallet_service.dart
@@ -347,19 +347,12 @@ class WalletService {
             if (response.data is List && (response.data as List).isNotEmpty) {
               print('First transaction raw data:');
               print((response.data as List).first);
-              if ((response.data as List).length > 1) {
-                print('Second transaction raw data:');
-                print((response.data as List)[1]);
-              }
-            } else if (response.data is Map<String, dynamic>) {
-              print('Response map keys: ${(response.data as Map).keys.toList()}');
-              final data = response.data as Map<String, dynamic>;
-              if (data.containsKey('payments') && data['payments'] is List && (data['payments'] as List).isNotEmpty) {
-                print('First payment raw data:');
-                print((data['payments'] as List).first);
-                if ((data['payments'] as List).length > 1) {
-                  print('Second payment raw data:');
-                  print((data['payments'] as List)[1]);
+              // Look specifically for our new invoices in the first few transactions
+              for (int i = 0; i < (response.data as List).length && i < 5; i++) {
+                final tx = (response.data as List)[i];
+                if (tx is Map && tx['extra'] != null) {
+                  print('--- Transaction $i extra field ---');
+                  print(tx['extra']);
                 }
               }
             }


### PR DESCRIPTION
  - Add original request currency display alongside wallet default currency
  - Extract fiat information from LNBits API 'extra' field and memo fallback
  - Update TransactionInfo model with comprehensive fiat fields:
    * fiatCurrency, fiatAmount, fiatRate (wallet default currency)  
    * originalFiatCurrency, originalFiatAmount, originalFiatRate (request currency)
  - Implement intelligent memo-based fallback when LNBits ignores fiat parameters
  - Replace ListTile with custom layout for better spacing control
  - Add scrollable modal for transaction details to prevent overflow
  - Support multiple LNBits API approaches for fiat invoice creation
  - Display hierarchical currency information: sats → wallet fiat → original fiat
  - Improve typography with larger font sizes for better readability