### PR TITLE
Lightning Address server detection bug

### DIFF
--- a/lib/providers/ln_address_provider.dart
+++ b/lib/providers/ln_address_provider.dart
@@ -36,6 +36,8 @@ class LNAddressProvider extends ChangeNotifier {
     if (_serverUrl != serverUrl) {
       _serverUrl = serverUrl;
       _clearServerCache();
+      // Update the underlying service URL to ensure consistency
+      _lnAddressService.updateBaseUrl(serverUrl);
       print('[LN_ADDRESS_PROVIDER] Server configured: $serverUrl');
     }
   }

--- a/lib/services/ln_address_service.dart
+++ b/lib/services/ln_address_service.dart
@@ -13,7 +13,7 @@ void _debugLog(String message) {
 
 class LNAddressService {
   final Dio _dio;
-  final String _baseUrl;
+  String _baseUrl;
 
   LNAddressService(this._baseUrl) : _dio = Dio() {
     _configureDio();
@@ -246,9 +246,19 @@ class LNAddressService {
     }
   }
 
+  /// Update base URL dynamically - used when server changes
+  void updateBaseUrl(String newBaseUrl) {
+    _debugLog('[LN_ADDRESS_SERVICE] 🔄 Updating base URL from $_baseUrl to $newBaseUrl');
+    _baseUrl = newBaseUrl;
+    _dio.options.baseUrl = newBaseUrl;
+    _debugLog('[LN_ADDRESS_SERVICE] ✅ Base URL updated successfully');
+  }
+
   // Detect specific server and get optimized endpoints
   List<String> _getOptimizedEndpoints() {
     final serverUrl = _baseUrl.toLowerCase();
+    
+    _debugLog('[LN_ADDRESS_SERVICE] 🔍 Server URL for detection: $serverUrl');
     
     // Detection of specific servers according to official source code
     if (serverUrl.contains('lachispa.me')) {


### PR DESCRIPTION
- Fixes critical bug where Lightning Address service was sending requests to wrong server
- Makes base URL mutable and adds dynamic update capability
- Ensures provider and service stay synchronized when server changes

Changes Made
- LNAddressService: Changed `_baseUrl` from final to mutable, added `updateBaseUrl()` method
- LNAddressProvider: Added service synchronization in `setServerUrl()` method
- Debugging: Added logs to track server URL detection and updates