### PR TITLE
Add deep links support for Lightning payment URLs

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 android {
     namespace = "com.example.chispa"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -24,6 +24,50 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <!-- Intent filters for Lightning payment URLs -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="bitcoin" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="lightning" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="lnurl" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="lnurlw" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="lnurlp" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="lnurlc" />
+            </intent-filter>
+            <!-- LaChispa specific scheme -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="lachispa" />
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -45,5 +45,64 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>lachispa.bitcoin</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>bitcoin</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>lachispa.lightning</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>lightning</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>lachispa.lnurl</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>lnurl</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>lachispa.lnurlw</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>lnurlw</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>lachispa.lnurlp</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>lnurlp</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>lachispa.lnurlc</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>lnurlc</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>lachispa.app</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>lachispa</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -249,5 +249,8 @@
   "tap_to_cycle": "Tippen, um Währungen zu wechseln",
   "calculating_text": "Berechne...",
   "settings_screen_title": "Einstellungen",
-  "about_title": "Über"
+  "about_title": "Über",
+  
+  "deep_link_login_required_title": "Anmeldung erforderlich",
+  "deep_link_login_required_message": "Sie müssen sich in Ihr LaChispa-Konto einloggen, um diese Zahlung zu verarbeiten."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -255,5 +255,8 @@
   "checking_currency_availability": "Checking {currency} availability...",
   "currency_added_successfully": "{currency} added successfully",
   "currency_not_available_on_server": "{currencyName} ({currency}) is not available on this server",
-  "error_checking_currency": "Error checking {currency}: {error}"
+  "error_checking_currency": "Error checking {currency}: {error}",
+  
+  "deep_link_login_required_title": "Login Required",
+  "deep_link_login_required_message": "You must log in to your LaChispa account to process this payment."
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -255,5 +255,8 @@
   "checking_currency_availability": "Verificando disponibilidad de {currency}...",
   "currency_added_successfully": "{currency} agregado correctamente",
   "currency_not_available_on_server": "{currencyName} ({currency}) no está disponible en este servidor",
-  "error_checking_currency": "Error verificando {currency}: {error}"
+  "error_checking_currency": "Error verificando {currency}: {error}",
+  
+  "deep_link_login_required_title": "Inicio de sesión requerido",
+  "deep_link_login_required_message": "Debes iniciar sesión en tu cuenta LaChispa para procesar este pago."
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -249,5 +249,8 @@
   "tap_to_cycle": "Appuyez pour parcourir les devises",
   "calculating_text": "Calcul...",
   "settings_screen_title": "Paramètres",
-  "about_title": "À propos"
+  "about_title": "À propos",
+  
+  "deep_link_login_required_title": "Connexion requise",
+  "deep_link_login_required_message": "Vous devez vous connecter à votre compte LaChispa pour traiter ce paiement."
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -249,5 +249,8 @@
   "tap_to_cycle": "Tocca per scorrere le valute",
   "calculating_text": "Calcolo...",
   "settings_screen_title": "Impostazioni",
-  "about_title": "Informazioni"
+  "about_title": "Informazioni",
+  
+  "deep_link_login_required_title": "Accesso richiesto",
+  "deep_link_login_required_message": "Devi accedere al tuo account LaChispa per elaborare questo pagamento."
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -255,5 +255,8 @@
   "checking_currency_availability": "Verificando disponibilidade de {currency}...",
   "currency_added_successfully": "{currency} adicionado com sucesso",
   "currency_not_available_on_server": "{currencyName} ({currency}) não está disponível neste servidor",
-  "error_checking_currency": "Erro ao verificar {currency}: {error}"
+  "error_checking_currency": "Erro ao verificar {currency}: {error}",
+  
+  "deep_link_login_required_title": "Login Necessário",
+  "deep_link_login_required_message": "Você deve fazer login em sua conta LaChispa para processar este pagamento."
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -249,5 +249,8 @@
   "tap_to_cycle": "Нажмите для переключения валют",
   "calculating_text": "Вычисление...",
   "settings_screen_title": "Настройки",
-  "about_title": "Информация"
+  "about_title": "Информация",
+  
+  "deep_link_login_required_title": "Требуется вход в систему",
+  "deep_link_login_required_message": "Вы должны войти в свою учетную запись LaChispa для обработки этого платежа."
 }

--- a/lib/screens/10send_screen.dart
+++ b/lib/screens/10send_screen.dart
@@ -10,7 +10,9 @@ import '../widgets/qr_scanner_widget.dart';
 import '../l10n/generated/app_localizations.dart';
 
 class SendScreen extends StatefulWidget {
-  const SendScreen({super.key});
+  final String? initialPaymentData;
+  
+  const SendScreen({super.key, this.initialPaymentData});
 
   @override
   State<SendScreen> createState() => _SendScreenState();
@@ -26,6 +28,24 @@ class _SendScreenState extends State<SendScreen> {
     super.initState();
     // Listen to text changes for automatic validation
     _inputController.addListener(_onTextChanged);
+    
+    // Set initial payment data if provided from deep link
+    if (widget.initialPaymentData != null) {
+      print('[SendScreen] Received initial payment data: ${widget.initialPaymentData}');
+      _inputController.text = widget.initialPaymentData!;
+      // Auto-process if valid payment data
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        print('[SendScreen] Checking if input is valid...');
+        if (_hasValidInput()) {
+          print('[SendScreen] Valid input detected, processing payment...');
+          _processPayment();
+        } else {
+          print('[SendScreen] Invalid input: ${widget.initialPaymentData}');
+        }
+      });
+    } else {
+      print('[SendScreen] No initial payment data provided');
+    }
   }
 
   @override

--- a/lib/services/deep_link_service.dart
+++ b/lib/services/deep_link_service.dart
@@ -1,0 +1,147 @@
+import 'dart:async';
+import 'package:app_links/app_links.dart';
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class DeepLinkService {
+  static final DeepLinkService _instance = DeepLinkService._internal();
+  factory DeepLinkService() => _instance;
+  DeepLinkService._internal();
+
+  final AppLinks _appLinks = AppLinks();
+  StreamSubscription<Uri>? _linkSubscription;
+  
+  // Callback to handle incoming links
+  Function(Uri)? _onLinkReceived;
+
+  /// Initialize deep link handling
+  Future<void> initialize({Function(Uri)? onLinkReceived}) async {
+    _onLinkReceived = onLinkReceived;
+    
+    // Handle app launch from deep link (when app is closed)
+    try {
+      final initialUri = await _appLinks.getInitialLink();
+      if (initialUri != null) {
+        _handleIncomingLink(initialUri);
+      }
+    } catch (e) {
+      print('[DEEP_LINK] Error getting initial link: $e');
+    }
+
+    // Handle app resume from deep link (when app is running/paused)
+    _linkSubscription = _appLinks.uriLinkStream.listen(
+      (Uri uri) {
+        _handleIncomingLink(uri);
+      },
+      onError: (err) {
+        print('[DEEP_LINK] Error listening to link stream: $err');
+      },
+    );
+  }
+
+  /// Handle incoming deep link
+  void _handleIncomingLink(Uri uri) {
+    print('[DEEP_LINK] Received link: $uri');
+    
+    // Validate if it's a supported scheme
+    if (_isSupportedScheme(uri.scheme)) {
+      _onLinkReceived?.call(uri);
+    } else {
+      print('[DEEP_LINK] Unsupported scheme: ${uri.scheme}');
+    }
+  }
+
+  /// Check if the URI scheme is supported by LaChispa
+  bool _isSupportedScheme(String scheme) {
+    const supportedSchemes = [
+      'bitcoin',
+      'lightning', 
+      'lnurl',
+      'lnurlw',
+      'lnurlp',
+      'lnurlc',
+      'lachispa'
+    ];
+    return supportedSchemes.contains(scheme.toLowerCase());
+  }
+
+  /// Parse Bitcoin URI and extract amount, label, message, etc.
+  Map<String, String> parseBitcoinUri(Uri uri) {
+    final Map<String, String> params = {};
+    
+    // Extract address from path
+    if (uri.path.isNotEmpty) {
+      params['address'] = uri.path;
+    }
+    
+    // Extract query parameters (amount, label, message, etc.)
+    uri.queryParameters.forEach((key, value) {
+      params[key] = value;
+    });
+    
+    return params;
+  }
+
+  /// Parse Lightning invoice/LNURL
+  String parseLightningUri(Uri uri) {
+    // For lightning: scheme, the invoice is usually in the path
+    if (uri.scheme.toLowerCase() == 'lightning') {
+      return uri.toString().replaceFirst('lightning:', '');
+    }
+    
+    // For LNURL schemes, return the full URI
+    return uri.toString();
+  }
+
+  /// Set callback for handling links
+  void setOnLinkReceived(Function(Uri) callback) {
+    _onLinkReceived = callback;
+  }
+
+  /// Store pending payment data for after login
+  Future<void> storePendingPayment(String paymentData) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString('pending_payment_data', paymentData);
+      print('[DEEP_LINK] Stored pending payment data: $paymentData');
+    } catch (e) {
+      print('[DEEP_LINK] Error storing pending payment: $e');
+    }
+  }
+
+  /// Retrieve and clear pending payment data
+  Future<String?> getPendingPayment() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final paymentData = prefs.getString('pending_payment_data');
+      print('[DEEP_LINK] Checking pending payment data: $paymentData');
+      if (paymentData != null) {
+        await prefs.remove('pending_payment_data');
+        print('[DEEP_LINK] Retrieved and cleared pending payment data: $paymentData');
+      } else {
+        print('[DEEP_LINK] No pending payment data found');
+      }
+      return paymentData;
+    } catch (e) {
+      print('[DEEP_LINK] Error retrieving pending payment: $e');
+      return null;
+    }
+  }
+
+  /// Check if there's pending payment data
+  Future<bool> hasPendingPayment() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      return prefs.containsKey('pending_payment_data');
+    } catch (e) {
+      print('[DEEP_LINK] Error checking pending payment: $e');
+      return false;
+    }
+  }
+
+  /// Clean up resources
+  void dispose() {
+    _linkSubscription?.cancel();
+    _linkSubscription = null;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   url_launcher: ^6.2.2
   webview_flutter: ^4.4.2
   package_info_plus: ^8.3.1
+  app_links: ^6.3.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Configure intent filters for Android (bitcoin:, lightning:, lnurl*)
- Add URL schemes for iOS platform support
- Create DeepLinkService for centralized link handling
- Implement auto-navigation to SendScreen for logged users
- Add internationalized login-required dialog (7 languages)
- Support schemes: bitcoin, lightning, lnurl, lnurlw, lnurlp, lnurlc
- Update NDK to v27 for compatibility with app_links plugin