### PR TITLE
Remove BTC Lake server option from server settings

### DIFF
--- a/lib/providers/server_provider.dart
+++ b/lib/providers/server_provider.dart
@@ -9,7 +9,6 @@ class ServerProvider with ChangeNotifier {
 
   static const Map<String, String> _defaultServers = {
     'LaChispa': 'https://lachispa.me',
-    'BTC Lake': 'https://lnbits.btclake.org',
   };
 
   String get selectedServer => _selectedServer;


### PR DESCRIPTION
- Eliminated 'BTC Lake' entry from defaultServers map
- Users can now only select LaChispa as predefined server option
- Custom server input remains available for other servers
