### PR TITLE
Add Docker support for web deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,53 @@
+# Flutter build outputs
+build/
+.dart_tool/
+.packages
+
+# IDE files
+.vscode/
+.idea/
+*.iml
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Git
+.git/
+.gitignore
+
+# Documentation
+README.md
+*.md
+
+# Docker files
+Dockerfile*
+docker-compose*
+.dockerignore
+
+# Logs
+*.log
+
+# Test files
+test/
+integration_test/
+
+# Coverage
+coverage/
+
+# Android specific
+android/app/upload-keystore.jks
+android/key.properties
+
+# iOS specific
+ios/Flutter/Flutter.framework
+ios/Flutter/Flutter.podspec
+ios/Pods/
+*.mobileprovision
+*.p12
+
+# Web specific (excluding the build output)
+web/*.js.map
+
+# Environment variables
+.env*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# Multi-stage build for LaChispa Flutter Web App  
+FROM ghcr.io/cirruslabs/flutter:latest AS build
+
+WORKDIR /app
+
+# Copy dependency files first for better caching
+COPY pubspec.yaml pubspec.lock ./
+
+# Get dependencies
+RUN flutter pub get
+
+# Copy the rest of the application
+COPY . .
+
+# Build Flutter web app for production
+RUN flutter build web --release
+
+# Production stage with Nginx
+FROM nginx:alpine
+
+# Copy built web files
+COPY --from=build /app/build/web /usr/share/nginx/html
+
+# Copy custom nginx configuration
+COPY nginx.conf /etc/nginx/nginx.conf
+
+# Expose port 80
+EXPOSE 80
+
+# Start nginx
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+
+services:
+  lachispa-web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: lachispa-web
+    ports:
+      - "7777:80"
+    restart: unless-stopped
+    environment:
+      - NGINX_HOST=localhost
+      - NGINX_PORT=80
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.lachispa.rule=Host(`lachispa.local`)"
+      - "traefik.http.services.lachispa.loadbalancer.server.port=80"
+    networks:
+      - lachispa-network
+
+networks:
+  lachispa-network:
+    driver: bridge

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,75 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    
+    # Gzip compression
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_types
+        text/plain
+        text/css
+        text/xml
+        text/javascript
+        application/json
+        application/javascript
+        application/xml+rss
+        application/atom+xml
+        image/svg+xml;
+
+    server {
+        listen 80;
+        server_name localhost;
+        root /usr/share/nginx/html;
+        index index.html;
+        
+        # Security headers
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        
+        # Main location for Flutter SPA
+        location / {
+            try_files $uri $uri/ /index.html;
+            
+            # PWA headers
+            add_header Cache-Control "no-cache, no-store, must-revalidate";
+            add_header Pragma "no-cache";
+            add_header Expires "0";
+        }
+        
+        # Cache static assets
+        location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+            add_header Access-Control-Allow-Origin "*";
+        }
+        
+        # Cache Flutter assets
+        location ~* ^/(assets|canvaskit)/ {
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+        }
+        
+        # Service worker should not be cached
+        location = /flutter_service_worker.js {
+            add_header Cache-Control "no-cache, no-store, must-revalidate";
+            add_header Pragma "no-cache";
+            add_header Expires "0";
+        }
+        
+        # Manifest file
+        location = /manifest.json {
+            add_header Cache-Control "no-cache, no-store, must-revalidate";
+            add_header Pragma "no-cache";
+            add_header Expires "0";
+        }
+    }
+}


### PR DESCRIPTION
- Add Dockerfile with multi-stage build (Flutter + Nginx)
- Add docker-compose.yml for easy orchestration on port 7777
- Add nginx.conf optimized for Flutter PWA with gzip and caching
- Add .dockerignore to exclude unnecessary files
- Enable web deployment with: docker compose up --build -d

