### PR TITLE
theme: migrate all screens and widgets to consume AppTokens

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -209,6 +209,25 @@
   "lightning_address_delete": "Löschen",
   "lightning_address_is_default": "Ist Standard",
   "lightning_address_set_default": "Als Standard festlegen",
+  "lightning_address_delete_title": "Lightning-Adresse löschen",
+  "lightning_address_delete_confirm": "Möchten Sie {address} wirklich löschen?",
+  "@lightning_address_delete_confirm": {
+    "placeholders": {
+      "address": {
+        "type": "String"
+      }
+    }
+  },
+  "lightning_address_created_success": "Lightning-Adresse erstellt",
+  "lightning_address_deleted_success": "Lightning-Adresse gelöscht",
+  "lightning_address_set_default_success": "{address} ist jetzt Ihre Standard-Lightning-Adresse",
+  "@lightning_address_set_default_success": {
+    "placeholders": {
+      "address": {
+        "type": "String"
+      }
+    }
+  },
   "create_new_wallet_help": "Neue Wallet erstellen",
   "create_wallet_short_description": "Um eine neue Wallet zu erstellen, greifen Sie über den Browser auf Ihr LNBits-Panel zu und verwenden Sie die Option \"Wallet erstellen\".",
   "create_wallet_detailed_instructions": "Um eine neue Wallet zu erstellen:\\n\\n1. Öffnen Sie Ihren Webbrowser\\n2. Greifen Sie auf Ihren LNBits-Server zu\\n3. Melden Sie sich mit Ihrem Konto an\\n4. Suchen Sie nach der Schaltfläche \"Wallet erstellen\"\\n5. Vergeben Sie einen Namen für Ihre neue Wallet\\n6. Kehren Sie zu LaChispa zurück und aktualisieren Sie Ihre Wallets\\n\\nDie neue Wallet wird automatisch in Ihrer Liste angezeigt.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -268,6 +268,25 @@
   "lightning_address_delete": "Delete",
   "lightning_address_is_default": "Is default",
   "lightning_address_set_default": "Set as default",
+  "lightning_address_delete_title": "Delete Lightning address",
+  "lightning_address_delete_confirm": "Are you sure you want to delete {address}?",
+  "@lightning_address_delete_confirm": {
+    "placeholders": {
+      "address": {
+        "type": "String"
+      }
+    }
+  },
+  "lightning_address_created_success": "Lightning address created",
+  "lightning_address_deleted_success": "Lightning address deleted",
+  "lightning_address_set_default_success": "{address} is now your default Lightning address",
+  "@lightning_address_set_default_success": {
+    "placeholders": {
+      "address": {
+        "type": "String"
+      }
+    }
+  },
   "create_new_wallet_help": "Create new wallet",
   "create_wallet_short_description": "To create a new wallet, access your LNBits panel from the browser and use the \"Create wallet\" option.",
   "create_wallet_detailed_instructions": "To create a new wallet:\\n\\n1. Open your web browser\\n2. Access your LNBits server\\n3. Log in with your account\\n4. Look for the \"Create wallet\" button\\n5. Assign a name to your new wallet\\n6. Return to LaChispa and refresh your wallets\\n\\nThe new wallet will appear automatically in your list.",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -263,6 +263,25 @@
   "lightning_address_delete": "Eliminar",
   "lightning_address_is_default": "Es por defecto",
   "lightning_address_set_default": "Establecer como por defecto",
+  "lightning_address_delete_title": "Eliminar dirección Lightning",
+  "lightning_address_delete_confirm": "¿Seguro que quieres eliminar {address}?",
+  "@lightning_address_delete_confirm": {
+    "placeholders": {
+      "address": {
+        "type": "String"
+      }
+    }
+  },
+  "lightning_address_created_success": "Dirección Lightning creada",
+  "lightning_address_deleted_success": "Dirección Lightning eliminada",
+  "lightning_address_set_default_success": "{address} es ahora tu dirección Lightning por defecto",
+  "@lightning_address_set_default_success": {
+    "placeholders": {
+      "address": {
+        "type": "String"
+      }
+    }
+  },
   "create_new_wallet_help": "Crear nueva billetera",
   "create_wallet_short_description": "Para crear una nueva billetera, accede a tu panel LNBits desde el navegador y usa la opción \"Crear billetera\".",
   "create_wallet_detailed_instructions": "Para crear una nueva billetera:\\n\\n1. Abre tu navegador web\\n2. Accede a tu servidor LNBits\\n3. Inicia sesión con tu cuenta\\n4. Busca el botón \"Crear billetera\"\\n5. Asigna un nombre a tu nueva billetera\\n6. Regresa a LaChispa y actualiza tus billeteras\\n\\nLa nueva billetera aparecerá automáticamente en tu lista.",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -209,6 +209,25 @@
   "lightning_address_delete": "Supprimer",
   "lightning_address_is_default": "Est par défaut",
   "lightning_address_set_default": "Définir par défaut",
+  "lightning_address_delete_title": "Supprimer l'adresse Lightning",
+  "lightning_address_delete_confirm": "Voulez-vous vraiment supprimer {address} ?",
+  "@lightning_address_delete_confirm": {
+    "placeholders": {
+      "address": {
+        "type": "String"
+      }
+    }
+  },
+  "lightning_address_created_success": "Adresse Lightning créée",
+  "lightning_address_deleted_success": "Adresse Lightning supprimée",
+  "lightning_address_set_default_success": "{address} est maintenant votre adresse Lightning par défaut",
+  "@lightning_address_set_default_success": {
+    "placeholders": {
+      "address": {
+        "type": "String"
+      }
+    }
+  },
   "create_new_wallet_help": "Créer un nouveau portefeuille",
   "create_wallet_short_description": "Pour créer un nouveau portefeuille, accédez à votre panneau LNBits depuis le navigateur et utilisez l'option \"Créer un portefeuille\".",
   "create_wallet_detailed_instructions": "Pour créer un nouveau portefeuille :\\n\\n1. Ouvrez votre navigateur web\\n2. Accédez à votre serveur LNBits\\n3. Connectez-vous avec votre compte\\n4. Recherchez le bouton \"Créer un portefeuille\"\\n5. Attribuez un nom à votre nouveau portefeuille\\n6. Retournez à LaChispa et actualisez vos portefeuilles\\n\\nLe nouveau portefeuille apparaîtra automatiquement dans votre liste.",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -209,6 +209,25 @@
   "lightning_address_delete": "Elimina",
   "lightning_address_is_default": "È predefinito",
   "lightning_address_set_default": "Imposta come predefinito",
+  "lightning_address_delete_title": "Elimina indirizzo Lightning",
+  "lightning_address_delete_confirm": "Sei sicuro di voler eliminare {address}?",
+  "@lightning_address_delete_confirm": {
+    "placeholders": {
+      "address": {
+        "type": "String"
+      }
+    }
+  },
+  "lightning_address_created_success": "Indirizzo Lightning creato",
+  "lightning_address_deleted_success": "Indirizzo Lightning eliminato",
+  "lightning_address_set_default_success": "{address} è ora il tuo indirizzo Lightning predefinito",
+  "@lightning_address_set_default_success": {
+    "placeholders": {
+      "address": {
+        "type": "String"
+      }
+    }
+  },
   "create_new_wallet_help": "Crea nuovo portafoglio",
   "create_wallet_short_description": "Per creare un nuovo portafoglio, accedi al tuo pannello LNBits dal browser e usa l'opzione \"Crea portafoglio\".",
   "create_wallet_detailed_instructions": "Per creare un nuovo portafoglio:\\n\\n1. Apri il tuo browser web\\n2. Accedi al tuo server LNBits\\n3. Effettua l'accesso con il tuo account\\n4. Cerca il pulsante \"Crea portafoglio\"\\n5. Assegna un nome al tuo nuovo portafoglio\\n6. Torna a LaChispa e aggiorna i tuoi portafogli\\n\\nIl nuovo portafoglio apparirà automaticamente nella tua lista.",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -209,6 +209,25 @@
   "lightning_address_delete": "Eliminar",
   "lightning_address_is_default": "É por defeito",
   "lightning_address_set_default": "Definir como por defeito",
+  "lightning_address_delete_title": "Eliminar endereço Lightning",
+  "lightning_address_delete_confirm": "Tem a certeza de que deseja eliminar {address}?",
+  "@lightning_address_delete_confirm": {
+    "placeholders": {
+      "address": {
+        "type": "String"
+      }
+    }
+  },
+  "lightning_address_created_success": "Endereço Lightning criado",
+  "lightning_address_deleted_success": "Endereço Lightning eliminado",
+  "lightning_address_set_default_success": "{address} é agora o seu endereço Lightning por defeito",
+  "@lightning_address_set_default_success": {
+    "placeholders": {
+      "address": {
+        "type": "String"
+      }
+    }
+  },
   "create_new_wallet_help": "Criar nova carteira",
   "create_wallet_short_description": "Para criar uma nova carteira, aceda ao seu painel LNBits pelo navegador e use a opção \\\"Criar carteira\\\".",
   "create_wallet_detailed_instructions": "Para criar uma nova carteira:\\n\\n1. Abra o seu navegador web\\n2. Aceda ao seu servidor LNBits\\n3. Inicie sessão com a sua conta\\n4. Procure o botão \\\"Criar carteira\\\"\\n5. Atribua um nome à sua nova carteira\\n6. Regresse ao LaChispa e atualize as suas carteiras\\n\\nA nova carteira aparecerá automaticamente na sua lista.",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -209,6 +209,25 @@
   "lightning_address_delete": "Удалить",
   "lightning_address_is_default": "По умолчанию",
   "lightning_address_set_default": "Установить по умолчанию",
+  "lightning_address_delete_title": "Удалить Lightning-адрес",
+  "lightning_address_delete_confirm": "Вы уверены, что хотите удалить {address}?",
+  "@lightning_address_delete_confirm": {
+    "placeholders": {
+      "address": {
+        "type": "String"
+      }
+    }
+  },
+  "lightning_address_created_success": "Lightning-адрес создан",
+  "lightning_address_deleted_success": "Lightning-адрес удалён",
+  "lightning_address_set_default_success": "{address} теперь ваш Lightning-адрес по умолчанию",
+  "@lightning_address_set_default_success": {
+    "placeholders": {
+      "address": {
+        "type": "String"
+      }
+    }
+  },
   "create_new_wallet_help": "Создать новый кошелек",
   "create_wallet_short_description": "Чтобы создать новый кошелек, войдите в панель LNBits через браузер и используйте опцию \\\"Создать кошелек\\\".",
   "create_wallet_detailed_instructions": "Чтобы создать новый кошелек:\\\\n\\\\n1. Откройте веб-браузер\\\\n2. Войдите на ваш сервер LNBits\\\\n3. Войдите в свой аккаунт\\\\n4. Найдите кнопку \\\"Создать кошелек\\\"\\\\n5. Дайте имя вашему новому кошельку\\\\n6. Вернитесь в LaChispa и обновите ваши кошельки\\\\n\\\\nНовый кошелек автоматически появится в вашем списке.",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1470,6 +1470,36 @@ abstract class AppLocalizations {
   /// **'Establecer como por defecto'**
   String get lightning_address_set_default;
 
+  /// No description provided for @lightning_address_delete_title.
+  ///
+  /// In es, this message translates to:
+  /// **'Eliminar dirección Lightning'**
+  String get lightning_address_delete_title;
+
+  /// No description provided for @lightning_address_delete_confirm.
+  ///
+  /// In es, this message translates to:
+  /// **'¿Seguro que quieres eliminar {address}?'**
+  String lightning_address_delete_confirm(String address);
+
+  /// No description provided for @lightning_address_created_success.
+  ///
+  /// In es, this message translates to:
+  /// **'Dirección Lightning creada'**
+  String get lightning_address_created_success;
+
+  /// No description provided for @lightning_address_deleted_success.
+  ///
+  /// In es, this message translates to:
+  /// **'Dirección Lightning eliminada'**
+  String get lightning_address_deleted_success;
+
+  /// No description provided for @lightning_address_set_default_success.
+  ///
+  /// In es, this message translates to:
+  /// **'{address} es ahora tu dirección Lightning por defecto'**
+  String lightning_address_set_default_success(String address);
+
   /// No description provided for @create_new_wallet_help.
   ///
   /// In es, this message translates to:

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -743,6 +743,25 @@ class AppLocalizationsDe extends AppLocalizations {
   String get lightning_address_set_default => 'Als Standard festlegen';
 
   @override
+  String get lightning_address_delete_title => 'Lightning-Adresse löschen';
+
+  @override
+  String lightning_address_delete_confirm(String address) {
+    return 'Möchten Sie $address wirklich löschen?';
+  }
+
+  @override
+  String get lightning_address_created_success => 'Lightning-Adresse erstellt';
+
+  @override
+  String get lightning_address_deleted_success => 'Lightning-Adresse gelöscht';
+
+  @override
+  String lightning_address_set_default_success(String address) {
+    return '$address ist jetzt Ihre Standard-Lightning-Adresse';
+  }
+
+  @override
   String get create_new_wallet_help => 'Neue Wallet erstellen';
 
   @override

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -725,6 +725,25 @@ class AppLocalizationsEn extends AppLocalizations {
   String get lightning_address_set_default => 'Set as default';
 
   @override
+  String get lightning_address_delete_title => 'Delete Lightning address';
+
+  @override
+  String lightning_address_delete_confirm(String address) {
+    return 'Are you sure you want to delete $address?';
+  }
+
+  @override
+  String get lightning_address_created_success => 'Lightning address created';
+
+  @override
+  String get lightning_address_deleted_success => 'Lightning address deleted';
+
+  @override
+  String lightning_address_set_default_success(String address) {
+    return '$address is now your default Lightning address';
+  }
+
+  @override
   String get create_new_wallet_help => 'Create new wallet';
 
   @override

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -731,6 +731,26 @@ class AppLocalizationsEs extends AppLocalizations {
   String get lightning_address_set_default => 'Establecer como por defecto';
 
   @override
+  String get lightning_address_delete_title => 'Eliminar dirección Lightning';
+
+  @override
+  String lightning_address_delete_confirm(String address) {
+    return '¿Seguro que quieres eliminar $address?';
+  }
+
+  @override
+  String get lightning_address_created_success => 'Dirección Lightning creada';
+
+  @override
+  String get lightning_address_deleted_success =>
+      'Dirección Lightning eliminada';
+
+  @override
+  String lightning_address_set_default_success(String address) {
+    return '$address es ahora tu dirección Lightning por defecto';
+  }
+
+  @override
   String get create_new_wallet_help => 'Crear nueva billetera';
 
   @override

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -750,6 +750,25 @@ class AppLocalizationsFr extends AppLocalizations {
   String get lightning_address_set_default => 'Définir par défaut';
 
   @override
+  String get lightning_address_delete_title => 'Supprimer l\'adresse Lightning';
+
+  @override
+  String lightning_address_delete_confirm(String address) {
+    return 'Voulez-vous vraiment supprimer $address ?';
+  }
+
+  @override
+  String get lightning_address_created_success => 'Adresse Lightning créée';
+
+  @override
+  String get lightning_address_deleted_success => 'Adresse Lightning supprimée';
+
+  @override
+  String lightning_address_set_default_success(String address) {
+    return '$address est maintenant votre adresse Lightning par défaut';
+  }
+
+  @override
   String get create_new_wallet_help => 'Créer un nouveau portefeuille';
 
   @override

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -748,6 +748,26 @@ class AppLocalizationsIt extends AppLocalizations {
   String get lightning_address_set_default => 'Imposta come predefinito';
 
   @override
+  String get lightning_address_delete_title => 'Elimina indirizzo Lightning';
+
+  @override
+  String lightning_address_delete_confirm(String address) {
+    return 'Sei sicuro di voler eliminare $address?';
+  }
+
+  @override
+  String get lightning_address_created_success => 'Indirizzo Lightning creato';
+
+  @override
+  String get lightning_address_deleted_success =>
+      'Indirizzo Lightning eliminato';
+
+  @override
+  String lightning_address_set_default_success(String address) {
+    return '$address è ora il tuo indirizzo Lightning predefinito';
+  }
+
+  @override
   String get create_new_wallet_help => 'Crea nuovo portafoglio';
 
   @override

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -733,6 +733,26 @@ class AppLocalizationsPt extends AppLocalizations {
   String get lightning_address_set_default => 'Definir como por defeito';
 
   @override
+  String get lightning_address_delete_title => 'Eliminar endereço Lightning';
+
+  @override
+  String lightning_address_delete_confirm(String address) {
+    return 'Tem a certeza de que deseja eliminar $address?';
+  }
+
+  @override
+  String get lightning_address_created_success => 'Endereço Lightning criado';
+
+  @override
+  String get lightning_address_deleted_success =>
+      'Endereço Lightning eliminado';
+
+  @override
+  String lightning_address_set_default_success(String address) {
+    return '$address é agora o seu endereço Lightning por defeito';
+  }
+
+  @override
   String get create_new_wallet_help => 'Criar nova carteira';
 
   @override

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -727,6 +727,25 @@ class AppLocalizationsRu extends AppLocalizations {
   String get lightning_address_set_default => 'Установить по умолчанию';
 
   @override
+  String get lightning_address_delete_title => 'Удалить Lightning-адрес';
+
+  @override
+  String lightning_address_delete_confirm(String address) {
+    return 'Вы уверены, что хотите удалить $address?';
+  }
+
+  @override
+  String get lightning_address_created_success => 'Lightning-адрес создан';
+
+  @override
+  String get lightning_address_deleted_success => 'Lightning-адрес удалён';
+
+  @override
+  String lightning_address_set_default_success(String address) {
+    return '$address теперь ваш Lightning-адрес по умолчанию';
+  }
+
+  @override
   String get create_new_wallet_help => 'Создать новый кошелек';
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'services/deep_link_service.dart';
 import 'screens/auth_checker.dart';
 import 'screens/10send_screen.dart';
 import 'l10n/generated/app_localizations.dart';
+import 'theme/themes.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -101,10 +102,11 @@ class _LaChispaAppState extends State<LaChispaApp> {
   
   void _showLoginRequiredDialog(BuildContext context) {
     final localizations = AppLocalizations.of(context)!;
-    
+
     showDialog(
       context: context,
       builder: (BuildContext context) {
+        // No literal colors here; AlertDialog inherits from theme.
         return AlertDialog(
           title: Text(localizations.deep_link_login_required_title),
           content: Text(localizations.deep_link_login_required_message),
@@ -189,10 +191,7 @@ class _LaChispaAppState extends State<LaChispaApp> {
               return MaterialApp(
                 navigatorKey: _navigatorKey,
                 title: 'LaChispa',
-                theme: ThemeData(
-                  fontFamily: 'Manrope',
-                  useMaterial3: true,
-                ),
+                theme: chispaTheme(),
                 locale: languageProvider.currentLocale,
                 localizationsDelegates: const [
                   AppLocalizations.delegate,

--- a/lib/screens/10send_screen.dart
+++ b/lib/screens/10send_screen.dart
@@ -272,7 +272,8 @@ class _SendScreenState extends State<SendScreen> {
       SnackBar(
         content: Row(
           children: [
-            Icon(Icons.check_circle, color: t.statusHealthy),
+            // White content on saturated status background; not a themable surface.
+            const Icon(Icons.check_circle, color: Colors.white),
             const SizedBox(width: 8),
             Expanded(
               child: Text(
@@ -295,7 +296,8 @@ class _SendScreenState extends State<SendScreen> {
       SnackBar(
         content: Row(
           children: [
-            Icon(Icons.error, color: t.statusUnhealthy),
+            // White content on saturated status background; not a themable surface.
+            const Icon(Icons.error, color: Colors.white),
             const SizedBox(width: 8),
             Expanded(
               child: Text(

--- a/lib/screens/10send_screen.dart
+++ b/lib/screens/10send_screen.dart
@@ -8,10 +8,11 @@ import '../providers/auth_provider.dart';
 import '../providers/wallet_provider.dart';
 import '../widgets/qr_scanner_widget.dart';
 import '../l10n/generated/app_localizations.dart';
+import '../theme/app_tokens.dart';
 
 class SendScreen extends StatefulWidget {
   final String? initialPaymentData;
-  
+
   const SendScreen({super.key, this.initialPaymentData});
 
   @override
@@ -28,7 +29,7 @@ class _SendScreenState extends State<SendScreen> {
     super.initState();
     // Listen to text changes for automatic validation
     _inputController.addListener(_onTextChanged);
-    
+
     // Set initial payment data if provided from deep link
     if (widget.initialPaymentData != null) {
       print('[SendScreen] Received initial payment data: ${widget.initialPaymentData}');
@@ -55,7 +56,7 @@ class _SendScreenState extends State<SendScreen> {
     _invoiceService.dispose();
     super.dispose();
   }
-  
+
   void _onTextChanged() {
     // Update button state when text changes
     setState(() {});
@@ -80,10 +81,10 @@ class _SendScreenState extends State<SendScreen> {
           onScanned: (String scannedData) {
             // Close the scanner
             Navigator.pop(context);
-            
+
             // Update input field with scanned data
             _inputController.text = scannedData;
-            
+
             // Process automatically if valid input is detected
             if (_hasValidInput()) {
               _processPayment();
@@ -93,7 +94,7 @@ class _SendScreenState extends State<SendScreen> {
       ),
     );
   }
-  
+
   String _cleanLightningInput(String input) {
     String cleaned = input.toLowerCase().trim();
     if (cleaned.startsWith('lightning:')) {
@@ -101,46 +102,46 @@ class _SendScreenState extends State<SendScreen> {
     }
     return cleaned;
   }
-  
+
   bool _hasValidInput() {
     final text = _inputController.text.trim();
     return text.isNotEmpty && (_isValidBolt11(text) || _isValidLNURL(text) || _isValidLightningAddress(text));
   }
-  
+
   bool _isValidBolt11(String text) {
     // Normalize text by removing common prefixes
     String normalizedText = _cleanLightningInput(text);
-    
+
     // Basic Lightning BOLT11 invoice validation
-    return normalizedText.startsWith('lnbc') || 
-           normalizedText.startsWith('lntb') || 
+    return normalizedText.startsWith('lnbc') ||
+           normalizedText.startsWith('lntb') ||
            normalizedText.startsWith('lnbcrt');
   }
-  
+
   bool _isValidLNURL(String text) {
     // Normalize text by removing common prefixes
     String normalizedText = _cleanLightningInput(text);
-    
+
     // Basic LNURL validation
     return normalizedText.startsWith('lnurl') ||
            (text.startsWith('http') && text.contains('lnurl'));
   }
-  
+
   bool _isValidLightningAddress(String text) {
     // Use enhanced validation method from InvoiceService
     return InvoiceService.isValidLightningAddress(text);
   }
-  
+
   Future<void> _processPayment() async {
     if (_isProcessing) return;
-    
+
     setState(() {
       _isProcessing = true;
     });
-    
+
     try {
       final input = _inputController.text.trim();
-      
+
       if (_isValidBolt11(input)) {
         await _processBolt11Payment(input);
       } else if (_isValidLNURL(input)) {
@@ -148,7 +149,7 @@ class _SendScreenState extends State<SendScreen> {
       } else if (_isValidLightningAddress(input)) {
         await _processLightningAddressPayment(input);
       }
-      
+
     } catch (e) {
       _showErrorSnackBar('${AppLocalizations.of(context)!.send_error_prefix}$e');
     } finally {
@@ -157,7 +158,7 @@ class _SendScreenState extends State<SendScreen> {
       });
     }
   }
-  
+
   Future<void> _processBolt11Payment(String bolt11) async {
     setState(() {
       _isProcessing = true;
@@ -166,7 +167,7 @@ class _SendScreenState extends State<SendScreen> {
     try {
       final authProvider = context.read<AuthProvider>();
       final walletProvider = context.read<WalletProvider>();
-      
+
       if (authProvider.sessionData == null) {
         throw Exception(AppLocalizations.of(context)!.invalid_session_error);
       }
@@ -231,14 +232,14 @@ class _SendScreenState extends State<SendScreen> {
       }
     }
   }
-  
+
   Future<void> _processLNURLPayment(String lnurl) async {
     // Clean LNURL by removing prefixes if they exist
     String cleanLnurl = lnurl.trim();
     if (cleanLnurl.toLowerCase().startsWith('lightning:')) {
       cleanLnurl = cleanLnurl.substring(10);
     }
-    
+
     // Navigate to amount screen for LNURL payment
     Navigator.push(
       context,
@@ -250,7 +251,7 @@ class _SendScreenState extends State<SendScreen> {
       ),
     );
   }
-  
+
   Future<void> _processLightningAddressPayment(String address) async {
     // Navigate to amount screen for Lightning Address payment
     Navigator.push(
@@ -263,13 +264,15 @@ class _SendScreenState extends State<SendScreen> {
       ),
     );
   }
-  
+
+  // ignore: unused_element
   void _showSuccessSnackBar(String message) {
+    final t = context.tokens;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Row(
           children: [
-            const Icon(Icons.check_circle, color: Colors.green),
+            Icon(Icons.check_circle, color: t.statusHealthy),
             const SizedBox(width: 8),
             Expanded(
               child: Text(
@@ -280,18 +283,19 @@ class _SendScreenState extends State<SendScreen> {
             ),
           ],
         ),
-        backgroundColor: Colors.green.withValues(alpha: 0.9),
+        backgroundColor: t.statusHealthy.withValues(alpha: 0.9),
         duration: const Duration(seconds: 3),
       ),
     );
   }
-  
+
   void _showErrorSnackBar(String message) {
+    final t = context.tokens;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Row(
           children: [
-            const Icon(Icons.error, color: Colors.red),
+            Icon(Icons.error, color: t.statusUnhealthy),
             const SizedBox(width: 8),
             Expanded(
               child: Text(
@@ -302,7 +306,7 @@ class _SendScreenState extends State<SendScreen> {
             ),
           ],
         ),
-        backgroundColor: Colors.red.withValues(alpha: 0.9),
+        backgroundColor: t.statusUnhealthy.withValues(alpha: 0.9),
         duration: const Duration(seconds: 4),
       ),
     );
@@ -310,15 +314,17 @@ class _SendScreenState extends State<SendScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final t = context.tokens;
     return Scaffold(
       body: LayoutBuilder(
         builder: (context, constraints) {
           final screenWidth = constraints.maxWidth;
           final isMobile = screenWidth < 768;
-          
+
           return Container(
             width: double.infinity,
             height: double.infinity,
+            // 2-stop variant of the brand gradient on send-flow screens
             decoration: const BoxDecoration(
               gradient: LinearGradient(
                 begin: Alignment.topLeft,
@@ -342,10 +348,10 @@ class _SendScreenState extends State<SendScreen> {
                               width: 40,
                               height: 40,
                               decoration: BoxDecoration(
-                                color: Colors.white.withValues(alpha: 0.08),
+                                color: t.surface,
                                 borderRadius: BorderRadius.circular(12),
                                 border: Border.all(
-                                  color: Colors.white.withValues(alpha: 0.1),
+                                  color: t.outline,
                                   width: 1,
                                 ),
                                 boxShadow: [
@@ -357,9 +363,9 @@ class _SendScreenState extends State<SendScreen> {
                                 ],
                               ),
                               child: IconButton(
-                                icon: const Icon(
+                                icon: Icon(
                                   Icons.arrow_back,
-                                  color: Colors.white,
+                                  color: t.textPrimary,
                                   size: 20,
                                 ),
                                 onPressed: () {
@@ -370,16 +376,15 @@ class _SendScreenState extends State<SendScreen> {
                             ),
                           ],
                         ),
-                        
+
                         SizedBox(height: isMobile ? 0 : 4),
-                        
+
                         Text(
                           AppLocalizations.of(context)!.send_title,
                           style: TextStyle(
-                            fontFamily: 'Manrope',
                             fontSize: isMobile ? 40 : 48,
                             fontWeight: FontWeight.w700,
-                            color: Colors.white,
+                            color: t.textPrimary,
                             height: 1.1,
                           ),
                           textAlign: TextAlign.center,
@@ -387,7 +392,7 @@ class _SendScreenState extends State<SendScreen> {
                       ],
                     ),
                   ),
-                  
+
                   Expanded(
                     child: Padding(
                       padding: EdgeInsets.symmetric(
@@ -398,7 +403,7 @@ class _SendScreenState extends State<SendScreen> {
                         crossAxisAlignment: CrossAxisAlignment.center,
                         children: [
                           SizedBox(height: isMobile ? 20 : 40),
-                          
+
                           Flexible(
                             child: Container(
                               width: double.infinity,
@@ -407,10 +412,10 @@ class _SendScreenState extends State<SendScreen> {
                                 maxHeight: isMobile ? 150 : 200,
                               ),
                               decoration: BoxDecoration(
-                                color: Colors.white.withValues(alpha: 0.08),
+                                color: t.surface,
                                 borderRadius: BorderRadius.circular(16),
                                 border: Border.all(
-                                  color: Colors.white.withValues(alpha: 0.1),
+                                  color: t.outline,
                                   width: 1,
                                 ),
                                 boxShadow: [
@@ -426,14 +431,14 @@ class _SendScreenState extends State<SendScreen> {
                                 child: TextField(
                                   controller: _inputController,
                                   style: TextStyle(
-                                    color: Colors.white,
+                                    color: t.textPrimary,
                                     fontSize: isMobile ? 14 : 16,
                                     fontWeight: FontWeight.w400,
                                   ),
                                   decoration: InputDecoration(
                                     hintText: AppLocalizations.of(context)!.paste_input_hint,
                                     hintStyle: TextStyle(
-                                      color: Colors.white.withValues(alpha: 0.6),
+                                      color: t.textPrimary.withValues(alpha: 0.6),
                                       fontSize: isMobile ? 14 : 16,
                                       fontWeight: FontWeight.w400,
                                     ),
@@ -451,26 +456,26 @@ class _SendScreenState extends State<SendScreen> {
                               ),
                             ),
                           ),
-                          
+
                           SizedBox(height: isMobile ? 16 : 24),
-                          
+
                           Column(
                             children: [
                               Row(
                                 children: [
                                   Expanded(
-                                    child: Container(
+                                    child: SizedBox(
                                       height: isMobile ? 48 : 56,
                                       child: ElevatedButton(
                                         onPressed: _pasteFromClipboard,
                                         style: ElevatedButton.styleFrom(
-                                          backgroundColor: Colors.white.withValues(alpha: 0.08),
-                                          foregroundColor: Colors.white,
+                                          backgroundColor: t.surface,
+                                          foregroundColor: t.textPrimary,
                                           elevation: 0,
                                           shape: RoundedRectangleBorder(
                                             borderRadius: BorderRadius.circular(16),
                                             side: BorderSide(
-                                              color: Colors.white.withValues(alpha: 0.1),
+                                              color: t.outline,
                                               width: 1,
                                             ),
                                           ),
@@ -483,13 +488,13 @@ class _SendScreenState extends State<SendScreen> {
                                               width: 20,
                                               height: 20,
                                               decoration: BoxDecoration(
-                                                color: Colors.white.withValues(alpha: 0.2),
+                                                color: t.textPrimary.withValues(alpha: 0.2),
                                                 borderRadius: BorderRadius.circular(4),
                                               ),
-                                              child: const Icon(
+                                              child: Icon(
                                                 Icons.content_paste,
                                                 size: 14,
-                                                color: Colors.white,
+                                                color: t.textPrimary,
                                               ),
                                             ),
                                             const SizedBox(width: 8),
@@ -498,7 +503,7 @@ class _SendScreenState extends State<SendScreen> {
                                               style: TextStyle(
                                                 fontSize: 14,
                                                 fontWeight: FontWeight.w500,
-                                                color: Colors.white,
+                                                color: t.textPrimary,
                                               ),
                                             ),
                                           ],
@@ -506,22 +511,22 @@ class _SendScreenState extends State<SendScreen> {
                                       ),
                                     ),
                                   ),
-                                  
+
                                   const SizedBox(width: 16),
-                                  
+
                                   Expanded(
-                                    child: Container(
+                                    child: SizedBox(
                                       height: isMobile ? 48 : 56,
                                       child: ElevatedButton(
                                         onPressed: _scanQR,
                                         style: ElevatedButton.styleFrom(
-                                          backgroundColor: Colors.white.withValues(alpha: 0.08),
-                                          foregroundColor: Colors.white,
+                                          backgroundColor: t.surface,
+                                          foregroundColor: t.textPrimary,
                                           elevation: 0,
                                           shape: RoundedRectangleBorder(
                                             borderRadius: BorderRadius.circular(16),
                                             side: BorderSide(
-                                              color: Colors.white.withValues(alpha: 0.1),
+                                              color: t.outline,
                                               width: 1,
                                             ),
                                           ),
@@ -534,13 +539,13 @@ class _SendScreenState extends State<SendScreen> {
                                               width: 20,
                                               height: 20,
                                               decoration: BoxDecoration(
-                                                color: Colors.white.withValues(alpha: 0.2),
+                                                color: t.textPrimary.withValues(alpha: 0.2),
                                                 borderRadius: BorderRadius.circular(4),
                                               ),
-                                              child: const Icon(
+                                              child: Icon(
                                                 Icons.qr_code_scanner,
                                                 size: 14,
-                                                color: Colors.white,
+                                                color: t.textPrimary,
                                               ),
                                             ),
                                             const SizedBox(width: 8),
@@ -549,7 +554,7 @@ class _SendScreenState extends State<SendScreen> {
                                               style: TextStyle(
                                                 fontSize: 14,
                                                 fontWeight: FontWeight.w500,
-                                                color: Colors.white,
+                                                color: t.textPrimary,
                                               ),
                                             ),
                                           ],
@@ -559,31 +564,31 @@ class _SendScreenState extends State<SendScreen> {
                                   ),
                                 ],
                               ),
-                              
+
                               SizedBox(height: isMobile ? 16 : 24),
-                              
-                              Container(
+
+                              SizedBox(
                                 width: double.infinity,
                                 height: isMobile ? 52 : 64,
                                 child: ElevatedButton(
                                   onPressed: (_hasValidInput() && !_isProcessing) ? _processPayment : null,
                                   style: ElevatedButton.styleFrom(
-                                    backgroundColor: _hasValidInput() 
-                                        ? const Color(0xFF2D3FE7)
-                                        : Colors.white.withValues(alpha: 0.08),
-                                    foregroundColor: Colors.white,
+                                    backgroundColor: _hasValidInput()
+                                        ? t.accentSolid
+                                        : t.surface,
+                                    foregroundColor: t.accentForeground,
                                     elevation: _hasValidInput() ? 8 : 0,
                                     shape: RoundedRectangleBorder(
                                       borderRadius: BorderRadius.circular(16),
                                       side: BorderSide(
                                         color: _hasValidInput()
-                                            ? const Color(0xFF4C63F7)
-                                            : Colors.white.withValues(alpha: 0.1),
+                                            ? t.accentSolid
+                                            : t.outline,
                                         width: 1,
                                       ),
                                     ),
-                                    shadowColor: _hasValidInput() 
-                                        ? const Color(0xFF2D3FE7).withValues(alpha: 0.3)
+                                    shadowColor: _hasValidInput()
+                                        ? t.accentSolid.withValues(alpha: 0.3)
                                         : Colors.transparent,
                                   ),
                                   child: _isProcessing
@@ -595,7 +600,7 @@ class _SendScreenState extends State<SendScreen> {
                                               height: 20,
                                               child: CircularProgressIndicator(
                                                 strokeWidth: 2,
-                                                valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                                                valueColor: AlwaysStoppedAnimation<Color>(t.accentForeground),
                                               ),
                                             ),
                                             const SizedBox(width: 12),
@@ -604,7 +609,7 @@ class _SendScreenState extends State<SendScreen> {
                                               style: TextStyle(
                                                 fontSize: 16,
                                                 fontWeight: FontWeight.w700,
-                                                color: Colors.white,
+                                                color: t.accentForeground,
                                               ),
                                             ),
                                           ],
@@ -614,22 +619,22 @@ class _SendScreenState extends State<SendScreen> {
                                           style: TextStyle(
                                             fontSize: 18,
                                             fontWeight: FontWeight.w700,
-                                            color: _hasValidInput() 
-                                                ? Colors.white 
-                                                : Colors.white.withValues(alpha: 0.4),
+                                            color: _hasValidInput()
+                                                ? t.accentForeground
+                                                : t.textPrimary.withValues(alpha: 0.4),
                                           ),
                                         ),
                                 ),
                               ),
                             ],
                           ),
-                          
+
                           // Flexible spacer to push info to bottom
                           Expanded(
                             flex: 1,
                             child: Container(),
                           ),
-                          
+
                           // Additional information (only if there's space)
                           if (isMobile) ...[
                             Padding(
@@ -637,7 +642,7 @@ class _SendScreenState extends State<SendScreen> {
                               child: Text(
                                 AppLocalizations.of(context)!.paste_input_hint,
                                 style: TextStyle(
-                                  color: Colors.white.withValues(alpha: 0.6),
+                                  color: t.textPrimary.withValues(alpha: 0.6),
                                   fontSize: 12,
                                   fontWeight: FontWeight.w400,
                                 ),

--- a/lib/screens/11amount_screen.dart
+++ b/lib/screens/11amount_screen.dart
@@ -544,7 +544,8 @@ class _AmountScreenState extends State<AmountScreen> {
       SnackBar(
         content: Row(
           children: [
-            Icon(Icons.check_circle, color: t.statusHealthy),
+            // White content on saturated status background; not a themable surface.
+            const Icon(Icons.check_circle, color: Colors.white),
             const SizedBox(width: 8),
             Text(message),
           ],
@@ -561,7 +562,8 @@ class _AmountScreenState extends State<AmountScreen> {
       SnackBar(
         content: Row(
           children: [
-            Icon(Icons.schedule, color: t.statusWarning),
+            // White content on saturated status background; not a themable surface.
+            const Icon(Icons.schedule, color: Colors.white),
             const SizedBox(width: 8),
             Text(message),
           ],
@@ -578,7 +580,8 @@ class _AmountScreenState extends State<AmountScreen> {
       SnackBar(
         content: Row(
           children: [
-            Icon(Icons.error, color: t.statusUnhealthy),
+            // White content on saturated status background; not a themable surface.
+            const Icon(Icons.error, color: Colors.white),
             const SizedBox(width: 8),
             Text(message),
           ],

--- a/lib/screens/11amount_screen.dart
+++ b/lib/screens/11amount_screen.dart
@@ -8,6 +8,7 @@ import '../providers/auth_provider.dart';
 import '../providers/wallet_provider.dart';
 import '../providers/currency_settings_provider.dart';
 import '../l10n/generated/app_localizations.dart';
+import '../theme/app_tokens.dart';
 import '12invoice_confirm_screen.dart';
 
 class AmountScreen extends StatefulWidget {
@@ -538,66 +539,69 @@ class _AmountScreenState extends State<AmountScreen> {
   }
 
   void _showSuccessSnackBar(String message) {
+    final t = context.tokens;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Row(
           children: [
-            const Icon(Icons.check_circle, color: Colors.green),
+            Icon(Icons.check_circle, color: t.statusHealthy),
             const SizedBox(width: 8),
             Text(message),
           ],
         ),
-        backgroundColor: Colors.green.withValues(alpha: 0.9),
+        backgroundColor: t.statusHealthy.withValues(alpha: 0.9),
         duration: const Duration(seconds: 3),
       ),
     );
   }
 
   void _showPendingSnackBar(String message) {
+    final t = context.tokens;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Row(
           children: [
-            const Icon(Icons.schedule, color: Colors.orange),
+            Icon(Icons.schedule, color: t.statusWarning),
             const SizedBox(width: 8),
             Text(message),
           ],
         ),
-        backgroundColor: Colors.orange.withValues(alpha: 0.9),
+        backgroundColor: t.statusWarning.withValues(alpha: 0.9),
         duration: const Duration(seconds: 4),
       ),
     );
   }
 
   void _showErrorSnackBar(String message) {
+    final t = context.tokens;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Row(
           children: [
-            const Icon(Icons.error, color: Colors.red),
+            Icon(Icons.error, color: t.statusUnhealthy),
             const SizedBox(width: 8),
             Text(message),
           ],
         ),
-        backgroundColor: Colors.red.withValues(alpha: 0.9),
+        backgroundColor: t.statusUnhealthy.withValues(alpha: 0.9),
         duration: const Duration(seconds: 3),
       ),
     );
   }
 
-  Widget _buildNumberButton(String text, VoidCallback onPressed, bool isMobile) {
+  Widget _buildNumberButton(String text, VoidCallback onPressed, bool isMobile, AppTokens t) {
     return SizedBox(
       height: isMobile ? 48 : 56,
       child: ElevatedButton(
         onPressed: onPressed,
         style: ElevatedButton.styleFrom(
-          backgroundColor: Colors.white.withValues(alpha: 0.08),
-          foregroundColor: Colors.white,
+          backgroundColor: t.surface,
+          foregroundColor: t.textPrimary,
           elevation: 0,
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(16),
             side: BorderSide(
-              color: Colors.white.withValues(alpha: 0.1),
+              color: t.outline,
               width: 1,
             ),
           ),
@@ -608,41 +612,41 @@ class _AmountScreenState extends State<AmountScreen> {
           style: TextStyle(
             fontSize: isMobile ? 18 : 20,
             fontWeight: FontWeight.w600,
-            color: Colors.white,
+            color: t.textPrimary,
           ),
         ),
       ),
     );
   }
 
-  Widget _buildActionButton(String text, VoidCallback onPressed, {IconData? icon, required bool isMobile}) {
+  Widget _buildActionButton(String text, VoidCallback onPressed, AppTokens t, {IconData? icon, required bool isMobile}) {
     return SizedBox(
       height: isMobile ? 48 : 56,
       child: ElevatedButton(
         onPressed: onPressed,
         style: ElevatedButton.styleFrom(
-          backgroundColor: Colors.white.withValues(alpha: 0.08),
-          foregroundColor: Colors.white,
+          backgroundColor: t.surface,
+          foregroundColor: t.textPrimary,
           elevation: 0,
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(16),
             side: BorderSide(
-              color: Colors.white.withValues(alpha: 0.1),
+              color: t.outline,
               width: 1,
             ),
           ),
           shadowColor: Colors.transparent,
         ),
         child: icon != null
-            ? Icon(icon, color: Colors.white, size: isMobile ? 18 : 20)
+            ? Icon(icon, color: t.textPrimary, size: isMobile ? 18 : 20)
             : Text(
                 text,
                 style: TextStyle(
-                  fontSize: (text == '00' || text == '000' || text == 'sats' || text == 'CUP' || text == 'USD') 
-                      ? (isMobile ? 12 : 14) 
+                  fontSize: (text == '00' || text == '000' || text == 'sats' || text == 'CUP' || text == 'USD')
+                      ? (isMobile ? 12 : 14)
                       : (isMobile ? 14 : 16),
                   fontWeight: FontWeight.w600,
-                  color: Colors.white,
+                  color: t.textPrimary,
                 ),
               ),
       ),
@@ -651,6 +655,7 @@ class _AmountScreenState extends State<AmountScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final t = context.tokens;
     return Consumer<CurrencySettingsProvider>(
       builder: (context, currencyProvider, child) {
         return Scaffold(
@@ -659,10 +664,11 @@ class _AmountScreenState extends State<AmountScreen> {
         builder: (context, constraints) {
           final screenWidth = constraints.maxWidth;
           final isMobile = screenWidth < 768;
-          
+
           return Container(
             width: double.infinity,
             height: double.infinity,
+            // 2-stop variant of the brand gradient used on send-flow screens
             decoration: const BoxDecoration(
               gradient: LinearGradient(
                 begin: Alignment.topLeft,
@@ -689,10 +695,10 @@ class _AmountScreenState extends State<AmountScreen> {
                               width: 40,
                               height: 40,
                               decoration: BoxDecoration(
-                                color: Colors.white.withValues(alpha: 0.08),
+                                color: t.surface,
                                 borderRadius: BorderRadius.circular(12),
                                 border: Border.all(
-                                  color: Colors.white.withValues(alpha: 0.1),
+                                  color: t.outline,
                                   width: 1,
                                 ),
                                 boxShadow: [
@@ -704,9 +710,9 @@ class _AmountScreenState extends State<AmountScreen> {
                                 ],
                               ),
                               child: IconButton(
-                                icon: const Icon(
+                                icon: Icon(
                                   Icons.arrow_back,
-                                  color: Colors.white,
+                                  color: t.textPrimary,
                                   size: 20,
                                 ),
                                 onPressed: () {
@@ -726,10 +732,9 @@ class _AmountScreenState extends State<AmountScreen> {
                             Text(
                               AppLocalizations.of(context)!.send_to_title,
                               style: TextStyle(
-                                fontFamily: 'Manrope',
                                 fontSize: isMobile ? 40 : 48,
                                 fontWeight: FontWeight.w700,
-                                color: Colors.white,
+                                color: t.textPrimary,
                                 height: 1.1,
                               ),
                               textAlign: TextAlign.center,
@@ -738,10 +743,9 @@ class _AmountScreenState extends State<AmountScreen> {
                             Text(
                               widget.destination,
                               style: TextStyle(
-                                fontFamily: 'Manrope',
                                 fontSize: isMobile ? 18 : 20,
                                 fontWeight: FontWeight.w400,
-                                color: Colors.white.withValues(alpha: 0.8),
+                                color: t.textPrimary.withValues(alpha: 0.8),
                               ),
                               textAlign: TextAlign.center,
                               maxLines: 2,
@@ -775,14 +779,13 @@ class _AmountScreenState extends State<AmountScreen> {
                             padding: const EdgeInsets.symmetric(vertical: 8),
                             child: Column(
                               children: [
-                                if (_selectedCurrency == 'sats') 
+                                if (_selectedCurrency == 'sats')
                                   Text(
                                     _formatDisplayAmount(),
                                     style: TextStyle(
-                                      fontFamily: 'Manrope',
                                       fontSize: isMobile ? 38 : 48,
                                       fontWeight: FontWeight.w700,
-                                      color: Colors.white,
+                                      color: t.textPrimary,
                                     ),
                                     textAlign: TextAlign.center,
                                   )
@@ -795,22 +798,20 @@ class _AmountScreenState extends State<AmountScreen> {
                                       Text(
                                         _formatDisplayAmount(),
                                         style: TextStyle(
-                                          fontFamily: 'Manrope',
                                           fontSize: isMobile ? 38 : 48,
                                           fontWeight: FontWeight.w700,
-                                          color: Colors.white,
+                                          color: t.textPrimary,
                                         ),
                                       ),
                                       const SizedBox(width: 12),
                                       Text(
-                                        _isConverting 
+                                        _isConverting
                                             ? '(${AppLocalizations.of(context)!.calculating_text}...)'
                                             : '(≈ $_cachedSatsAmount sats)',
                                         style: TextStyle(
-                                          fontFamily: 'Manrope',
                                           fontSize: isMobile ? 18 : 22,
                                           fontWeight: FontWeight.w400,
-                                          color: Colors.white.withValues(alpha: 0.7),
+                                          color: t.textPrimary.withValues(alpha: 0.7),
                                         ),
                                       ),
                                     ],
@@ -825,10 +826,10 @@ class _AmountScreenState extends State<AmountScreen> {
                           Flexible(
                             child: Container(
                               decoration: BoxDecoration(
-                                color: Colors.white.withValues(alpha: 0.08),
+                                color: t.surface,
                                 borderRadius: BorderRadius.circular(16),
                                 border: Border.all(
-                                  color: Colors.white.withValues(alpha: 0.1),
+                                  color: t.outline,
                                   width: 1,
                                 ),
                                 boxShadow: [
@@ -846,55 +847,55 @@ class _AmountScreenState extends State<AmountScreen> {
                                   children: [
                                     Row(
                                       children: [
-                                        Expanded(child: _buildNumberButton('1', () => _onNumberPressed('1'), isMobile)),
+                                        Expanded(child: _buildNumberButton('1', () => _onNumberPressed('1'), isMobile, t)),
                                         SizedBox(width: isMobile ? 8 : 12),
-                                        Expanded(child: _buildNumberButton('2', () => _onNumberPressed('2'), isMobile)),
+                                        Expanded(child: _buildNumberButton('2', () => _onNumberPressed('2'), isMobile, t)),
                                         SizedBox(width: isMobile ? 8 : 12),
-                                        Expanded(child: _buildNumberButton('3', () => _onNumberPressed('3'), isMobile)),
+                                        Expanded(child: _buildNumberButton('3', () => _onNumberPressed('3'), isMobile, t)),
                                         SizedBox(width: isMobile ? 8 : 12),
-                                        Expanded(child: _buildActionButton('⌫', _onDeletePressed, icon: Icons.backspace_outlined, isMobile: isMobile)),
+                                        Expanded(child: _buildActionButton('⌫', _onDeletePressed, t, icon: Icons.backspace_outlined, isMobile: isMobile)),
                                       ],
                                     ),
-                                    
+
                                     SizedBox(height: isMobile ? 8 : 12),
-                                    
+
                                     Row(
                                       children: [
-                                        Expanded(child: _buildNumberButton('4', () => _onNumberPressed('4'), isMobile)),
+                                        Expanded(child: _buildNumberButton('4', () => _onNumberPressed('4'), isMobile, t)),
                                         SizedBox(width: isMobile ? 8 : 12),
-                                        Expanded(child: _buildNumberButton('5', () => _onNumberPressed('5'), isMobile)),
+                                        Expanded(child: _buildNumberButton('5', () => _onNumberPressed('5'), isMobile, t)),
                                         SizedBox(width: isMobile ? 8 : 12),
-                                        Expanded(child: _buildNumberButton('6', () => _onNumberPressed('6'), isMobile)),
+                                        Expanded(child: _buildNumberButton('6', () => _onNumberPressed('6'), isMobile, t)),
                                         SizedBox(width: isMobile ? 8 : 12),
-                                        Expanded(child: _buildActionButton('00', () => _onZerosPressed('00'), isMobile: isMobile)),
+                                        Expanded(child: _buildActionButton('00', () => _onZerosPressed('00'), t, isMobile: isMobile)),
                                       ],
                                     ),
-                                    
+
                                     SizedBox(height: isMobile ? 8 : 12),
-                                    
+
                                     Row(
                                       children: [
-                                        Expanded(child: _buildNumberButton('7', () => _onNumberPressed('7'), isMobile)),
+                                        Expanded(child: _buildNumberButton('7', () => _onNumberPressed('7'), isMobile, t)),
                                         SizedBox(width: isMobile ? 8 : 12),
-                                        Expanded(child: _buildNumberButton('8', () => _onNumberPressed('8'), isMobile)),
+                                        Expanded(child: _buildNumberButton('8', () => _onNumberPressed('8'), isMobile, t)),
                                         SizedBox(width: isMobile ? 8 : 12),
-                                        Expanded(child: _buildNumberButton('9', () => _onNumberPressed('9'), isMobile)),
+                                        Expanded(child: _buildNumberButton('9', () => _onNumberPressed('9'), isMobile, t)),
                                         SizedBox(width: isMobile ? 8 : 12),
-                                        Expanded(child: _buildActionButton('000', () => _onZerosPressed('000'), isMobile: isMobile)),
+                                        Expanded(child: _buildActionButton('000', () => _onZerosPressed('000'), t, isMobile: isMobile)),
                                       ],
                                     ),
-                                    
+
                                     SizedBox(height: isMobile ? 8 : 12),
-                                    
+
                                     Row(
                                       children: [
-                                        Expanded(child: _buildActionButton('.', _onDecimalPressed, isMobile: isMobile)),
+                                        Expanded(child: _buildActionButton('.', _onDecimalPressed, t, isMobile: isMobile)),
                                         SizedBox(width: isMobile ? 8 : 12),
-                                        Expanded(child: _buildNumberButton('0', () => _onNumberPressed('0'), isMobile)),
+                                        Expanded(child: _buildNumberButton('0', () => _onNumberPressed('0'), isMobile, t)),
                                         SizedBox(width: isMobile ? 8 : 12),
-                                        Expanded(child: _buildActionButton('C', _onClearPressed, isMobile: isMobile)),
+                                        Expanded(child: _buildActionButton('C', _onClearPressed, t, isMobile: isMobile)),
                                         SizedBox(width: isMobile ? 8 : 12),
-                                        Expanded(child: _buildActionButton(_selectedCurrency, _toggleCurrency, isMobile: isMobile)),
+                                        Expanded(child: _buildActionButton(_selectedCurrency, _toggleCurrency, t, isMobile: isMobile)),
                                       ],
                                     ),
                                   ],
@@ -910,10 +911,10 @@ class _AmountScreenState extends State<AmountScreen> {
                           Container(
                             width: double.infinity,
                             decoration: BoxDecoration(
-                              color: Colors.white.withValues(alpha: 0.08),
+                              color: t.surface,
                               borderRadius: BorderRadius.circular(16),
                               border: Border.all(
-                                color: Colors.white.withValues(alpha: 0.1),
+                                color: t.outline,
                                 width: 1,
                               ),
                             ),
@@ -923,20 +924,20 @@ class _AmountScreenState extends State<AmountScreen> {
                               focusNode: _commentFocusNode,
                               maxLines: 2,
                               maxLength: 150,
-                              style: const TextStyle(
-                                color: Colors.white,
+                              style: TextStyle(
+                                color: t.textPrimary,
                                 fontSize: 16,
                               ),
                               decoration: InputDecoration(
                                 hintText: AppLocalizations.of(context)!.add_note_optional,
                                 hintStyle: TextStyle(
-                                  color: Colors.white.withValues(alpha: 0.6),
+                                  color: t.textPrimary.withValues(alpha: 0.6),
                                   fontSize: 16,
                                 ),
                                 border: InputBorder.none,
                                 contentPadding: const EdgeInsets.all(16),
                                 counterStyle: TextStyle(
-                                  color: Colors.white.withValues(alpha: 0.5),
+                                  color: t.textTertiary,
                                   fontSize: 12,
                                 ),
                               ),
@@ -944,7 +945,7 @@ class _AmountScreenState extends State<AmountScreen> {
                           ),
                           
                           const SizedBox(height: 16),
-                          
+
                           SizedBox(
                             width: double.infinity,
                             height: 64,
@@ -954,21 +955,21 @@ class _AmountScreenState extends State<AmountScreen> {
                                   : null,
                               style: ElevatedButton.styleFrom(
                                 backgroundColor: (double.tryParse(_amount) ?? 0) > 0
-                                    ? const Color(0xFF2D3FE7)
-                                    : Colors.white.withValues(alpha: 0.08),
-                                foregroundColor: Colors.white,
+                                    ? t.accentSolid
+                                    : t.surface,
+                                foregroundColor: t.accentForeground,
                                 elevation: (double.tryParse(_amount) ?? 0) > 0 ? 8 : 0,
                                 shape: RoundedRectangleBorder(
                                   borderRadius: BorderRadius.circular(16),
                                   side: BorderSide(
                                     color: (double.tryParse(_amount) ?? 0) > 0
-                                        ? const Color(0xFF4C63F7)
-                                        : Colors.white.withValues(alpha: 0.1),
+                                        ? t.accentSolid
+                                        : t.outline,
                                     width: 1,
                                   ),
                                 ),
                                 shadowColor: (double.tryParse(_amount) ?? 0) > 0
-                                    ? const Color(0xFF2D3FE7).withValues(alpha: 0.3)
+                                    ? t.accentSolid.withValues(alpha: 0.3)
                                     : Colors.transparent,
                               ),
                               child: _isProcessingPayment
@@ -980,7 +981,7 @@ class _AmountScreenState extends State<AmountScreen> {
                                           height: 20,
                                           child: CircularProgressIndicator(
                                             strokeWidth: 2,
-                                            valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                                            valueColor: AlwaysStoppedAnimation<Color>(t.accentForeground),
                                           ),
                                         ),
                                         const SizedBox(width: 12),
@@ -989,7 +990,7 @@ class _AmountScreenState extends State<AmountScreen> {
                                           style: TextStyle(
                                             fontSize: 16,
                                             fontWeight: FontWeight.w700,
-                                            color: Colors.white,
+                                            color: t.accentForeground,
                                           ),
                                         ),
                                       ],
@@ -1002,15 +1003,15 @@ class _AmountScreenState extends State<AmountScreen> {
                                         fontSize: 16,
                                         fontWeight: FontWeight.w700,
                                         color: (double.tryParse(_amount) ?? 0) > 0
-                                            ? Colors.white
-                                            : Colors.white.withValues(alpha: 0.4),
+                                            ? t.accentForeground
+                                            : t.textPrimary.withValues(alpha: 0.4),
                                       ),
                                       textAlign: TextAlign.center,
                                     ),
                             ),
                           ),
-                          
-                          
+
+
                           // Compact loading indicator for exchange rates
                           if (_isLoadingRates) ...[
                             const SizedBox(height: 8),
@@ -1023,7 +1024,7 @@ class _AmountScreenState extends State<AmountScreen> {
                                   child: CircularProgressIndicator(
                                     strokeWidth: 2,
                                     valueColor: AlwaysStoppedAnimation<Color>(
-                                      Colors.white.withValues(alpha: 0.6),
+                                      t.textPrimary.withValues(alpha: 0.6),
                                     ),
                                   ),
                                 ),
@@ -1031,7 +1032,7 @@ class _AmountScreenState extends State<AmountScreen> {
                                 Text(
                                   AppLocalizations.of(context)!.loading_text,
                                   style: TextStyle(
-                                    color: Colors.white.withValues(alpha: 0.6),
+                                    color: t.textPrimary.withValues(alpha: 0.6),
                                     fontSize: 12,
                                     fontWeight: FontWeight.w400,
                                   ),

--- a/lib/screens/12invoice_confirm_screen.dart
+++ b/lib/screens/12invoice_confirm_screen.dart
@@ -125,7 +125,8 @@ class _InvoiceConfirmScreenState extends State<InvoiceConfirmScreen> {
       SnackBar(
         content: Row(
           children: [
-            Icon(Icons.check_circle, color: t.statusHealthy),
+            // White content on saturated status background; not a themable surface.
+            const Icon(Icons.check_circle, color: Colors.white),
             const SizedBox(width: 8),
             Expanded(child: Text(message)),
           ],
@@ -142,7 +143,8 @@ class _InvoiceConfirmScreenState extends State<InvoiceConfirmScreen> {
       SnackBar(
         content: Row(
           children: [
-            Icon(Icons.schedule, color: t.statusWarning),
+            // White content on saturated status background; not a themable surface.
+            const Icon(Icons.schedule, color: Colors.white),
             const SizedBox(width: 8),
             Expanded(child: Text(message)),
           ],
@@ -159,7 +161,8 @@ class _InvoiceConfirmScreenState extends State<InvoiceConfirmScreen> {
       SnackBar(
         content: Row(
           children: [
-            Icon(Icons.error, color: t.statusUnhealthy),
+            // White content on saturated status background; not a themable surface.
+            const Icon(Icons.error, color: Colors.white),
             const SizedBox(width: 8),
             Expanded(child: Text(message)),
           ],

--- a/lib/screens/12invoice_confirm_screen.dart
+++ b/lib/screens/12invoice_confirm_screen.dart
@@ -5,6 +5,7 @@ import '../services/invoice_service.dart';
 import '../providers/auth_provider.dart';
 import '../providers/wallet_provider.dart';
 import '../l10n/generated/app_localizations.dart';
+import '../theme/app_tokens.dart';
 
 class InvoiceConfirmScreen extends StatefulWidget {
   final DecodedInvoice decodedInvoice;
@@ -97,7 +98,7 @@ class _InvoiceConfirmScreenState extends State<InvoiceConfirmScreen> {
 
       // Return to previous screen after brief delay for user feedback
       await Future.delayed(const Duration(seconds: 2));
-      
+
       if (mounted) {
         Navigator.of(context).popUntil((route) => route.isFirst);
       }
@@ -119,48 +120,51 @@ class _InvoiceConfirmScreenState extends State<InvoiceConfirmScreen> {
   }
 
   void _showSuccessSnackBar(String message) {
+    final t = context.tokens;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Row(
           children: [
-            const Icon(Icons.check_circle, color: Colors.green),
+            Icon(Icons.check_circle, color: t.statusHealthy),
             const SizedBox(width: 8),
             Expanded(child: Text(message)),
           ],
         ),
-        backgroundColor: Colors.green.withValues(alpha: 0.9),
+        backgroundColor: t.statusHealthy.withValues(alpha: 0.9),
         duration: const Duration(seconds: 3),
       ),
     );
   }
 
   void _showPendingSnackBar(String message) {
+    final t = context.tokens;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Row(
           children: [
-            const Icon(Icons.schedule, color: Colors.orange),
+            Icon(Icons.schedule, color: t.statusWarning),
             const SizedBox(width: 8),
             Expanded(child: Text(message)),
           ],
         ),
-        backgroundColor: Colors.orange.withValues(alpha: 0.9),
+        backgroundColor: t.statusWarning.withValues(alpha: 0.9),
         duration: const Duration(seconds: 4),
       ),
     );
   }
 
   void _showErrorSnackBar(String message) {
+    final t = context.tokens;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Row(
           children: [
-            const Icon(Icons.error, color: Colors.red),
+            Icon(Icons.error, color: t.statusUnhealthy),
             const SizedBox(width: 8),
             Expanded(child: Text(message)),
           ],
         ),
-        backgroundColor: Colors.red.withValues(alpha: 0.9),
+        backgroundColor: t.statusUnhealthy.withValues(alpha: 0.9),
         duration: const Duration(seconds: 4),
       ),
     );
@@ -168,15 +172,17 @@ class _InvoiceConfirmScreenState extends State<InvoiceConfirmScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final t = context.tokens;
     return Scaffold(
       body: LayoutBuilder(
         builder: (context, constraints) {
           final screenWidth = constraints.maxWidth;
           final isMobile = screenWidth < 768;
-          
+
           return Container(
             width: double.infinity,
             height: double.infinity,
+            // Send/confirm screens use a 2-stop variant of the brand gradient
             decoration: const BoxDecoration(
               gradient: LinearGradient(
                 begin: Alignment.topLeft,
@@ -200,10 +206,10 @@ class _InvoiceConfirmScreenState extends State<InvoiceConfirmScreen> {
                               width: 40,
                               height: 40,
                               decoration: BoxDecoration(
-                                color: Colors.white.withValues(alpha: 0.08),
+                                color: t.surface,
                                 borderRadius: BorderRadius.circular(12),
                                 border: Border.all(
-                                  color: Colors.white.withValues(alpha: 0.1),
+                                  color: t.outline,
                                   width: 1,
                                 ),
                                 boxShadow: [
@@ -215,9 +221,9 @@ class _InvoiceConfirmScreenState extends State<InvoiceConfirmScreen> {
                                 ],
                               ),
                               child: IconButton(
-                                icon: const Icon(
+                                icon: Icon(
                                   Icons.arrow_back,
-                                  color: Colors.white,
+                                  color: t.textPrimary,
                                   size: 20,
                                 ),
                                 onPressed: () {
@@ -228,16 +234,15 @@ class _InvoiceConfirmScreenState extends State<InvoiceConfirmScreen> {
                             ),
                           ],
                         ),
-                        
+
                         SizedBox(height: isMobile ? 0 : 4),
-                        
+
                         Text(
                           AppLocalizations.of(context)!.pay_button_confirm,
                           style: TextStyle(
-                            fontFamily: 'Manrope',
                             fontSize: isMobile ? 40 : 48,
                             fontWeight: FontWeight.w700,
-                            color: Colors.white,
+                            color: t.textPrimary,
                             height: 1.1,
                           ),
                           textAlign: TextAlign.center,
@@ -245,7 +250,7 @@ class _InvoiceConfirmScreenState extends State<InvoiceConfirmScreen> {
                       ],
                     ),
                   ),
-                  
+
                   Expanded(
                     child: SingleChildScrollView(
                       padding: EdgeInsets.symmetric(
@@ -255,14 +260,14 @@ class _InvoiceConfirmScreenState extends State<InvoiceConfirmScreen> {
                       child: Column(
                         children: [
                           SizedBox(height: isMobile ? 16 : 24),
-                          
+
                           Container(
                             width: double.infinity,
                             decoration: BoxDecoration(
-                              color: Colors.white.withValues(alpha: 0.08),
+                              color: t.surface,
                               borderRadius: BorderRadius.circular(16),
                               border: Border.all(
-                                color: Colors.white.withValues(alpha: 0.1),
+                                color: t.outline,
                                 width: 1,
                               ),
                               boxShadow: [
@@ -284,57 +289,61 @@ class _InvoiceConfirmScreenState extends State<InvoiceConfirmScreen> {
                                         Text(
                                           _displayAmount,
                                           style: TextStyle(
-                                            fontFamily: 'Manrope',
                                             fontSize: isMobile ? 36 : 48,
                                             fontWeight: FontWeight.w700,
-                                            color: Colors.white,
+                                            color: t.textPrimary,
                                           ),
                                           textAlign: TextAlign.center,
                                         ),
                                       ],
                                     ),
                                   ),
-                                  
+
                                   const SizedBox(height: 32),
-                                  
+
                                   _buildDescriptionRow(
+                                    t,
                                     AppLocalizations.of(context)!.invoice_description_label,
-                                    widget.decodedInvoice.description.isEmpty 
-                                        ? AppLocalizations.of(context)!.no_description_text 
+                                    widget.decodedInvoice.description.isEmpty
+                                        ? AppLocalizations.of(context)!.no_description_text
                                         : widget.decodedInvoice.description,
                                     icon: Icons.description_outlined,
                                   ),
-                                  
+
                                   const SizedBox(height: 16),
-                                  
+
                                   _buildInfoRow(
+                                    t,
                                     AppLocalizations.of(context)!.invoice_status_label,
                                     widget.decodedInvoice.isExpired ? AppLocalizations.of(context)!.expired_status : AppLocalizations.of(context)!.valid_status,
                                     icon: widget.decodedInvoice.isExpired ? Icons.error_outline : Icons.check_circle_outline,
-                                    valueColor: widget.decodedInvoice.isExpired ? Colors.red : Colors.green,
+                                    valueColor: widget.decodedInvoice.isExpired ? t.statusUnhealthy : t.statusHealthy,
                                   ),
-                                  
+
                                   const SizedBox(height: 16),
-                                  
+
                                   _buildInfoRow(
+                                    t,
                                     AppLocalizations.of(context)!.expiry_label,
                                     widget.decodedInvoice.formattedExpiry,
                                     icon: Icons.schedule_outlined,
-                                    valueColor: widget.decodedInvoice.isExpired ? Colors.red : null,
+                                    valueColor: widget.decodedInvoice.isExpired ? t.statusUnhealthy : null,
                                   ),
-                                  
+
                                   if (widget.decodedInvoice.paymentHash.isNotEmpty) ...[
                                     const SizedBox(height: 16),
                                     _buildInfoRow(
+                                      t,
                                       AppLocalizations.of(context)!.payment_hash_label,
                                       widget.decodedInvoice.shortPaymentHash,
                                       icon: Icons.fingerprint_outlined,
                                     ),
                                   ],
-                                  
+
                                   if (widget.decodedInvoice.destination.isNotEmpty) ...[
                                     const SizedBox(height: 16),
                                     _buildInfoRow(
+                                      t,
                                       AppLocalizations.of(context)!.recipient_label,
                                       widget.decodedInvoice.destination.length > 20
                                           ? '${widget.decodedInvoice.destination.substring(0, 20)}...'
@@ -346,27 +355,27 @@ class _InvoiceConfirmScreenState extends State<InvoiceConfirmScreen> {
                               ),
                             ),
                           ),
-                          
+
                           const SizedBox(height: 32),
-                          
+
                           Row(
                             children: [
                               Expanded(
                                 flex: 1,
-                                child: Container(
+                                child: SizedBox(
                                   height: 56,
                                   child: ElevatedButton(
                                     onPressed: _isProcessing ? null : () {
                                       Navigator.pop(context);
                                     },
                                     style: ElevatedButton.styleFrom(
-                                      backgroundColor: Colors.white.withValues(alpha: 0.08),
-                                      foregroundColor: Colors.white,
+                                      backgroundColor: t.surface,
+                                      foregroundColor: t.textPrimary,
                                       elevation: 0,
                                       shape: RoundedRectangleBorder(
                                         borderRadius: BorderRadius.circular(16),
                                         side: BorderSide(
-                                          color: Colors.white.withValues(alpha: 0.1),
+                                          color: t.outline,
                                           width: 1,
                                         ),
                                       ),
@@ -377,7 +386,7 @@ class _InvoiceConfirmScreenState extends State<InvoiceConfirmScreen> {
                                       style: TextStyle(
                                         fontSize: 15,
                                         fontWeight: FontWeight.w600,
-                                        color: Colors.white,
+                                        color: t.textPrimary,
                                       ),
                                       textAlign: TextAlign.center,
                                       overflow: TextOverflow.visible,
@@ -385,12 +394,12 @@ class _InvoiceConfirmScreenState extends State<InvoiceConfirmScreen> {
                                   ),
                                 ),
                               ),
-                              
+
                               const SizedBox(width: 16),
-                              
+
                               Expanded(
                                 flex: 1,
-                                child: Container(
+                                child: SizedBox(
                                   height: 56,
                                   child: ElevatedButton(
                                     onPressed: (!widget.decodedInvoice.isExpired && !_isProcessing)
@@ -398,21 +407,21 @@ class _InvoiceConfirmScreenState extends State<InvoiceConfirmScreen> {
                                         : null,
                                     style: ElevatedButton.styleFrom(
                                       backgroundColor: (!widget.decodedInvoice.isExpired && !_isProcessing)
-                                          ? const Color(0xFF2D3FE7)
-                                          : Colors.white.withValues(alpha: 0.08),
-                                      foregroundColor: Colors.white,
+                                          ? t.accentSolid
+                                          : t.surface,
+                                      foregroundColor: t.accentForeground,
                                       elevation: (!widget.decodedInvoice.isExpired && !_isProcessing) ? 8 : 0,
                                       shape: RoundedRectangleBorder(
                                         borderRadius: BorderRadius.circular(16),
                                         side: BorderSide(
                                           color: (!widget.decodedInvoice.isExpired && !_isProcessing)
-                                              ? const Color(0xFF4C63F7)
-                                              : Colors.white.withValues(alpha: 0.1),
+                                              ? t.accentSolid
+                                              : t.outline,
                                           width: 1,
                                         ),
                                       ),
                                       shadowColor: (!widget.decodedInvoice.isExpired && !_isProcessing)
-                                          ? const Color(0xFF2D3FE7).withValues(alpha: 0.3)
+                                          ? t.accentSolid.withValues(alpha: 0.3)
                                           : Colors.transparent,
                                     ),
                                     child: _isProcessing
@@ -424,7 +433,7 @@ class _InvoiceConfirmScreenState extends State<InvoiceConfirmScreen> {
                                                 height: 18,
                                                 child: CircularProgressIndicator(
                                                   strokeWidth: 2,
-                                                  valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                                                  valueColor: AlwaysStoppedAnimation<Color>(t.accentForeground),
                                                 ),
                                               ),
                                               const SizedBox(width: 8),
@@ -433,7 +442,7 @@ class _InvoiceConfirmScreenState extends State<InvoiceConfirmScreen> {
                                                 style: TextStyle(
                                                   fontSize: 14,
                                                   fontWeight: FontWeight.w600,
-                                                  color: Colors.white,
+                                                  color: t.accentForeground,
                                                 ),
                                               ),
                                             ],
@@ -444,8 +453,8 @@ class _InvoiceConfirmScreenState extends State<InvoiceConfirmScreen> {
                                               fontSize: 16,
                                               fontWeight: FontWeight.w700,
                                               color: (!widget.decodedInvoice.isExpired && !_isProcessing)
-                                                  ? Colors.white
-                                                  : Colors.white.withValues(alpha: 0.4),
+                                                  ? t.accentForeground
+                                                  : t.textPrimary.withValues(alpha: 0.4),
                                             ),
                                             textAlign: TextAlign.center,
                                             overflow: TextOverflow.visible,
@@ -455,7 +464,7 @@ class _InvoiceConfirmScreenState extends State<InvoiceConfirmScreen> {
                               ),
                             ],
                           ),
-                          
+
                           const SizedBox(height: 24),
                         ],
                       ),
@@ -470,14 +479,14 @@ class _InvoiceConfirmScreenState extends State<InvoiceConfirmScreen> {
     );
   }
 
-  Widget _buildInfoRow(String label, String value, {IconData? icon, Color? valueColor}) {
+  Widget _buildInfoRow(AppTokens t, String label, String value, {IconData? icon, Color? valueColor}) {
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         if (icon != null) ...[
           Icon(
             icon,
-            color: Colors.white.withValues(alpha: 0.7),
+            color: t.textPrimary.withValues(alpha: 0.7),
             size: 20,
           ),
           const SizedBox(width: 12),
@@ -487,10 +496,9 @@ class _InvoiceConfirmScreenState extends State<InvoiceConfirmScreen> {
           child: Text(
             label,
             style: TextStyle(
-              fontFamily: 'Manrope',
               fontSize: 14,
               fontWeight: FontWeight.w600,
-              color: Colors.white.withValues(alpha: 0.7),
+              color: t.textPrimary.withValues(alpha: 0.7),
             ),
           ),
         ),
@@ -500,10 +508,9 @@ class _InvoiceConfirmScreenState extends State<InvoiceConfirmScreen> {
           child: Text(
             value,
             style: TextStyle(
-              fontFamily: 'Manrope',
               fontSize: 14,
               fontWeight: FontWeight.w400,
-              color: valueColor ?? Colors.white,
+              color: valueColor ?? t.textPrimary,
             ),
             textAlign: TextAlign.right,
           ),
@@ -512,7 +519,7 @@ class _InvoiceConfirmScreenState extends State<InvoiceConfirmScreen> {
     );
   }
 
-  Widget _buildDescriptionRow(String label, String value, {IconData? icon, Color? valueColor}) {
+  Widget _buildDescriptionRow(AppTokens t, String label, String value, {IconData? icon, Color? valueColor}) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -521,7 +528,7 @@ class _InvoiceConfirmScreenState extends State<InvoiceConfirmScreen> {
             if (icon != null) ...[
               Icon(
                 icon,
-                color: Colors.white.withValues(alpha: 0.7),
+                color: t.textPrimary.withValues(alpha: 0.7),
                 size: 20,
               ),
               const SizedBox(width: 12),
@@ -529,10 +536,9 @@ class _InvoiceConfirmScreenState extends State<InvoiceConfirmScreen> {
             Text(
               label,
               style: TextStyle(
-                fontFamily: 'Manrope',
                 fontSize: 14,
                 fontWeight: FontWeight.w600,
-                color: Colors.white.withValues(alpha: 0.7),
+                color: t.textPrimary.withValues(alpha: 0.7),
               ),
             ),
           ],
@@ -542,20 +548,19 @@ class _InvoiceConfirmScreenState extends State<InvoiceConfirmScreen> {
           width: double.infinity,
           padding: const EdgeInsets.all(12),
           decoration: BoxDecoration(
-            color: Colors.white.withValues(alpha: 0.05),
+            color: t.inputFill,
             borderRadius: BorderRadius.circular(8),
             border: Border.all(
-              color: Colors.white.withValues(alpha: 0.1),
+              color: t.outline,
               width: 1,
             ),
           ),
           child: Text(
             value,
             style: TextStyle(
-              fontFamily: 'Manrope',
               fontSize: 14,
               fontWeight: FontWeight.w400,
-              color: valueColor ?? Colors.white,
+              color: valueColor ?? t.textPrimary,
               height: 1.4,
             ),
             maxLines: null, // Allows multiple lines

--- a/lib/screens/14fixed_float_screen.dart
+++ b/lib/screens/14fixed_float_screen.dart
@@ -4,6 +4,7 @@ import 'dart:io' show Platform;
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:url_launcher/url_launcher.dart';
 import '../l10n/generated/app_localizations.dart';
+import '../theme/app_tokens.dart';
 
 class FixedFloatScreen extends StatefulWidget {
   const FixedFloatScreen({super.key});
@@ -87,22 +88,23 @@ class _FixedFloatScreenState extends State<FixedFloatScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final t = context.tokens;
     return Scaffold(
+      // Scaffold base bg matches gradient first stop
       backgroundColor: const Color(0xFF0F1419),
       appBar: AppBar(
-        title: const Text(
+        title: Text(
           'Fixed Float',
           style: TextStyle(
-            fontFamily: 'Manrope',
             fontSize: 20,
             fontWeight: FontWeight.w600,
-            color: Colors.white,
+            color: t.textPrimary,
           ),
         ),
-        backgroundColor: const Color(0xFF1A1D47),
+        backgroundColor: t.dialogBackground,
         elevation: 0,
-        iconTheme: const IconThemeData(
-          color: Colors.white,
+        iconTheme: IconThemeData(
+          color: t.textPrimary,
         ),
         actions: [
           if (_controller != null && !_hasError)
@@ -115,27 +117,16 @@ class _FixedFloatScreenState extends State<FixedFloatScreen> {
         ],
       ),
       body: Container(
-        decoration: const BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-            colors: [
-              Color(0xFF0F1419),
-              Color(0xFF1A1D47),
-              Color(0xFF2D3FE7),
-            ],
-            stops: [0.0, 0.5, 1.0],
-          ),
-        ),
-        child: _buildBody(),
+        decoration: BoxDecoration(gradient: t.backgroundGradient),
+        child: _buildBody(t),
       ),
     );
   }
 
-  Widget _buildBody() {
+  Widget _buildBody(AppTokens t) {
     if (_hasError || _controller == null) {
       // Fallback UI for unsupported platforms or errors
-      return _buildFallbackUI();
+      return _buildFallbackUI(t);
     }
 
     return Stack(
@@ -164,7 +155,7 @@ class _FixedFloatScreenState extends State<FixedFloatScreen> {
             ),
           ),
         ),
-        
+
         // Loading indicator
         if (_isLoading)
           Container(
@@ -173,17 +164,16 @@ class _FixedFloatScreenState extends State<FixedFloatScreen> {
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  const CircularProgressIndicator(
-                    valueColor: AlwaysStoppedAnimation<Color>(Color(0xFF2D3FE7)),
+                  CircularProgressIndicator(
+                    valueColor: AlwaysStoppedAnimation<Color>(t.accentSolid),
                   ),
                   const SizedBox(height: 16),
                   Text(
                     AppLocalizations.of(context)!.fixed_float_loading,
-                    style: const TextStyle(
-                      fontFamily: 'Manrope',
+                    style: TextStyle(
                       fontSize: 16,
                       fontWeight: FontWeight.w500,
-                      color: Colors.white,
+                      color: t.textPrimary,
                     ),
                   ),
                 ],
@@ -194,7 +184,7 @@ class _FixedFloatScreenState extends State<FixedFloatScreen> {
     );
   }
 
-  Widget _buildFallbackUI() {
+  Widget _buildFallbackUI(AppTokens t) {
     return Padding(
       padding: const EdgeInsets.all(24),
       child: Column(
@@ -205,73 +195,71 @@ class _FixedFloatScreenState extends State<FixedFloatScreen> {
             width: 120,
             height: 120,
             decoration: BoxDecoration(
-              color: Colors.white.withValues(alpha: 0.1),
+              color: t.outline,
               borderRadius: BorderRadius.circular(20),
               border: Border.all(
-                color: Colors.white.withValues(alpha: 0.2),
+                color: t.outlineStrong,
                 width: 2,
               ),
             ),
-            child: const Icon(
+            child: Icon(
               Icons.swap_horiz,
               size: 60,
-              color: Color(0xFF2D3FE7),
+              color: t.accentSolid,
             ),
           ),
-          
+
           const SizedBox(height: 32),
-          
+
           // Title
-          const Text(
+          Text(
             'Fixed Float',
             style: TextStyle(
-              fontFamily: 'Manrope',
               fontSize: 28,
               fontWeight: FontWeight.bold,
-              color: Colors.white,
+              color: t.textPrimary,
             ),
           ),
-          
+
           const SizedBox(height: 16),
-          
+
           // Description
           Text(
             AppLocalizations.of(context)!.fixed_float_description,
             textAlign: TextAlign.center,
             style: TextStyle(
-              fontFamily: 'Manrope',
               fontSize: 16,
               fontWeight: FontWeight.w400,
-              color: Colors.white.withValues(alpha: 0.8),
+              color: t.textPrimary.withValues(alpha: 0.8),
               height: 1.4,
             ),
           ),
-          
+
           if (_errorMessage != null) ...[
             const SizedBox(height: 16),
             Container(
               padding: const EdgeInsets.all(12),
               decoration: BoxDecoration(
-                color: Colors.orange.withValues(alpha: 0.2),
+                color: t.statusWarning.withValues(alpha: 0.2),
                 borderRadius: BorderRadius.circular(8),
                 border: Border.all(
-                  color: Colors.orange.withValues(alpha: 0.3),
+                  color: t.statusWarning.withValues(alpha: 0.3),
                 ),
               ),
               child: Text(
                 AppLocalizations.of(context)!.fixed_float_webview_error,
                 textAlign: TextAlign.center,
                 style: TextStyle(
-                  fontFamily: 'Manrope',
                   fontSize: 14,
+                  // Lighter shade of warning is intrinsic to error text styling
                   color: Colors.orange.shade200,
                 ),
               ),
             ),
           ],
-          
+
           const SizedBox(height: 40),
-          
+
           // Launch button
           SizedBox(
             width: double.infinity,
@@ -285,17 +273,17 @@ class _FixedFloatScreenState extends State<FixedFloatScreen> {
                     ScaffoldMessenger.of(context).showSnackBar(
                       SnackBar(
                         content: Text(AppLocalizations.of(context)!.fixed_float_error_opening(e.toString())),
-                        backgroundColor: Colors.red,
+                        backgroundColor: t.statusUnhealthy,
                       ),
                     );
                   }
                 }
               },
               style: ElevatedButton.styleFrom(
-                backgroundColor: const Color(0xFF2D3FE7),
-                foregroundColor: Colors.white,
+                backgroundColor: t.accentSolid,
+                foregroundColor: t.accentForeground,
                 elevation: 8,
-                shadowColor: const Color(0xFF2D3FE7).withValues(alpha: 0.3),
+                shadowColor: t.accentSolid.withValues(alpha: 0.3),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(16),
                 ),
@@ -306,7 +294,6 @@ class _FixedFloatScreenState extends State<FixedFloatScreen> {
                   Text(
                     AppLocalizations.of(context)!.fixed_float_open_button,
                     style: const TextStyle(
-                      fontFamily: 'Manrope',
                       fontSize: 16,
                       fontWeight: FontWeight.w600,
                     ),
@@ -320,20 +307,19 @@ class _FixedFloatScreenState extends State<FixedFloatScreen> {
               ),
             ),
           ),
-          
+
           const SizedBox(height: 16),
-          
+
           // Info text
           Text(
-            kIsWeb || !(Platform.isAndroid || Platform.isIOS) 
+            kIsWeb || !(Platform.isAndroid || Platform.isIOS)
                 ? AppLocalizations.of(context)!.fixed_float_external_browser
                 : AppLocalizations.of(context)!.fixed_float_within_app,
             textAlign: TextAlign.center,
             style: TextStyle(
-              fontFamily: 'Manrope',
               fontSize: 12,
               fontWeight: FontWeight.w400,
-              color: Colors.white.withValues(alpha: 0.6),
+              color: t.textPrimary.withValues(alpha: 0.6),
             ),
           ),
         ],

--- a/lib/screens/14fixed_float_screen.dart
+++ b/lib/screens/14fixed_float_screen.dart
@@ -90,8 +90,7 @@ class _FixedFloatScreenState extends State<FixedFloatScreen> {
   Widget build(BuildContext context) {
     final t = context.tokens;
     return Scaffold(
-      // Scaffold base bg matches gradient first stop
-      backgroundColor: const Color(0xFF0F1419),
+      backgroundColor: t.scaffoldBase,
       appBar: AppBar(
         title: Text(
           'Fixed Float',
@@ -159,7 +158,7 @@ class _FixedFloatScreenState extends State<FixedFloatScreen> {
         // Loading indicator
         if (_isLoading)
           Container(
-            color: const Color(0xFF0F1419).withValues(alpha: 0.9),
+            color: t.scaffoldBase.withValues(alpha: 0.9),
             child: Center(
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
@@ -195,10 +194,10 @@ class _FixedFloatScreenState extends State<FixedFloatScreen> {
             width: 120,
             height: 120,
             decoration: BoxDecoration(
-              color: t.outline,
+              color: t.surface,
               borderRadius: BorderRadius.circular(20),
               border: Border.all(
-                color: t.outlineStrong,
+                color: t.outline,
                 width: 2,
               ),
             ),
@@ -251,8 +250,7 @@ class _FixedFloatScreenState extends State<FixedFloatScreen> {
                 textAlign: TextAlign.center,
                 style: TextStyle(
                   fontSize: 14,
-                  // Lighter shade of warning is intrinsic to error text styling
-                  color: Colors.orange.shade200,
+                  color: t.statusWarningSoft,
                 ),
               ),
             ),

--- a/lib/screens/15boltz_screen.dart
+++ b/lib/screens/15boltz_screen.dart
@@ -90,8 +90,7 @@ class _BoltzScreenState extends State<BoltzScreen> {
   Widget build(BuildContext context) {
     final t = context.tokens;
     return Scaffold(
-      // Scaffold base bg matches gradient first stop
-      backgroundColor: const Color(0xFF0F1419),
+      backgroundColor: t.scaffoldBase,
       appBar: AppBar(
         title: Text(
           'Boltz',
@@ -159,7 +158,7 @@ class _BoltzScreenState extends State<BoltzScreen> {
         // Loading indicator
         if (_isLoading)
           Container(
-            color: const Color(0xFF0F1419).withValues(alpha: 0.9),
+            color: t.scaffoldBase.withValues(alpha: 0.9),
             child: Center(
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
@@ -195,10 +194,10 @@ class _BoltzScreenState extends State<BoltzScreen> {
             width: 120,
             height: 120,
             decoration: BoxDecoration(
-              color: t.outline,
+              color: t.surface,
               borderRadius: BorderRadius.circular(20),
               border: Border.all(
-                color: t.outlineStrong,
+                color: t.outline,
                 width: 2,
               ),
             ),
@@ -251,8 +250,7 @@ class _BoltzScreenState extends State<BoltzScreen> {
                 textAlign: TextAlign.center,
                 style: TextStyle(
                   fontSize: 14,
-                  // Lighter shade of warning is intrinsic to error text styling
-                  color: Colors.orange.shade200,
+                  color: t.statusWarningSoft,
                 ),
               ),
             ),

--- a/lib/screens/15boltz_screen.dart
+++ b/lib/screens/15boltz_screen.dart
@@ -4,6 +4,7 @@ import 'dart:io' show Platform;
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:url_launcher/url_launcher.dart';
 import '../l10n/generated/app_localizations.dart';
+import '../theme/app_tokens.dart';
 
 class BoltzScreen extends StatefulWidget {
   const BoltzScreen({super.key});
@@ -87,22 +88,23 @@ class _BoltzScreenState extends State<BoltzScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final t = context.tokens;
     return Scaffold(
+      // Scaffold base bg matches gradient first stop
       backgroundColor: const Color(0xFF0F1419),
       appBar: AppBar(
-        title: const Text(
+        title: Text(
           'Boltz',
           style: TextStyle(
-            fontFamily: 'Manrope',
             fontSize: 20,
             fontWeight: FontWeight.w600,
-            color: Colors.white,
+            color: t.textPrimary,
           ),
         ),
-        backgroundColor: const Color(0xFF1A1D47),
+        backgroundColor: t.dialogBackground,
         elevation: 0,
-        iconTheme: const IconThemeData(
-          color: Colors.white,
+        iconTheme: IconThemeData(
+          color: t.textPrimary,
         ),
         actions: [
           if (_controller != null && !_hasError)
@@ -115,27 +117,16 @@ class _BoltzScreenState extends State<BoltzScreen> {
         ],
       ),
       body: Container(
-        decoration: const BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-            colors: [
-              Color(0xFF0F1419),
-              Color(0xFF1A1D47),
-              Color(0xFF2D3FE7),
-            ],
-            stops: [0.0, 0.5, 1.0],
-          ),
-        ),
-        child: _buildBody(),
+        decoration: BoxDecoration(gradient: t.backgroundGradient),
+        child: _buildBody(t),
       ),
     );
   }
 
-  Widget _buildBody() {
+  Widget _buildBody(AppTokens t) {
     if (_hasError || _controller == null) {
       // Fallback UI for unsupported platforms or errors
-      return _buildFallbackUI();
+      return _buildFallbackUI(t);
     }
 
     return Stack(
@@ -164,7 +155,7 @@ class _BoltzScreenState extends State<BoltzScreen> {
             ),
           ),
         ),
-        
+
         // Loading indicator
         if (_isLoading)
           Container(
@@ -173,17 +164,16 @@ class _BoltzScreenState extends State<BoltzScreen> {
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  const CircularProgressIndicator(
-                    valueColor: AlwaysStoppedAnimation<Color>(Color(0xFF2D3FE7)),
+                  CircularProgressIndicator(
+                    valueColor: AlwaysStoppedAnimation<Color>(t.accentSolid),
                   ),
                   const SizedBox(height: 16),
                   Text(
                     AppLocalizations.of(context)!.boltz_loading,
-                    style: const TextStyle(
-                      fontFamily: 'Manrope',
+                    style: TextStyle(
                       fontSize: 16,
                       fontWeight: FontWeight.w500,
-                      color: Colors.white,
+                      color: t.textPrimary,
                     ),
                   ),
                 ],
@@ -194,7 +184,7 @@ class _BoltzScreenState extends State<BoltzScreen> {
     );
   }
 
-  Widget _buildFallbackUI() {
+  Widget _buildFallbackUI(AppTokens t) {
     return Padding(
       padding: const EdgeInsets.all(24),
       child: Column(
@@ -205,73 +195,71 @@ class _BoltzScreenState extends State<BoltzScreen> {
             width: 120,
             height: 120,
             decoration: BoxDecoration(
-              color: Colors.white.withValues(alpha: 0.1),
+              color: t.outline,
               borderRadius: BorderRadius.circular(20),
               border: Border.all(
-                color: Colors.white.withValues(alpha: 0.2),
+                color: t.outlineStrong,
                 width: 2,
               ),
             ),
-            child: const Icon(
+            child: Icon(
               Icons.currency_exchange,
               size: 60,
-              color: Color(0xFF2D3FE7),
+              color: t.accentSolid,
             ),
           ),
-          
+
           const SizedBox(height: 32),
-          
+
           // Title
-          const Text(
+          Text(
             'Boltz',
             style: TextStyle(
-              fontFamily: 'Manrope',
               fontSize: 28,
               fontWeight: FontWeight.bold,
-              color: Colors.white,
+              color: t.textPrimary,
             ),
           ),
-          
+
           const SizedBox(height: 16),
-          
+
           // Description
           Text(
             AppLocalizations.of(context)!.boltz_description,
             textAlign: TextAlign.center,
             style: TextStyle(
-              fontFamily: 'Manrope',
               fontSize: 16,
               fontWeight: FontWeight.w400,
-              color: Colors.white.withValues(alpha: 0.8),
+              color: t.textPrimary.withValues(alpha: 0.8),
               height: 1.4,
             ),
           ),
-          
+
           if (_errorMessage != null) ...[
             const SizedBox(height: 16),
             Container(
               padding: const EdgeInsets.all(12),
               decoration: BoxDecoration(
-                color: Colors.orange.withValues(alpha: 0.2),
+                color: t.statusWarning.withValues(alpha: 0.2),
                 borderRadius: BorderRadius.circular(8),
                 border: Border.all(
-                  color: Colors.orange.withValues(alpha: 0.3),
+                  color: t.statusWarning.withValues(alpha: 0.3),
                 ),
               ),
               child: Text(
                 AppLocalizations.of(context)!.boltz_webview_error,
                 textAlign: TextAlign.center,
                 style: TextStyle(
-                  fontFamily: 'Manrope',
                   fontSize: 14,
+                  // Lighter shade of warning is intrinsic to error text styling
                   color: Colors.orange.shade200,
                 ),
               ),
             ),
           ],
-          
+
           const SizedBox(height: 40),
-          
+
           // Launch button
           SizedBox(
             width: double.infinity,
@@ -285,17 +273,17 @@ class _BoltzScreenState extends State<BoltzScreen> {
                     ScaffoldMessenger.of(context).showSnackBar(
                       SnackBar(
                         content: Text(AppLocalizations.of(context)!.boltz_error_opening(e.toString())),
-                        backgroundColor: Colors.red,
+                        backgroundColor: t.statusUnhealthy,
                       ),
                     );
                   }
                 }
               },
               style: ElevatedButton.styleFrom(
-                backgroundColor: const Color(0xFF2D3FE7),
-                foregroundColor: Colors.white,
+                backgroundColor: t.accentSolid,
+                foregroundColor: t.accentForeground,
                 elevation: 8,
-                shadowColor: const Color(0xFF2D3FE7).withValues(alpha: 0.3),
+                shadowColor: t.accentSolid.withValues(alpha: 0.3),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(16),
                 ),
@@ -306,7 +294,6 @@ class _BoltzScreenState extends State<BoltzScreen> {
                   Text(
                     AppLocalizations.of(context)!.boltz_open_button,
                     style: const TextStyle(
-                      fontFamily: 'Manrope',
                       fontSize: 16,
                       fontWeight: FontWeight.w600,
                     ),
@@ -320,20 +307,19 @@ class _BoltzScreenState extends State<BoltzScreen> {
               ),
             ),
           ),
-          
+
           const SizedBox(height: 16),
-          
+
           // Info text
           Text(
-            kIsWeb || !(Platform.isAndroid || Platform.isIOS) 
+            kIsWeb || !(Platform.isAndroid || Platform.isIOS)
                 ? AppLocalizations.of(context)!.boltz_external_browser
                 : AppLocalizations.of(context)!.boltz_within_app,
             textAlign: TextAlign.center,
             style: TextStyle(
-              fontFamily: 'Manrope',
               fontSize: 12,
               fontWeight: FontWeight.w400,
-              color: Colors.white.withValues(alpha: 0.6),
+              color: t.textPrimary.withValues(alpha: 0.6),
             ),
           ),
         ],

--- a/lib/screens/16currency_settings_screen.dart
+++ b/lib/screens/16currency_settings_screen.dart
@@ -5,6 +5,7 @@ import '../providers/wallet_provider.dart';
 import '../models/currency_info.dart';
 import '../l10n/generated/app_localizations.dart';
 import '../providers/auth_provider.dart';
+import '../theme/app_tokens.dart';
 
 class CurrencySettingsScreen extends StatefulWidget {
   const CurrencySettingsScreen({super.key});
@@ -124,17 +125,17 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
       context: context,
       barrierDismissible: false,
       builder: (context) => AlertDialog(
-        backgroundColor: const Color(0xFF1A1D47),
+        backgroundColor: context.tokens.dialogBackground,
         content: Row(
           children: [
-            const CircularProgressIndicator(
-              valueColor: AlwaysStoppedAnimation<Color>(Color(0xFF5B73FF)),
+            CircularProgressIndicator(
+              valueColor: AlwaysStoppedAnimation<Color>(context.tokens.accentBright),
             ),
             const SizedBox(width: 16),
             Expanded(
               child: Text(
                 AppLocalizations.of(context)!.checking_currency_availability(currency),
-                style: const TextStyle(color: Colors.white),
+                style: TextStyle(color: context.tokens.textPrimary),
               ),
             ),
           ],
@@ -232,18 +233,7 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
         return Scaffold(
           backgroundColor: Colors.transparent,
           body: Container(
-            decoration: const BoxDecoration(
-              gradient: LinearGradient(
-                begin: Alignment.topLeft,
-                end: Alignment.bottomRight,
-                colors: [
-                  Color(0xFF0F1419),
-                  Color(0xFF1A1D47),
-                  Color(0xFF2D3FE7),
-                ],
-                stops: [0.0, 0.5, 1.0],
-              ),
-            ),
+            decoration: BoxDecoration(gradient: context.tokens.backgroundGradient),
             child: SafeArea(
               child: Column(
                 children: [
@@ -293,25 +283,25 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
             width: 48,
             height: 48,
             decoration: BoxDecoration(
-              color: Colors.white.withValues(alpha: 0.08),
+              color: context.tokens.surface,
               borderRadius: BorderRadius.circular(12),
               border: Border.all(
-                color: Colors.white.withValues(alpha: 0.1),
+                color: context.tokens.outline,
                 width: 1,
               ),
             ),
             child: IconButton(
-              icon: const Icon(
+              icon: Icon(
                 Icons.arrow_back,
-                color: Colors.white,
+                color: context.tokens.textPrimary,
                 size: 24,
               ),
               onPressed: () => Navigator.pop(context),
             ),
           ),
-          
+
           const SizedBox(width: 16),
-          
+
           // Title
           Expanded(
             child: Column(
@@ -319,20 +309,18 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
               children: [
                 Text(
                   AppLocalizations.of(context)!.currency_settings_title ?? 'Currency Settings',
-                  style: const TextStyle(
-                    fontFamily: 'Manrope',
-                    fontSize: 24,
+                  style: TextStyle(
+        fontSize: 24,
                     fontWeight: FontWeight.bold,
-                    color: Colors.white,
+                    color: context.tokens.textPrimary,
                   ),
                 ),
                 const SizedBox(height: 4),
                 Text(
                   AppLocalizations.of(context)!.currency_settings_subtitle ?? 'Select your preferred currencies',
                   style: TextStyle(
-                    fontFamily: 'Manrope',
-                    fontSize: 14,
-                    color: Colors.white.withValues(alpha: 0.7),
+        fontSize: 14,
+                    color: context.tokens.textPrimary.withValues(alpha: 0.7),
                   ),
                 ),
               ],
@@ -368,10 +356,10 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
       width: double.infinity,
       padding: const EdgeInsets.all(20),
       decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.08),
+        color: context.tokens.surface,
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
-          color: Colors.white.withValues(alpha: 0.1),
+          color: context.tokens.outline,
           width: 1,
         ),
       ),
@@ -381,29 +369,28 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
           // Header
           Row(
             children: [
-              const Icon(
+              Icon(
                 Icons.add_circle_outline,
-                color: Color(0xFF5B73FF),
+                color: context.tokens.accentBright,
                 size: 20,
               ),
               const SizedBox(width: 8),
               Text(
                 AppLocalizations.of(context)!.available_currencies ?? 'Add Currency',
-                style: const TextStyle(
-                  fontFamily: 'Manrope',
-                  fontSize: 18,
+                style: TextStyle(
+    fontSize: 18,
                   fontWeight: FontWeight.w600,
-                  color: Colors.white,
+                  color: context.tokens.textPrimary,
                 ),
               ),
               const Spacer(),
               if (currencyProvider.isLoadingCurrencies)
-                const SizedBox(
+                SizedBox(
                   width: 16,
                   height: 16,
                   child: CircularProgressIndicator(
                     strokeWidth: 2,
-                    valueColor: AlwaysStoppedAnimation<Color>(Color(0xFF5B73FF)),
+                    valueColor: AlwaysStoppedAnimation<Color>(context.tokens.accentBright),
                   ),
                 ),
             ],
@@ -421,20 +408,20 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
               width: double.infinity,
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
               decoration: BoxDecoration(
-                color: Colors.white.withValues(alpha: 0.05),
+                color: context.tokens.inputFill,
                 borderRadius: BorderRadius.circular(12),
                 border: Border.all(
                   color: _isDropdownOpen 
-                      ? const Color(0xFF5B73FF)
-                      : Colors.white.withValues(alpha: 0.1),
+                      ? context.tokens.accentBright
+                      : context.tokens.outline,
                   width: _isDropdownOpen ? 2 : 1,
                 ),
               ),
               child: Row(
                 children: [
-                  const Icon(
+                  Icon(
                     Icons.search,
-                    color: Color(0xFF5B73FF),
+                    color: context.tokens.accentBright,
                     size: 20,
                   ),
                   const SizedBox(width: 12),
@@ -443,14 +430,14 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
                         ? TextField(
                             controller: _searchController,
                             autofocus: true,
-                            style: const TextStyle(
-                              color: Colors.white,
+                            style: TextStyle(
+                              color: context.tokens.textPrimary,
                               fontSize: 16,
                             ),
                             decoration: InputDecoration(
                               hintText: 'Search currencies...',
                               hintStyle: TextStyle(
-                                color: Colors.white.withValues(alpha: 0.5),
+                                color: context.tokens.textSecondary,
                                 fontSize: 16,
                               ),
                               border: InputBorder.none,
@@ -461,14 +448,14 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
                         : Text(
                             'Search and select currencies...',
                             style: TextStyle(
-                              color: Colors.white.withValues(alpha: 0.7),
+                              color: context.tokens.textPrimary.withValues(alpha: 0.7),
                               fontSize: 16,
                             ),
                           ),
                   ),
                   Icon(
                     _isDropdownOpen ? Icons.keyboard_arrow_up : Icons.keyboard_arrow_down,
-                    color: Color(0xFF5B73FF),
+                    color: context.tokens.accentBright,
                     size: 20,
                   ),
                 ],
@@ -482,10 +469,10 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
             Container(
               constraints: const BoxConstraints(maxHeight: 300),
               decoration: BoxDecoration(
-                color: Colors.white.withValues(alpha: 0.05),
+                color: context.tokens.inputFill,
                 borderRadius: BorderRadius.circular(12),
                 border: Border.all(
-                  color: Colors.white.withValues(alpha: 0.1),
+                  color: context.tokens.outline,
                   width: 1,
                 ),
               ),
@@ -498,7 +485,7 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
                               ? 'No currencies found'
                               : 'No currencies available',
                           style: TextStyle(
-                            color: Colors.white.withValues(alpha: 0.7),
+                            color: context.tokens.textPrimary.withValues(alpha: 0.7),
                             fontSize: 14,
                           ),
                         ),
@@ -557,10 +544,10 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
       width: double.infinity,
       padding: const EdgeInsets.all(20),
       decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.08),
+        color: context.tokens.surface,
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
-          color: Colors.white.withValues(alpha: 0.1),
+          color: context.tokens.outline,
           width: 1,
         ),
       ),
@@ -569,28 +556,26 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
         children: [
           Row(
             children: [
-              const Icon(
+              Icon(
                 Icons.star,
-                color: Color(0xFF5B73FF),
+                color: context.tokens.accentBright,
                 size: 20,
               ),
               const SizedBox(width: 8),
               Text(
                 AppLocalizations.of(context)!.selected_currencies ?? 'Selected Currencies',
-                style: const TextStyle(
-                  fontFamily: 'Manrope',
-                  fontSize: 18,
+                style: TextStyle(
+    fontSize: 18,
                   fontWeight: FontWeight.w600,
-                  color: Colors.white,
+                  color: context.tokens.textPrimary,
                 ),
               ),
               const Spacer(),
               Text(
                 '${selectedCurrencies.length + 1}', // +1 for sats
                 style: TextStyle(
-                  fontFamily: 'Manrope',
-                  fontSize: 14,
-                  color: Colors.white.withValues(alpha: 0.7),
+    fontSize: 14,
+                  color: context.tokens.textPrimary.withValues(alpha: 0.7),
                 ),
               ),
             ],
@@ -666,7 +651,7 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
           decoration: BoxDecoration(
             border: Border(
               bottom: BorderSide(
-                color: Colors.white.withValues(alpha: 0.05),
+                color: context.tokens.inputFill,
                 width: 0.5,
               ),
             ),
@@ -678,7 +663,7 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
                 width: 32,
                 height: 32,
                 decoration: BoxDecoration(
-                  color: Colors.white.withValues(alpha: 0.05),
+                  color: context.tokens.inputFill,
                   borderRadius: BorderRadius.circular(8),
                 ),
                 child: Center(
@@ -701,23 +686,21 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
                         Text(
                           currency,
                           style: TextStyle(
-                            fontFamily: 'Manrope',
-                            fontSize: 14,
+                        fontSize: 14,
                             fontWeight: FontWeight.bold,
                             color: isAlreadySelected 
-                                ? Colors.white.withValues(alpha: 0.5)
-                                : Colors.white,
+                                ? context.tokens.textSecondary
+                                : context.tokens.textPrimary,
                           ),
                         ),
                         const SizedBox(width: 6),
                         Text(
                           name,
                           style: TextStyle(
-                            fontFamily: 'Manrope',
-                            fontSize: 12,
+                        fontSize: 12,
                             color: isAlreadySelected 
-                                ? Colors.white.withValues(alpha: 0.4)
-                                : Colors.white.withValues(alpha: 0.7),
+                                ? context.tokens.textTertiary
+                                : context.tokens.textPrimary.withValues(alpha: 0.7),
                           ),
                         ),
                       ],
@@ -726,11 +709,10 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
                       Text(
                         country,
                         style: TextStyle(
-                          fontFamily: 'Manrope',
-                          fontSize: 11,
+                    fontSize: 11,
                           color: isAlreadySelected 
-                              ? Colors.white.withValues(alpha: 0.3)
-                              : Colors.white.withValues(alpha: 0.5),
+                              ? context.tokens.textTertiary
+                              : context.tokens.textSecondary,
                         ),
                       ),
                   ],
@@ -741,13 +723,13 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
               if (isAlreadySelected)
                 Icon(
                   Icons.check_circle,
-                  color: Colors.white.withValues(alpha: 0.5),
+                  color: context.tokens.textSecondary,
                   size: 18,
                 )
               else
                 Icon(
                   Icons.add_circle_outline,
-                  color: Color(0xFF5B73FF),
+                  color: context.tokens.accentBright,
                   size: 18,
                 ),
             ],
@@ -779,13 +761,13 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
             padding: const EdgeInsets.all(16),
             decoration: BoxDecoration(
               color: isSelected 
-                  ? const Color(0xFF2D3FE7).withValues(alpha: 0.2)
-                  : Colors.white.withValues(alpha: 0.05),
+                  ? context.tokens.accentSolid.withValues(alpha: 0.2)
+                  : context.tokens.inputFill,
               borderRadius: BorderRadius.circular(12),
               border: Border.all(
                 color: isSelected 
-                    ? const Color(0xFF2D3FE7)
-                    : Colors.white.withValues(alpha: 0.1),
+                    ? context.tokens.accentSolid
+                    : context.tokens.outline,
                 width: isSelected ? 2 : 1,
               ),
             ),
@@ -797,13 +779,13 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
                   height: 48,
                   decoration: BoxDecoration(
                     color: isSelected 
-                        ? const Color(0xFF2D3FE7).withValues(alpha: 0.3)
-                        : Colors.white.withValues(alpha: 0.1),
+                        ? context.tokens.accentSolid.withValues(alpha: 0.3)
+                        : context.tokens.outline,
                     borderRadius: BorderRadius.circular(12),
                     border: Border.all(
                       color: isSelected 
-                          ? const Color(0xFF2D3FE7)
-                          : Colors.white.withValues(alpha: 0.2),
+                          ? context.tokens.accentSolid
+                          : context.tokens.outlineStrong,
                       width: 1,
                     ),
                   ),
@@ -822,13 +804,13 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
                           child: Container(
                             width: 16,
                             height: 16,
-                            decoration: const BoxDecoration(
-                              color: Color(0xFF2D3FE7),
+                            decoration: BoxDecoration(
+                              color: context.tokens.accentSolid,
                               shape: BoxShape.circle,
                             ),
-                            child: const Icon(
+                            child: Icon(
                               Icons.check,
-                              color: Colors.white,
+                              color: context.tokens.accentForeground,
                               size: 12,
                             ),
                           ),
@@ -849,10 +831,9 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
                           Text(
                             currency,
                             style: TextStyle(
-                              fontFamily: 'Manrope',
-                              fontSize: 16,
+                            fontSize: 16,
                               fontWeight: FontWeight.bold,
-                              color: isSelected ? const Color(0xFF2D3FE7) : Colors.white,
+                              color: isSelected ? context.tokens.accentSolid : context.tokens.textPrimary,
                             ),
                           ),
                           const SizedBox(width: 8),
@@ -860,19 +841,18 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
                             padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
                             decoration: BoxDecoration(
                               color: isSelected 
-                                  ? const Color(0xFF2D3FE7).withValues(alpha: 0.2)
-                                  : Colors.white.withValues(alpha: 0.1),
+                                  ? context.tokens.accentSolid.withValues(alpha: 0.2)
+                                  : context.tokens.outline,
                               borderRadius: BorderRadius.circular(10),
                             ),
                             child: Text(
                               currencyInfo?.symbol ?? currency,
                               style: TextStyle(
-                                fontFamily: 'Manrope',
                                 fontSize: 12,
                                 fontWeight: FontWeight.w500,
                                 color: isSelected 
-                                    ? const Color(0xFF2D3FE7)
-                                    : Colors.white.withValues(alpha: 0.7),
+                                    ? context.tokens.accentSolid
+                                    : context.tokens.textPrimary.withValues(alpha: 0.7),
                               ),
                             ),
                           ),
@@ -882,12 +862,11 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
                       Text(
                         name,
                         style: TextStyle(
-                          fontFamily: 'Manrope',
-                          fontSize: 14,
+                    fontSize: 14,
                           fontWeight: FontWeight.w500,
                           color: isSelected 
-                              ? const Color(0xFF2D3FE7).withValues(alpha: 0.8)
-                              : Colors.white.withValues(alpha: 0.9),
+                              ? context.tokens.accentSolid.withValues(alpha: 0.8)
+                              : context.tokens.textPrimary.withValues(alpha: 0.9),
                         ),
                       ),
                       if (country.isNotEmpty) ...[
@@ -895,11 +874,10 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
                         Text(
                           country,
                           style: TextStyle(
-                            fontFamily: 'Manrope',
-                            fontSize: 12,
+                        fontSize: 12,
                             color: isSelected 
-                                ? const Color(0xFF2D3FE7).withValues(alpha: 0.6)
-                                : Colors.white.withValues(alpha: 0.6),
+                                ? context.tokens.accentSolid.withValues(alpha: 0.6)
+                                : context.tokens.textSecondary,
                           ),
                         ),
                       ],
@@ -910,7 +888,7 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
                 // Arrow indicator
                 Icon(
                   isSelected ? Icons.check_circle : Icons.radio_button_unchecked,
-                  color: isSelected ? const Color(0xFF2D3FE7) : Colors.white.withValues(alpha: 0.5),
+                  color: isSelected ? context.tokens.accentSolid : context.tokens.textSecondary,
                   size: 24,
                 ),
               ],
@@ -939,12 +917,12 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
       decoration: BoxDecoration(
         color: isFirst 
             ? const Color(0xFFFFD700).withValues(alpha: 0.1)
-            : Colors.white.withValues(alpha: 0.05),
+            : context.tokens.inputFill,
         borderRadius: BorderRadius.circular(12),
         border: Border.all(
           color: isFirst 
               ? const Color(0xFFFFD700).withValues(alpha: 0.3)
-              : Colors.white.withValues(alpha: 0.1),
+              : context.tokens.outline,
           width: isFirst ? 2 : 1,
         ),
       ),
@@ -957,12 +935,12 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
             decoration: BoxDecoration(
               color: isFirst 
                   ? const Color(0xFFFFD700).withValues(alpha: 0.2)
-                  : const Color(0xFF2D3FE7).withValues(alpha: 0.1),
+                  : context.tokens.accentSolid.withValues(alpha: 0.1),
               borderRadius: BorderRadius.circular(12),
               border: Border.all(
                 color: isFirst 
                     ? const Color(0xFFFFD700).withValues(alpha: 0.5)
-                    : Colors.white.withValues(alpha: 0.2),
+                    : context.tokens.outlineStrong,
                 width: 1,
               ),
             ),
@@ -985,10 +963,9 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
                     Text(
                       currency.toUpperCase(),
                       style: TextStyle(
-                        fontFamily: 'Manrope',
-                        fontSize: 16,
+                fontSize: 16,
                         fontWeight: FontWeight.bold,
-                        color: isFirst ? const Color(0xFFFFD700) : Colors.white,
+                        color: isFirst ? const Color(0xFFFFD700) : context.tokens.textPrimary,
                       ),
                     ),
                     const SizedBox(width: 8),
@@ -997,18 +974,17 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
                       decoration: BoxDecoration(
                         color: isFirst 
                             ? const Color(0xFFFFD700).withValues(alpha: 0.2)
-                            : Colors.white.withValues(alpha: 0.1),
+                            : context.tokens.outline,
                         borderRadius: BorderRadius.circular(10),
                       ),
                       child: Text(
                         symbol,
                         style: TextStyle(
-                          fontFamily: 'Manrope',
-                          fontSize: 12,
+                    fontSize: 12,
                           fontWeight: FontWeight.w500,
                           color: isFirst 
                               ? const Color(0xFFFFD700)
-                              : Colors.white.withValues(alpha: 0.7),
+                              : context.tokens.textPrimary.withValues(alpha: 0.7),
                         ),
                       ),
                     ),
@@ -1018,12 +994,11 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
                 Text(
                   name,
                   style: TextStyle(
-                    fontFamily: 'Manrope',
-                    fontSize: 14,
+        fontSize: 14,
                     fontWeight: FontWeight.w500,
                     color: isFirst 
                         ? const Color(0xFFFFD700).withValues(alpha: 0.8)
-                        : Colors.white.withValues(alpha: 0.9),
+                        : context.tokens.textPrimary.withValues(alpha: 0.9),
                   ),
                 ),
                 if (country.isNotEmpty) ...[
@@ -1031,11 +1006,10 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
                   Text(
                     country,
                     style: TextStyle(
-                      fontFamily: 'Manrope',
-                      fontSize: 12,
+            fontSize: 12,
                       color: isFirst 
                           ? const Color(0xFFFFD700).withValues(alpha: 0.6)
-                          : Colors.white.withValues(alpha: 0.6),
+                          : context.tokens.textSecondary,
                     ),
                   ),
                 ],
@@ -1073,12 +1047,12 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
               decoration: BoxDecoration(
                 color: isFirst 
                     ? const Color(0xFFFFD700).withValues(alpha: 0.1)
-                    : Colors.white.withValues(alpha: 0.05),
+                    : context.tokens.inputFill,
                 borderRadius: BorderRadius.circular(8),
                 border: Border.all(
                   color: isFirst 
                       ? const Color(0xFFFFD700).withValues(alpha: 0.3)
-                      : Colors.white.withValues(alpha: 0.2),
+                      : context.tokens.outlineStrong,
                   width: 1,
                 ),
               ),
@@ -1086,7 +1060,7 @@ class _CurrencySettingsScreenState extends State<CurrencySettingsScreen>
                 Icons.lock,
                 color: isFirst 
                     ? const Color(0xFFFFD700).withValues(alpha: 0.7)
-                    : Colors.white.withValues(alpha: 0.5),
+                    : context.tokens.textSecondary,
                 size: 18,
               ),
             ),

--- a/lib/screens/17settings_screen.dart
+++ b/lib/screens/17settings_screen.dart
@@ -114,8 +114,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
             child: Container(
               padding: const EdgeInsets.all(8),
               decoration: BoxDecoration(
-                color: t.outline,
+                color: t.surface,
                 borderRadius: BorderRadius.circular(12),
+                border: Border.all(color: t.outline, width: 1),
               ),
               child: Icon(
                 Icons.arrow_back,

--- a/lib/screens/17settings_screen.dart
+++ b/lib/screens/17settings_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import '../providers/language_provider.dart';
 import '../providers/currency_settings_provider.dart';
 import '../l10n/generated/app_localizations.dart';
+import '../theme/app_tokens.dart';
 import '7ln_address_screen.dart';
 import '16currency_settings_screen.dart';
 import '18language_selection_screen.dart';
@@ -17,28 +18,18 @@ class SettingsScreen extends StatefulWidget {
 class _SettingsScreenState extends State<SettingsScreen> {
   @override
   Widget build(BuildContext context) {
+    final t = context.tokens;
     return Scaffold(
       body: Container(
         width: double.infinity,
         height: double.infinity,
-        decoration: const BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-            colors: [
-              Color(0xFF0F1419),
-              Color(0xFF1A1D47),
-              Color(0xFF2D3FE7),
-            ],
-            stops: [0.0, 0.5, 1.0],
-          ),
-        ),
+        decoration: BoxDecoration(gradient: t.backgroundGradient),
         child: SafeArea(
           child: Column(
             children: [
               // Header with back button
-              _buildHeader(),
-              
+              _buildHeader(t),
+
               // Settings list
               Expanded(
                 child: ListView(
@@ -46,8 +37,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   children: [
                     // Lightning Address
                     _buildSettingsItem(
+                      t: t,
                       icon: Icons.alternate_email,
-                      iconColor: const Color(0xFF4C63F7),
+                      iconColor: t.accentSolid,
                       title: AppLocalizations.of(context)!.lightning_address_title,
                       onTap: () {
                         Navigator.push(
@@ -58,15 +50,16 @@ class _SettingsScreenState extends State<SettingsScreen> {
                         );
                       },
                     ),
-                    
+
                     const SizedBox(height: 12),
-                    
+
                     // Currency Settings
                     Consumer<CurrencySettingsProvider>(
                       builder: (context, currencyProvider, child) {
                         return _buildSettingsItem(
+                          t: t,
                           icon: Icons.attach_money,
-                          iconColor: const Color(0xFF4C63F7),
+                          iconColor: t.accentSolid,
                           title: AppLocalizations.of(context)!.currency_settings_title,
                           subtitle: '${currencyProvider.availableCurrencies.length} currencies',
                           onTap: () {
@@ -80,15 +73,16 @@ class _SettingsScreenState extends State<SettingsScreen> {
                         );
                       },
                     ),
-                    
+
                     const SizedBox(height: 12),
-                    
+
                     // Language Settings
                     Consumer<LanguageProvider>(
                       builder: (context, languageProvider, child) {
                         return _buildSettingsItem(
+                          t: t,
                           icon: Icons.language,
-                          iconColor: const Color(0xFF4C63F7),
+                          iconColor: t.accentSolid,
                           title: AppLocalizations.of(context)!.language_selector_title,
                           subtitle: languageProvider.getCurrentLanguageName(),
                           onTap: () => Navigator.push(
@@ -110,7 +104,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     );
   }
 
-  Widget _buildHeader() {
+  Widget _buildHeader(AppTokens t) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
       child: Row(
@@ -120,12 +114,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
             child: Container(
               padding: const EdgeInsets.all(8),
               decoration: BoxDecoration(
-                color: Colors.white.withValues(alpha: 0.1),
+                color: t.outline,
                 borderRadius: BorderRadius.circular(12),
               ),
-              child: const Icon(
+              child: Icon(
                 Icons.arrow_back,
-                color: Colors.white,
+                color: t.textPrimary,
                 size: 24,
               ),
             ),
@@ -135,10 +129,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
             child: Text(
               AppLocalizations.of(context)!.settings_screen_title,
               style: TextStyle(
-                fontFamily: 'Manrope',
                 fontSize: 20,
                 fontWeight: FontWeight.w600,
-                color: Colors.white,
+                color: t.textPrimary,
               ),
             ),
           ),
@@ -148,6 +141,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }
 
   Widget _buildSettingsItem({
+    required AppTokens t,
     required IconData icon,
     required Color iconColor,
     required String title,
@@ -159,10 +153,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
       child: Container(
         padding: const EdgeInsets.all(16),
         decoration: BoxDecoration(
-          color: Colors.white.withValues(alpha: 0.08),
+          color: t.surface,
           borderRadius: BorderRadius.circular(16),
           border: Border.all(
-            color: Colors.white.withValues(alpha: 0.1),
+            color: t.outline,
             width: 1,
           ),
         ),
@@ -187,11 +181,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 children: [
                   Text(
                     title,
-                    style: const TextStyle(
-                      fontFamily: 'Manrope',
+                    style: TextStyle(
                       fontSize: 16,
                       fontWeight: FontWeight.w600,
-                      color: Colors.white,
+                      color: t.textPrimary,
                     ),
                   ),
                   if (subtitle != null) ...[
@@ -199,10 +192,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     Text(
                       subtitle,
                       style: TextStyle(
-                        fontFamily: 'Manrope',
                         fontSize: 14,
                         fontWeight: FontWeight.w400,
-                        color: Colors.white.withValues(alpha: 0.6),
+                        color: t.textSecondary,
                       ),
                     ),
                   ],
@@ -212,7 +204,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             Icon(
               Icons.arrow_forward_ios,
               size: 16,
-              color: Colors.white.withValues(alpha: 0.5),
+              color: t.textSecondary,
             ),
           ],
         ),

--- a/lib/screens/18language_selection_screen.dart
+++ b/lib/screens/18language_selection_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'dart:async';
 import '../providers/language_provider.dart';
 import '../l10n/generated/app_localizations.dart';
+import '../theme/app_tokens.dart';
 import '../widgets/spark_effect.dart';
 
 class LanguageSelectionScreen extends StatefulWidget {
@@ -87,6 +88,7 @@ class _LanguageSelectionScreenState extends State<LanguageSelectionScreen>
 
   @override
   Widget build(BuildContext context) {
+    final t = context.tokens;
     final languageProvider = Provider.of<LanguageProvider>(context);
     final l10n = AppLocalizations.of(context)!;
     final availableLanguages = languageProvider.getAvailableLanguages();
@@ -96,18 +98,7 @@ class _LanguageSelectionScreenState extends State<LanguageSelectionScreen>
       body: Container(
         width: double.infinity,
         height: double.infinity,
-        decoration: const BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-            colors: [
-              Color(0xFF0F1419),
-              Color(0xFF1A1D47),
-              Color(0xFF2D3FE7),
-            ],
-            stops: [0.0, 0.5, 1.0],
-          ),
-        ),
+        decoration: BoxDecoration(gradient: t.backgroundGradient),
         child: Stack(
           children: [
             // Main content
@@ -137,10 +128,10 @@ class _LanguageSelectionScreenState extends State<LanguageSelectionScreen>
                                   width: 48,
                                   height: 48,
                                   decoration: BoxDecoration(
-                                    color: Colors.white.withValues(alpha: 0.08),
+                                    color: t.surface,
                                     borderRadius: BorderRadius.circular(12),
                                     border: Border.all(
-                                      color: Colors.white.withValues(alpha: 0.1),
+                                      color: t.outline,
                                       width: 1,
                                     ),
                                     boxShadow: [
@@ -152,7 +143,7 @@ class _LanguageSelectionScreenState extends State<LanguageSelectionScreen>
                                     ],
                                   ),
                                   child: IconButton(
-                                    icon: const Icon(Icons.arrow_back, color: Colors.white, size: 24),
+                                    icon: Icon(Icons.arrow_back, color: t.textPrimary, size: 24),
                                     onPressed: () => Navigator.pop(context),
                                   ),
                                 ),
@@ -160,11 +151,10 @@ class _LanguageSelectionScreenState extends State<LanguageSelectionScreen>
                                 // Title - made smaller
                                 Text(
                                   l10n.language_selector_title,
-                                  style: const TextStyle(
-                                    color: Colors.white,
+                                  style: TextStyle(
+                                    color: t.textPrimary,
                                     fontSize: 50,
                                     fontWeight: FontWeight.bold,
-                                    fontFamily: 'Manrope',
                                   ),
                                 ),
                                 const Spacer(),
@@ -196,10 +186,9 @@ class _LanguageSelectionScreenState extends State<LanguageSelectionScreen>
                                   Text(
                                     l10n.language_selector_description,
                                     style: TextStyle(
-                                      color: Colors.white.withValues(alpha: 0.9),
+                                      color: t.textPrimary.withValues(alpha: 0.9),
                                       fontSize: 18,
                                       fontWeight: FontWeight.w500,
-                                      fontFamily: 'Manrope',
                                     ),
                                   ),
                                   const SizedBox(height: 32),
@@ -226,12 +215,12 @@ class _LanguageSelectionScreenState extends State<LanguageSelectionScreen>
                                           height: containerHeight,
                                           margin: EdgeInsets.only(bottom: marginBottom),
                                           decoration: BoxDecoration(
-                                            color: Colors.white.withValues(alpha: isCenter ? 0.12 : 0.06),
+                                            color: t.textPrimary.withValues(alpha: isCenter ? 0.12 : 0.06),
                                             borderRadius: BorderRadius.circular(16),
                                             border: Border.all(
-                                              color: isSelected 
-                                                  ? const Color(0xFF2D3FE7)
-                                                  : Colors.white.withValues(alpha: 0.1),
+                                              color: isSelected
+                                                  ? t.accentSolid
+                                                  : t.outline,
                                               width: isSelected ? 2 : 1,
                                             ),
                                             boxShadow: [
@@ -257,10 +246,10 @@ class _LanguageSelectionScreenState extends State<LanguageSelectionScreen>
                                                     width: flagSize,
                                                     height: flagSize,
                                                     decoration: BoxDecoration(
-                                                      color: Colors.white.withValues(alpha: 0.08),
+                                                      color: t.surface,
                                                       borderRadius: BorderRadius.circular(8),
                                                       border: Border.all(
-                                                        color: Colors.white.withValues(alpha: 0.1),
+                                                        color: t.outline,
                                                         width: 1,
                                                       ),
                                                     ),
@@ -272,7 +261,7 @@ class _LanguageSelectionScreenState extends State<LanguageSelectionScreen>
                                                     ),
                                                   ),
                                                   const SizedBox(width: 20),
-                                                  
+
                                                   // Language info - in same line
                                                   Expanded(
                                                     child: RichText(
@@ -281,40 +270,38 @@ class _LanguageSelectionScreenState extends State<LanguageSelectionScreen>
                                                           TextSpan(
                                                             text: language['name']!,
                                                             style: TextStyle(
-                                                              color: isSelected 
-                                                                  ? const Color(0xFF4C63F7)
-                                                                  : Colors.white.withValues(alpha: isCenter ? 1.0 : 0.8),
+                                                              color: isSelected
+                                                                  ? t.accentSolid
+                                                                  : t.textPrimary.withValues(alpha: isCenter ? 1.0 : 0.8),
                                                               fontSize: fontSize,
                                                               fontWeight: isCenter ? FontWeight.bold : FontWeight.w600,
-                                                              fontFamily: 'Manrope',
                                                             ),
                                                           ),
                                                           TextSpan(
                                                             text: ' ${language['code']!.toUpperCase()}',
                                                             style: TextStyle(
-                                                              color: Colors.white.withValues(alpha: 0.6),
+                                                              color: t.textSecondary,
                                                               fontSize: fontSize * 0.75,
                                                               fontWeight: FontWeight.w500,
-                                                              fontFamily: 'Manrope',
                                                             ),
                                                           ),
                                                         ],
                                                       ),
                                                     ),
                                                   ),
-                                                  
+
                                                   // Selected indicator
                                                   if (isSelected)
                                                     Container(
                                                       width: isCenter ? 36 : 28,
                                                       height: isCenter ? 36 : 28,
-                                                      decoration: const BoxDecoration(
-                                                        color: Color(0xFF2D3FE7),
+                                                      decoration: BoxDecoration(
+                                                        color: t.accentSolid,
                                                         shape: BoxShape.circle,
                                                       ),
                                                       child: Icon(
                                                         Icons.check,
-                                                        color: Colors.white,
+                                                        color: t.accentForeground,
                                                         size: isCenter ? 22 : 16,
                                                       ),
                                                     )
@@ -326,7 +313,7 @@ class _LanguageSelectionScreenState extends State<LanguageSelectionScreen>
                                                         color: Colors.transparent,
                                                         shape: BoxShape.circle,
                                                         border: Border.all(
-                                                          color: Colors.white.withValues(alpha: 0.3),
+                                                          color: t.textPrimary.withValues(alpha: 0.3),
                                                           width: 2,
                                                         ),
                                                       ),

--- a/lib/screens/2start_screen.dart
+++ b/lib/screens/2start_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import '../providers/server_provider.dart';
 import '../providers/language_provider.dart';
 import '../l10n/generated/app_localizations.dart';
+import '../theme/app_tokens.dart';
 import '3server_settings_screen.dart';
 import '4login_screen.dart';
 import '5signup_screen.dart';
@@ -57,22 +58,12 @@ class _StartScreenState extends State<StartScreen>
   @override
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
+    final t = context.tokens;
     return Scaffold(
       body: Container(
         width: double.infinity,
         height: double.infinity,
-        decoration: const BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-            colors: [
-              Color(0xFF0F1419),
-              Color(0xFF1A1D47),
-              Color(0xFF2D3FE7),
-            ],
-            stops: [0.0, 0.5, 1.0],
-          ),
-        ),
+        decoration: BoxDecoration(gradient: t.backgroundGradient),
         child: SafeArea(
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 24),
@@ -82,13 +73,13 @@ class _StartScreenState extends State<StartScreen>
                 const SizedBox(height: 8),
                 _buildTopBar(),
                 const SizedBox(height: 28),
-                _buildHero(l),
+                _buildHero(l, t),
                 const SizedBox(height: 14),
-                _buildTagline(l),
+                _buildTagline(l, t),
                 const Spacer(),
-                _buildCtas(l),
+                _buildCtas(l, t),
                 const SizedBox(height: 10),
-                _buildServerChangeChip(l),
+                _buildServerChangeChip(l, t),
                 const SizedBox(height: 12),
               ],
             ),
@@ -111,6 +102,7 @@ class _StartScreenState extends State<StartScreen>
   }
 
   Widget _buildLanguageSelector() {
+    final t = context.tokens;
     return Consumer<LanguageProvider>(
       builder: (context, lang, _) {
         return InkWell(
@@ -134,7 +126,7 @@ class _StartScreenState extends State<StartScreen>
                 Icon(
                   Icons.keyboard_arrow_down,
                   size: 14,
-                  color: Colors.white.withValues(alpha: 0.6),
+                  color: t.textSecondary,
                 ),
               ],
             ),
@@ -144,7 +136,7 @@ class _StartScreenState extends State<StartScreen>
     );
   }
 
-  Widget _buildHero(AppLocalizations l) {
+  Widget _buildHero(AppLocalizations l, AppTokens t) {
     return FadeTransition(
       opacity: _heroAnim,
       child: SlideTransition(
@@ -157,24 +149,22 @@ class _StartScreenState extends State<StartScreen>
           children: [
             Text(
               l.welcome_hero_prefix,
-              style: const TextStyle(
-                fontFamily: 'Manrope',
+              style: TextStyle(
                 fontSize: 34,
                 fontWeight: FontWeight.w600,
                 height: 1.1,
                 letterSpacing: -0.8,
-                color: Colors.white,
+                color: t.textPrimary,
               ),
             ),
-            const Text(
+            Text(
               'LaChispa',
               style: TextStyle(
-                fontFamily: 'Manrope',
                 fontSize: 34,
                 fontWeight: FontWeight.w800,
                 height: 1.1,
                 letterSpacing: -0.8,
-                color: Colors.white,
+                color: t.textPrimary,
               ),
             ),
           ],
@@ -183,31 +173,30 @@ class _StartScreenState extends State<StartScreen>
     );
   }
 
-  Widget _buildTagline(AppLocalizations l) {
+  Widget _buildTagline(AppLocalizations l, AppTokens t) {
     return FadeTransition(
       opacity: _bodyAnim,
       child: Text(
         l.welcome_hero_tagline,
         style: TextStyle(
-          fontFamily: 'Manrope',
           fontSize: 14,
           fontWeight: FontWeight.w400,
           height: 1.5,
-          color: Colors.white.withValues(alpha: 0.55),
+          color: t.textSecondary,
         ),
       ),
     );
   }
 
-  Widget _buildServerChangeChip(AppLocalizations l) {
+  Widget _buildServerChangeChip(AppLocalizations l, AppTokens t) {
     return FadeTransition(
       opacity: _ctaAnim,
       child: Consumer<ServerProvider>(
         builder: (context, server, _) {
           final dotColor = switch (server.serverHealth) {
-            ServerHealth.healthy => const Color(0xFF4ADE80),
-            ServerHealth.unhealthy => const Color(0xFFEF4444),
-            ServerHealth.checking => Colors.white.withValues(alpha: 0.25),
+            ServerHealth.healthy => t.statusHealthy,
+            ServerHealth.unhealthy => t.statusUnhealthy,
+            ServerHealth.checking => t.statusChecking,
           };
           return SizedBox(
             width: double.infinity,
@@ -225,11 +214,8 @@ class _StartScreenState extends State<StartScreen>
                 });
               },
               style: OutlinedButton.styleFrom(
-                backgroundColor: Colors.white.withValues(alpha: 0.05),
-                side: BorderSide(
-                  color: Colors.white.withValues(alpha: 0.1),
-                  width: 1,
-                ),
+                backgroundColor: t.surface,
+                side: BorderSide(color: t.outline, width: 1),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(12),
                 ),
@@ -249,11 +235,10 @@ class _StartScreenState extends State<StartScreen>
                   Expanded(
                     child: Text(
                       server.serverDisplayName,
-                      style: const TextStyle(
-                        fontFamily: 'Manrope',
+                      style: TextStyle(
                         fontSize: 15,
                         fontWeight: FontWeight.w700,
-                        color: Colors.white,
+                        color: t.textPrimary,
                       ),
                       overflow: TextOverflow.ellipsis,
                     ),
@@ -262,17 +247,16 @@ class _StartScreenState extends State<StartScreen>
                   Text(
                     l.welcome_server_change,
                     style: TextStyle(
-                      fontFamily: 'Manrope',
                       fontSize: 12,
                       fontWeight: FontWeight.w500,
-                      color: Colors.white.withValues(alpha: 0.55),
+                      color: t.textSecondary,
                     ),
                   ),
                   const SizedBox(width: 6),
                   Icon(
                     Icons.settings_outlined,
                     size: 15,
-                    color: Colors.white.withValues(alpha: 0.55),
+                    color: t.textSecondary,
                   ),
                 ],
               ),
@@ -283,12 +267,13 @@ class _StartScreenState extends State<StartScreen>
     );
   }
 
-  Widget _buildCtas(AppLocalizations l) {
+  Widget _buildCtas(AppLocalizations l, AppTokens t) {
     return FadeTransition(
       opacity: _ctaAnim,
       child: Column(
         children: [
           _primaryCta(
+            t: t,
             icon: Icons.login_rounded,
             label: l.login_title,
             onPressed: () => Navigator.push(
@@ -298,6 +283,7 @@ class _StartScreenState extends State<StartScreen>
           ),
           const SizedBox(height: 12),
           _secondaryCta(
+            t: t,
             icon: Icons.person_add_alt_1_rounded,
             label: l.create_account_title,
             onPressed: () => Navigator.push(
@@ -311,6 +297,7 @@ class _StartScreenState extends State<StartScreen>
   }
 
   Widget _primaryCta({
+    required AppTokens t,
     required IconData icon,
     required String label,
     required VoidCallback onPressed,
@@ -319,15 +306,11 @@ class _StartScreenState extends State<StartScreen>
       width: double.infinity,
       height: 54,
       decoration: BoxDecoration(
-        gradient: const LinearGradient(
-          begin: Alignment.centerLeft,
-          end: Alignment.centerRight,
-          colors: [Color(0xFF2D3FE7), Color(0xFF4C63F7)],
-        ),
+        gradient: t.accentGradient,
         borderRadius: BorderRadius.circular(14),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withValues(alpha: 0.35),
+            color: t.ctaShadow,
             blurRadius: 18,
             offset: const Offset(0, 8),
           ),
@@ -341,15 +324,14 @@ class _StartScreenState extends State<StartScreen>
           child: Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Icon(icon, size: 18, color: Colors.white),
+              Icon(icon, size: 18, color: t.accentForeground),
               const SizedBox(width: 10),
               Text(
                 label,
-                style: const TextStyle(
-                  fontFamily: 'Manrope',
+                style: TextStyle(
                   fontSize: 16,
                   fontWeight: FontWeight.w700,
-                  color: Colors.white,
+                  color: t.accentForeground,
                 ),
               ),
             ],
@@ -360,6 +342,7 @@ class _StartScreenState extends State<StartScreen>
   }
 
   Widget _secondaryCta({
+    required AppTokens t,
     required IconData icon,
     required String label,
     required VoidCallback onPressed,
@@ -370,10 +353,7 @@ class _StartScreenState extends State<StartScreen>
       child: OutlinedButton(
         onPressed: onPressed,
         style: OutlinedButton.styleFrom(
-          side: BorderSide(
-            color: Colors.white.withValues(alpha: 0.18),
-            width: 1,
-          ),
+          side: BorderSide(color: t.outlineStrong, width: 1),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(14),
           ),
@@ -381,15 +361,14 @@ class _StartScreenState extends State<StartScreen>
         child: Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(icon, size: 18, color: Colors.white.withValues(alpha: 0.9)),
+            Icon(icon, size: 18, color: t.textPrimary),
             const SizedBox(width: 10),
             Text(
               label,
-              style: const TextStyle(
-                fontFamily: 'Manrope',
+              style: TextStyle(
                 fontSize: 16,
                 fontWeight: FontWeight.w600,
-                color: Colors.white,
+                color: t.textPrimary,
               ),
             ),
           ],

--- a/lib/screens/3server_settings_screen.dart
+++ b/lib/screens/3server_settings_screen.dart
@@ -266,8 +266,9 @@ class _ServerSettingsScreenState extends State<ServerSettingsScreen>
             child: Container(
               padding: const EdgeInsets.all(8),
               decoration: BoxDecoration(
-                color: t.outline,
+                color: t.surface,
                 borderRadius: BorderRadius.circular(12),
+                border: Border.all(color: t.outline, width: 1),
               ),
               child: Icon(
                 Icons.arrow_back,
@@ -425,7 +426,7 @@ class _ServerSettingsScreenState extends State<ServerSettingsScreen>
                 color: t.textSecondary,
               ),
               filled: true,
-              fillColor: t.outline,
+              fillColor: t.inputFill,
               border: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(12),
                 borderSide: BorderSide(

--- a/lib/screens/3server_settings_screen.dart
+++ b/lib/screens/3server_settings_screen.dart
@@ -4,6 +4,7 @@ import 'dart:math' as math;
 import 'dart:async';
 import '../providers/server_provider.dart';
 import '../l10n/generated/app_localizations.dart';
+import '../theme/app_tokens.dart';
 
 class ServerSettingsScreen extends StatefulWidget {
   const ServerSettingsScreen({super.key});
@@ -12,7 +13,7 @@ class ServerSettingsScreen extends StatefulWidget {
   State<ServerSettingsScreen> createState() => _ServerSettingsScreenState();
 }
 
-class _ServerSettingsScreenState extends State<ServerSettingsScreen> 
+class _ServerSettingsScreenState extends State<ServerSettingsScreen>
     with TickerProviderStateMixin {
   late String _selectedServer;
   final _customServerController = TextEditingController();
@@ -48,15 +49,15 @@ class _ServerSettingsScreenState extends State<ServerSettingsScreen>
 
   void _createRandomSpark() {
     if (!mounted) return;
-    
+
     final sparkCount = _random.nextInt(3) + 2; // 2-4 sparks
-    
+
     for (int spark = 0; spark < sparkCount; spark++) {
       final screenSize = MediaQuery.of(context).size;
       final x = _random.nextDouble() * screenSize.width;
       final y = _random.nextDouble() * screenSize.height;
       final particleCount = _random.nextInt(20) + 10; // 10-30 particles
-      
+
       for (int i = 0; i < particleCount; i++) {
         _particles.add(Particle(x, y, _random));
       }
@@ -66,7 +67,7 @@ class _ServerSettingsScreenState extends State<ServerSettingsScreen>
   void _initializeServerSelection() {
     final serverProvider = context.read<ServerProvider>();
     _selectedServer = serverProvider.selectedServer;
-    
+
     // Check if the current server is not in the default list
     bool isInDefaultList = serverProvider.defaultServers.values
         .any((url) => url == _selectedServer);
@@ -100,14 +101,14 @@ class _ServerSettingsScreenState extends State<ServerSettingsScreen>
 
   Future<void> _saveServer() async {
     if (_isSaving) return;
-    
+
     setState(() {
       _isSaving = true;
     });
 
     final serverProvider = context.read<ServerProvider>();
-    
-    String serverToSave = _isCustomSelected 
+
+    String serverToSave = _isCustomSelected
         ? _customServerController.text.trim()
         : _selectedServer;
 
@@ -121,13 +122,13 @@ class _ServerSettingsScreenState extends State<ServerSettingsScreen>
 
     try {
       await serverProvider.selectServer(serverToSave);
-      
+
       if (mounted) {
         _showMessage('${AppLocalizations.of(context)!.server_settings_title}: ${serverProvider.serverDisplayName}', isError: false);
-        
+
         // Wait a moment for the user to see the message
         await Future.delayed(const Duration(seconds: 1));
-        
+
         // Return to the previous screen
         if (mounted) {
           Navigator.pop(context);
@@ -146,11 +147,12 @@ class _ServerSettingsScreenState extends State<ServerSettingsScreen>
 
   void _showMessage(String message, {required bool isError}) {
     if (!mounted) return;
-    
+    final t = context.tokens;
+
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Text(message),
-        backgroundColor: isError ? Colors.red : const Color(0xFF2D3FE7),
+        backgroundColor: isError ? t.statusUnhealthy : t.accentSolid,
         duration: const Duration(seconds: 3),
       ),
     );
@@ -166,22 +168,12 @@ class _ServerSettingsScreenState extends State<ServerSettingsScreen>
 
   @override
   Widget build(BuildContext context) {
+    final t = context.tokens;
     return Scaffold(
       body: Container(
         width: double.infinity,
         height: double.infinity,
-        decoration: const BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-            colors: [
-              Color(0xFF0F1419),
-              Color(0xFF1A1D47),
-              Color(0xFF2D3FE7),
-            ],
-            stops: [0.0, 0.5, 1.0],
-          ),
-        ),
+        decoration: BoxDecoration(gradient: t.backgroundGradient),
         child: Stack(
           children: [
             // Animated spark effects
@@ -194,14 +186,14 @@ class _ServerSettingsScreenState extends State<ServerSettingsScreen>
                 );
               },
             ),
-            
+
             // Main content
             SafeArea(
               child: Column(
                 children: [
                   // Header with back button
-                  _buildHeader(),
-                  
+                  _buildHeader(t),
+
                   // Content
                   Expanded(
                     child: Padding(
@@ -210,48 +202,46 @@ class _ServerSettingsScreenState extends State<ServerSettingsScreen>
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           const SizedBox(height: 32),
-                          
+
                           // Title
                           Text(
                             AppLocalizations.of(context)!.server_settings_title,
                             style: TextStyle(
-                              fontFamily: 'Manrope',
                               fontSize: 24,
                               fontWeight: FontWeight.bold,
-                              color: Colors.white,
+                              color: t.textPrimary,
                             ),
                           ),
                           const SizedBox(height: 8),
-                          
+
                           Text(
                             AppLocalizations.of(context)!.server_url_label,
                             style: TextStyle(
-                              fontFamily: 'Manrope',
                               fontSize: 16,
                               fontWeight: FontWeight.w500,
-                              color: Colors.white.withValues(alpha: 0.8),
+                              color: t.textPrimary.withValues(alpha: 0.8),
                             ),
                           ),
                           const SizedBox(height: 32),
-                          
+
                           // Server list
                           Expanded(
                             child: SingleChildScrollView(
                               child: Column(
                                 children: [
                                   // Predefined servers
-                                  _buildDefaultServers(),
+                                  _buildDefaultServers(t),
                                   const SizedBox(height: 24),
-                                  
+
                                   // Custom server
-                                  _buildCustomServerSection(),
+                                  _buildCustomServerSection(t),
                                 ],
                               ),
                             ),
                           ),
-                          
+
                           // Save button
-                          _buildSaveButton(),
+                          _buildSaveButton(t),
                           const SizedBox(height: 32),
                         ],
                       ),
@@ -266,7 +256,7 @@ class _ServerSettingsScreenState extends State<ServerSettingsScreen>
     );
   }
 
-  Widget _buildHeader() {
+  Widget _buildHeader(AppTokens t) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
       child: Row(
@@ -276,12 +266,12 @@ class _ServerSettingsScreenState extends State<ServerSettingsScreen>
             child: Container(
               padding: const EdgeInsets.all(8),
               decoration: BoxDecoration(
-                color: Colors.white.withValues(alpha: 0.1),
+                color: t.outline,
                 borderRadius: BorderRadius.circular(12),
               ),
-              child: const Icon(
+              child: Icon(
                 Icons.arrow_back,
-                color: Colors.white,
+                color: t.textPrimary,
                 size: 24,
               ),
             ),
@@ -290,10 +280,9 @@ class _ServerSettingsScreenState extends State<ServerSettingsScreen>
           Text(
             AppLocalizations.of(context)!.server_settings_title,
             style: TextStyle(
-              fontFamily: 'Manrope',
               fontSize: 20,
               fontWeight: FontWeight.w600,
-              color: Colors.white,
+              color: t.textPrimary,
             ),
           ),
         ],
@@ -301,13 +290,13 @@ class _ServerSettingsScreenState extends State<ServerSettingsScreen>
     );
   }
 
-  Widget _buildDefaultServers() {
+  Widget _buildDefaultServers(AppTokens t) {
     return Consumer<ServerProvider>(
       builder: (context, serverProvider, child) {
         return Column(
           children: serverProvider.defaultServers.entries.map((entry) {
             final isSelected = _selectedServer == entry.value && !_isCustomSelected;
-            
+
             return Padding(
               padding: const EdgeInsets.only(bottom: 12),
               child: GestureDetector(
@@ -316,14 +305,14 @@ class _ServerSettingsScreenState extends State<ServerSettingsScreen>
                   width: double.infinity,
                   padding: const EdgeInsets.all(16),
                   decoration: BoxDecoration(
-                    color: isSelected 
-                        ? const Color(0xFF2D3FE7).withValues(alpha: 0.3)
-                        : Colors.white.withValues(alpha: 0.08),
+                    color: isSelected
+                        ? t.accentSolid.withValues(alpha: 0.3)
+                        : t.surface,
                     borderRadius: BorderRadius.circular(16),
                     border: Border.all(
-                      color: isSelected 
-                          ? const Color(0xFF2D3FE7)
-                          : Colors.white.withValues(alpha: 0.2),
+                      color: isSelected
+                          ? t.accentSolid
+                          : t.outlineStrong,
                       width: isSelected ? 2 : 1,
                     ),
                   ),
@@ -332,9 +321,9 @@ class _ServerSettingsScreenState extends State<ServerSettingsScreen>
                       Icon(
                         isSelected ? Icons.radio_button_checked : Icons.radio_button_unchecked,
                         size: 24,
-                        color: isSelected 
-                            ? const Color(0xFF4C63F7) 
-                            : Colors.white.withValues(alpha: 0.5),
+                        color: isSelected
+                            ? t.accentSolid
+                            : t.textSecondary,
                       ),
                       const SizedBox(width: 16),
                       Expanded(
@@ -344,24 +333,22 @@ class _ServerSettingsScreenState extends State<ServerSettingsScreen>
                             Text(
                               entry.key,
                               style: TextStyle(
-                                fontFamily: 'Manrope',
                                 fontSize: 16,
                                 fontWeight: FontWeight.w600,
-                                color: isSelected 
-                                    ? Colors.white 
-                                    : Colors.white.withValues(alpha: 0.9),
+                                color: isSelected
+                                    ? t.textPrimary
+                                    : t.textPrimary.withValues(alpha: 0.9),
                               ),
                             ),
                             const SizedBox(height: 4),
                             Text(
                               entry.value,
                               style: TextStyle(
-                                fontFamily: 'Manrope',
                                 fontSize: 14,
                                 fontWeight: FontWeight.w400,
-                                color: isSelected 
-                                    ? Colors.white.withValues(alpha: 0.8)
-                                    : Colors.white.withValues(alpha: 0.6),
+                                color: isSelected
+                                    ? t.textPrimary.withValues(alpha: 0.8)
+                                    : t.textSecondary,
                               ),
                             ),
                           ],
@@ -378,19 +365,19 @@ class _ServerSettingsScreenState extends State<ServerSettingsScreen>
     );
   }
 
-  Widget _buildCustomServerSection() {
+  Widget _buildCustomServerSection(AppTokens t) {
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: _isCustomSelected 
-            ? const Color(0xFF2D3FE7).withValues(alpha: 0.3)
-            : Colors.white.withValues(alpha: 0.08),
+        color: _isCustomSelected
+            ? t.accentSolid.withValues(alpha: 0.3)
+            : t.surface,
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
-          color: _isCustomSelected 
-              ? const Color(0xFF2D3FE7)
-              : Colors.white.withValues(alpha: 0.2),
+          color: _isCustomSelected
+              ? t.accentSolid
+              : t.outlineStrong,
           width: _isCustomSelected ? 2 : 1,
         ),
       ),
@@ -404,20 +391,19 @@ class _ServerSettingsScreenState extends State<ServerSettingsScreen>
                 Icon(
                   _isCustomSelected ? Icons.radio_button_checked : Icons.radio_button_unchecked,
                   size: 24,
-                  color: _isCustomSelected 
-                      ? const Color(0xFF4C63F7) 
-                      : Colors.white.withValues(alpha: 0.5),
+                  color: _isCustomSelected
+                      ? t.accentSolid
+                      : t.textSecondary,
                 ),
                 const SizedBox(width: 16),
                 Text(
                   AppLocalizations.of(context)!.server_url_label,
                   style: TextStyle(
-                    fontFamily: 'Manrope',
                     fontSize: 16,
                     fontWeight: FontWeight.w600,
-                    color: _isCustomSelected 
-                        ? Colors.white 
-                        : Colors.white.withValues(alpha: 0.9),
+                    color: _isCustomSelected
+                        ? t.textPrimary
+                        : t.textPrimary.withValues(alpha: 0.9),
                   ),
                 ),
               ],
@@ -428,36 +414,34 @@ class _ServerSettingsScreenState extends State<ServerSettingsScreen>
             controller: _customServerController,
             onChanged: _onCustomServerChanged,
             onTap: _selectCustomServer,
-            style: const TextStyle(
-              fontFamily: 'Manrope',
+            style: TextStyle(
               fontSize: 16,
-              color: Colors.white,
+              color: t.textPrimary,
             ),
             decoration: InputDecoration(
               hintText: AppLocalizations.of(context)!.server_url_placeholder,
               hintStyle: TextStyle(
-                fontFamily: 'Manrope',
                 fontSize: 16,
-                color: Colors.white.withValues(alpha: 0.5),
+                color: t.textSecondary,
               ),
               filled: true,
-              fillColor: Colors.white.withValues(alpha: 0.1),
+              fillColor: t.outline,
               border: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(12),
                 borderSide: BorderSide(
-                  color: Colors.white.withValues(alpha: 0.2),
+                  color: t.outlineStrong,
                 ),
               ),
               enabledBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(12),
                 borderSide: BorderSide(
-                  color: Colors.white.withValues(alpha: 0.2),
+                  color: t.outlineStrong,
                 ),
               ),
               focusedBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(12),
-                borderSide: const BorderSide(
-                  color: Color(0xFF2D3FE7),
+                borderSide: BorderSide(
+                  color: t.accentSolid,
                   width: 2,
                 ),
               ),
@@ -467,10 +451,9 @@ class _ServerSettingsScreenState extends State<ServerSettingsScreen>
           Text(
             AppLocalizations.of(context)!.server_url_label,
             style: TextStyle(
-              fontFamily: 'Manrope',
               fontSize: 12,
               fontWeight: FontWeight.w400,
-              color: Colors.white.withValues(alpha: 0.6),
+              color: t.textSecondary,
             ),
           ),
         ],
@@ -478,23 +461,16 @@ class _ServerSettingsScreenState extends State<ServerSettingsScreen>
     );
   }
 
-  Widget _buildSaveButton() {
+  Widget _buildSaveButton(AppTokens t) {
     return Container(
       width: double.infinity,
       height: 56,
       decoration: BoxDecoration(
-        gradient: const LinearGradient(
-          begin: Alignment.centerLeft,
-          end: Alignment.centerRight,
-          colors: [
-            Color(0xFF2D3FE7),
-            Color(0xFF4C63F7),
-          ],
-        ),
+        gradient: t.accentGradient,
         borderRadius: BorderRadius.circular(16),
         boxShadow: [
           BoxShadow(
-            color: const Color(0xFF2D3FE7).withValues(alpha: 0.3),
+            color: t.accentSolid.withValues(alpha: 0.3),
             blurRadius: 12,
             offset: const Offset(0, 6),
           ),
@@ -510,21 +486,20 @@ class _ServerSettingsScreenState extends State<ServerSettingsScreen>
           ),
         ),
         child: _isSaving
-            ? const SizedBox(
+            ? SizedBox(
                 width: 20,
                 height: 20,
                 child: CircularProgressIndicator(
-                  color: Colors.white,
+                  color: t.accentForeground,
                   strokeWidth: 2,
                 ),
               )
             : Text(
                 AppLocalizations.of(context)!.connect_button,
                 style: TextStyle(
-                  fontFamily: 'Manrope',
                   fontSize: 16,
                   fontWeight: FontWeight.w600,
-                  color: Colors.white,
+                  color: t.accentForeground,
                 ),
               ),
       ),
@@ -565,7 +540,7 @@ class Particle {
   }
 
   bool get isAlive => life > 0;
-  
+
   // Use smooth curve for fade out
   double get opacity {
     final normalizedLife = life / 100;
@@ -589,7 +564,7 @@ class SparkPainter extends CustomPainter {
 
     // Get devicePixelRatio for high density screens
     final devicePixelRatio = 1.0; // Can be obtained from context if needed
-    
+
     // Draw particles
     for (final particle in particles) {
       final alpha = particle.opacity;
@@ -597,8 +572,8 @@ class SparkPainter extends CustomPainter {
 
       final center = Offset(particle.x, particle.y);
       final scaledSize = particle.size * devicePixelRatio;
-      
-      // More saturated and bright colors
+
+      // Particle effect colors are intrinsic to the visual (kept literal)
       const primaryColor = Color(0xFF5B73FF); // Brighter
       const secondaryColor = Color(0xFF4C63F7); // Original
 
@@ -606,20 +581,20 @@ class SparkPainter extends CustomPainter {
       final glowPaint2 = Paint()
         ..color = primaryColor.withValues(alpha: alpha * 0.4)
         ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 2.0);
-      
+
       canvas.drawCircle(center, scaledSize * 2, glowPaint2);
 
       // 2. Inner glow (smaller)
       final glowPaint1 = Paint()
         ..color = secondaryColor.withValues(alpha: alpha * 0.8)
         ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 2.0);
-      
+
       canvas.drawCircle(center, scaledSize * 1.5, glowPaint1);
 
       // 3. Main particle (solid, brighter)
       final particlePaint = Paint()
         ..color = primaryColor.withValues(alpha: alpha * 0.9);
-      
+
       canvas.drawCircle(center, scaledSize, particlePaint);
     }
   }

--- a/lib/screens/4login_screen.dart
+++ b/lib/screens/4login_screen.dart
@@ -5,6 +5,7 @@ import '../providers/server_provider.dart';
 import '../services/user_credentials_service.dart';
 import '../models/saved_user.dart';
 import '../l10n/generated/app_localizations.dart';
+import '../theme/app_tokens.dart';
 import '5signup_screen.dart';
 import '6home_screen.dart';
 
@@ -203,6 +204,7 @@ class _LoginScreenState extends State<LoginScreen>
     
     print('[LoginScreen] Creating overlay with ${_usernameSuggestions.length} suggestions');
     
+    final t = context.tokens;
     _overlayEntry = OverlayEntry(
       builder: (context) => Positioned(
         left: 24,
@@ -214,7 +216,7 @@ class _LoginScreenState extends State<LoginScreen>
           child: Material(
             elevation: 8,
             borderRadius: BorderRadius.circular(12),
-            color: const Color(0xFF1A1D47),
+            color: t.dialogBackground,
             child: Container(
               constraints: const BoxConstraints(maxHeight: 200),
               child: Column(
@@ -231,30 +233,30 @@ class _LoginScreenState extends State<LoginScreen>
                       decoration: BoxDecoration(
                         border: Border(
                           bottom: BorderSide(
-                            color: Colors.white.withValues(alpha: 0.1),
+                            color: t.outline,
                             width: 1,
                           ),
                         ),
                       ),
                       child: Row(
                         children: [
-                          const Icon(
+                          Icon(
                             Icons.person,
-                            color: Colors.white,
+                            color: t.textPrimary,
                             size: 16,
                           ),
                           const SizedBox(width: 8),
                           Text(
                             username,
-                            style: const TextStyle(
-                              color: Colors.white,
+                            style: TextStyle(
+                              color: t.textPrimary,
                               fontSize: 16,
                             ),
                           ),
                           const Spacer(),
-                          const Icon(
+                          Icon(
                             Icons.login,
-                            color: Colors.white54,
+                            color: t.textTertiary,
                             size: 16,
                           ),
                         ],
@@ -378,7 +380,7 @@ class _LoginScreenState extends State<LoginScreen>
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(
                 content: Text(AppLocalizations.of(context)!.credentials_found_message),
-                backgroundColor: Colors.green,
+                backgroundColor: context.tokens.statusHealthy,
                 duration: const Duration(seconds: 2),
               ),
             );
@@ -423,7 +425,7 @@ class _LoginScreenState extends State<LoginScreen>
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(AppLocalizations.of(context)!.password_will_be_remembered),
-          backgroundColor: Colors.green,
+          backgroundColor: context.tokens.statusHealthy,
           duration: const Duration(seconds: 2),
         ),
       );
@@ -432,43 +434,44 @@ class _LoginScreenState extends State<LoginScreen>
   
   // Show warning about credential deletion
   Future<bool> _showCredentialDeletionWarning() async {
+    final t = context.tokens;
     final result = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
-        backgroundColor: const Color(0xFF1A1D47),
+        backgroundColor: t.dialogBackground,
         title: Row(
           children: [
-            const Icon(Icons.warning, color: Colors.orange),
+            Icon(Icons.warning, color: t.statusWarning),
             const SizedBox(width: 8),
             Text(
               AppLocalizations.of(context)!.delete_credentials_title,
-              style: const TextStyle(color: Colors.white),
+              style: TextStyle(color: t.textPrimary),
             ),
           ],
         ),
         content: Text(
           AppLocalizations.of(context)!.delete_credentials_message,
-          style: const TextStyle(color: Colors.white70),
+          style: TextStyle(color: t.textPrimary.withValues(alpha: 0.7)),
         ),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context, false),
             child: Text(
               AppLocalizations.of(context)!.delete_credentials_cancel,
-              style: const TextStyle(color: Colors.white54),
+              style: TextStyle(color: t.textTertiary),
             ),
           ),
           TextButton(
             onPressed: () => Navigator.pop(context, true),
             child: Text(
               AppLocalizations.of(context)!.delete_credentials_confirm,
-              style: const TextStyle(color: Colors.red),
+              style: TextStyle(color: t.statusUnhealthy),
             ),
           ),
         ],
       ),
     );
-    
+
     return result ?? false;
   }
 
@@ -536,10 +539,10 @@ class _LoginScreenState extends State<LoginScreen>
             if (mounted) {
               ScaffoldMessenger.of(context).showSnackBar(
                 SnackBar(
-                  content: Text(result 
+                  content: Text(result
                     ? AppLocalizations.of(context)!.password_saved_successfully
                     : AppLocalizations.of(context)!.password_save_failed),
-                  backgroundColor: const Color(0xFF2D3FE7),
+                  backgroundColor: context.tokens.accentSolid,
                   duration: const Duration(seconds: 2),
                 ),
               );
@@ -590,24 +593,15 @@ class _LoginScreenState extends State<LoginScreen>
 
   @override
   Widget build(BuildContext context) {
+    final t = context.tokens;
     return Scaffold(
       body: Container(
-        decoration: const BoxDecoration(
-          gradient: LinearGradient(
-            colors: [
-              Color(0xFF0F1419),
-              Color(0xFF1A1D47),
-              Color(0xFF2D3FE7),
-            ],
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-          ),
-        ),
+        decoration: BoxDecoration(gradient: t.backgroundGradient),
         child: SafeArea(
           child: Column(
             children: [
               // Top navigation arrow
-              _buildTopNavigation(),
+              _buildTopNavigation(t),
               // Contenido scrolleable
               Expanded(
                 child: SingleChildScrollView(
@@ -615,13 +609,13 @@ class _LoginScreenState extends State<LoginScreen>
                   child: Column(
                     children: [
                       const SizedBox(height: 8),
-                      _buildHeader(),
+                      _buildHeader(t),
                       const SizedBox(height: 32),
-                      _buildLoginForm(),
+                      _buildLoginForm(t),
                       const SizedBox(height: 16),
-                      _buildHelpInfo(),
+                      _buildHelpInfo(t),
                       const SizedBox(height: 16),
-                      _buildServerInfo(),
+                      _buildServerInfo(t),
                       const SizedBox(height: 16),
                     ],
                   ),
@@ -634,7 +628,7 @@ class _LoginScreenState extends State<LoginScreen>
     );
   }
 
-  Widget _buildHeader() {
+  Widget _buildHeader(AppTokens t) {
     return Column(
       children: [
         AnimatedBuilder(
@@ -644,7 +638,7 @@ class _LoginScreenState extends State<LoginScreen>
               decoration: BoxDecoration(
                 boxShadow: [
                   BoxShadow(
-                    color: const Color(0xFF2D3FE7).withValues(alpha: _glowAnimation.value * 0.3),
+                    color: t.accentSolid.withValues(alpha: _glowAnimation.value * 0.3),
                     blurRadius: 20,
                     spreadRadius: 5,
                   ),
@@ -655,10 +649,10 @@ class _LoginScreenState extends State<LoginScreen>
                 style: TextStyle(
                   fontSize: 32,
                   fontWeight: FontWeight.w700,
-                  color: Colors.white,
+                  color: t.textPrimary,
                   shadows: [
                     Shadow(
-                      color: const Color(0xFF2D3FE7).withValues(alpha: _glowAnimation.value * 0.8),
+                      color: t.accentSolid.withValues(alpha: _glowAnimation.value * 0.8),
                       blurRadius: 10,
                       offset: const Offset(0, 2),
                     ),
@@ -674,20 +668,20 @@ class _LoginScreenState extends State<LoginScreen>
           textAlign: TextAlign.center,
           style: TextStyle(
             fontSize: 16,
-            color: Colors.white.withValues(alpha: 0.7),
+            color: t.textPrimary.withValues(alpha: 0.7),
           ),
         ),
       ],
     );
   }
 
-  Widget _buildLoginForm() {
+  Widget _buildLoginForm(AppTokens t) {
     return Container(
       decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.08),
+        color: t.surface,
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
-          color: Colors.white.withValues(alpha: 0.1),
+          color: t.outline,
         ),
       ),
       padding: const EdgeInsets.all(24),
@@ -696,20 +690,20 @@ class _LoginScreenState extends State<LoginScreen>
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            _buildUsernameField(),
+            _buildUsernameField(t),
             const SizedBox(height: 20),
-            _buildPasswordField(),
+            _buildPasswordField(t),
             const SizedBox(height: 16),
-            _buildRememberPasswordCheckbox(),
+            _buildRememberPasswordCheckbox(t),
             const SizedBox(height: 32),
-            _buildLoginButton(),
+            _buildLoginButton(t),
           ],
         ),
       ),
     );
   }
 
-  Widget _buildUsernameField() {
+  Widget _buildUsernameField(AppTokens t) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -728,33 +722,33 @@ class _LoginScreenState extends State<LoginScreen>
           decoration: InputDecoration(
             labelText: AppLocalizations.of(context)!.username_label,
             hintText: AppLocalizations.of(context)!.username_placeholder,
-            labelStyle: TextStyle(color: Colors.white.withValues(alpha: 0.7)),
-            hintStyle: TextStyle(color: Colors.white.withValues(alpha: 0.5)),
-            prefixIcon: Icon(Icons.person, color: Colors.white.withValues(alpha: 0.7)),
-            suffixIcon: _usernameSuggestions.isNotEmpty 
-                ? Icon(Icons.arrow_drop_down, color: Colors.white.withValues(alpha: 0.7))
+            labelStyle: TextStyle(color: t.textPrimary.withValues(alpha: 0.7)),
+            hintStyle: TextStyle(color: t.textSecondary),
+            prefixIcon: Icon(Icons.person, color: t.textPrimary.withValues(alpha: 0.7)),
+            suffixIcon: _usernameSuggestions.isNotEmpty
+                ? Icon(Icons.arrow_drop_down, color: t.textPrimary.withValues(alpha: 0.7))
                 : null,
             filled: true,
-            fillColor: Colors.white.withValues(alpha: 0.05),
+            fillColor: t.inputFill,
             border: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
-              borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.1)),
+              borderSide: BorderSide(color: t.outline),
             ),
             enabledBorder: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
-              borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.1)),
+              borderSide: BorderSide(color: t.outline),
             ),
             focusedBorder: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
-              borderSide: const BorderSide(color: Color(0xFF2D3FE7)),
+              borderSide: BorderSide(color: t.accentSolid),
             ),
           ),
-          style: const TextStyle(color: Colors.white),
+          style: TextStyle(color: t.textPrimary),
           textInputAction: TextInputAction.next,
           onTap: () async {
             print('[LoginScreen] Username field tapped, reloading users...');
             await _loadInitialUsers();
-            
+
             if (_usernameSuggestions.isNotEmpty) {
               print('[LoginScreen] Activating dropdown with ${_usernameSuggestions.length} suggestions');
               setState(() {
@@ -773,10 +767,10 @@ class _LoginScreenState extends State<LoginScreen>
           Container(
             margin: const EdgeInsets.only(top: 4),
             decoration: BoxDecoration(
-              color: const Color(0xFF1A1D47),
+              color: t.dialogBackground,
               borderRadius: BorderRadius.circular(12),
               border: Border.all(
-                color: Colors.white.withValues(alpha: 0.1),
+                color: t.outline,
               ),
             ),
             child: Column(
@@ -787,23 +781,23 @@ class _LoginScreenState extends State<LoginScreen>
                   decoration: BoxDecoration(
                     border: Border(
                       bottom: BorderSide(
-                        color: Colors.white.withValues(alpha: 0.1),
+                        color: t.outline,
                         width: 1,
                       ),
                     ),
                   ),
                   child: Row(
                     children: [
-                      const Icon(
+                      Icon(
                         Icons.account_circle,
-                        color: Colors.white,
+                        color: t.textPrimary,
                         size: 16,
                       ),
                       const SizedBox(width: 8),
                       Text(
                         AppLocalizations.of(context)!.saved_users_header,
                         style: TextStyle(
-                          color: Colors.white.withValues(alpha: 0.8),
+                          color: t.textPrimary.withValues(alpha: 0.8),
                           fontSize: 14,
                           fontWeight: FontWeight.w500,
                         ),
@@ -818,7 +812,7 @@ class _LoginScreenState extends State<LoginScreen>
                         },
                         icon: Icon(
                           Icons.close,
-                          color: Colors.white.withValues(alpha: 0.6),
+                          color: t.textSecondary,
                           size: 16,
                         ),
                         padding: EdgeInsets.zero,
@@ -848,12 +842,12 @@ class _LoginScreenState extends State<LoginScreen>
                             Container(
                               padding: const EdgeInsets.all(6),
                               decoration: BoxDecoration(
-                                color: const Color(0xFF2D3FE7),
+                                color: t.accentSolid,
                                 borderRadius: BorderRadius.circular(8),
                               ),
-                              child: const Icon(
+                              child: Icon(
                                 Icons.person,
-                                color: Colors.white,
+                                color: t.accentForeground,
                                 size: 14,
                               ),
                             ),
@@ -864,8 +858,8 @@ class _LoginScreenState extends State<LoginScreen>
                                 children: [
                                   Text(
                                     username,
-                                    style: const TextStyle(
-                                      color: Colors.white,
+                                    style: TextStyle(
+                                      color: t.textPrimary,
                                       fontSize: 16,
                                       fontWeight: FontWeight.w500,
                                     ),
@@ -873,16 +867,16 @@ class _LoginScreenState extends State<LoginScreen>
                                   Text(
                                     AppLocalizations.of(context)!.tap_to_autocomplete_hint,
                                     style: TextStyle(
-                                      color: Colors.white.withValues(alpha: 0.6),
+                                      color: t.textSecondary,
                                       fontSize: 12,
                                     ),
                                   ),
                                 ],
                               ),
                             ),
-                            const Icon(
+                            Icon(
                               Icons.arrow_forward_ios,
-                              color: Colors.white54,
+                              color: t.textTertiary,
                               size: 14,
                             ),
                           ],
@@ -898,7 +892,7 @@ class _LoginScreenState extends State<LoginScreen>
     );
   }
 
-  Widget _buildPasswordField() {
+  Widget _buildPasswordField(AppTokens t) {
     return TextFormField(
       controller: _passwordController,
       validator: (value) {
@@ -914,13 +908,13 @@ class _LoginScreenState extends State<LoginScreen>
       decoration: InputDecoration(
         labelText: AppLocalizations.of(context)!.password_label,
         hintText: AppLocalizations.of(context)!.password_placeholder,
-        labelStyle: TextStyle(color: Colors.white.withValues(alpha: 0.7)),
-        hintStyle: TextStyle(color: Colors.white.withValues(alpha: 0.5)),
-        prefixIcon: Icon(Icons.lock, color: Colors.white.withValues(alpha: 0.7)),
+        labelStyle: TextStyle(color: t.textPrimary.withValues(alpha: 0.7)),
+        hintStyle: TextStyle(color: t.textSecondary),
+        prefixIcon: Icon(Icons.lock, color: t.textPrimary.withValues(alpha: 0.7)),
         suffixIcon: IconButton(
           icon: Icon(
             _isPasswordVisible ? Icons.visibility : Icons.visibility_off,
-            color: Colors.white.withValues(alpha: 0.7),
+            color: t.textPrimary.withValues(alpha: 0.7),
           ),
           onPressed: () {
             setState(() {
@@ -929,27 +923,27 @@ class _LoginScreenState extends State<LoginScreen>
           },
         ),
         filled: true,
-        fillColor: Colors.white.withValues(alpha: 0.05),
+        fillColor: t.inputFill,
         border: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
-          borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.1)),
+          borderSide: BorderSide(color: t.outline),
         ),
         enabledBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
-          borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.1)),
+          borderSide: BorderSide(color: t.outline),
         ),
         focusedBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
-          borderSide: const BorderSide(color: Color(0xFF2D3FE7)),
+          borderSide: BorderSide(color: t.accentSolid),
         ),
       ),
-      style: const TextStyle(color: Colors.white),
+      style: TextStyle(color: t.textPrimary),
       textInputAction: TextInputAction.done,
       onFieldSubmitted: (_) => _handleLogin(),
     );
   }
 
-  Widget _buildRememberPasswordCheckbox() {
+  Widget _buildRememberPasswordCheckbox(AppTokens t) {
     return Row(
       children: [
         Checkbox(
@@ -957,10 +951,10 @@ class _LoginScreenState extends State<LoginScreen>
           onChanged: (value) {
             _handleRememberPasswordChange(value ?? false);
           },
-          activeColor: const Color(0xFF2D3FE7),
-          checkColor: Colors.white,
+          activeColor: t.accentSolid,
+          checkColor: t.accentForeground,
           side: BorderSide(
-            color: Colors.white.withValues(alpha: 0.3),
+            color: t.textPrimary.withValues(alpha: 0.3),
             width: 2,
           ),
         ),
@@ -972,7 +966,7 @@ class _LoginScreenState extends State<LoginScreen>
           child: Text(
             AppLocalizations.of(context)!.remember_password_label,
             style: TextStyle(
-              color: Colors.white.withValues(alpha: 0.8),
+              color: t.textPrimary.withValues(alpha: 0.8),
               fontSize: 16,
             ),
           ),
@@ -981,17 +975,13 @@ class _LoginScreenState extends State<LoginScreen>
     );
   }
 
-  Widget _buildLoginButton() {
+  Widget _buildLoginButton(AppTokens t) {
     return Consumer<AuthProvider>(
       builder: (context, authProvider, child) {
         return Container(
           height: 56,
           decoration: BoxDecoration(
-            gradient: const LinearGradient(
-              colors: [Color(0xFF2D3FE7), Color(0xFF4C63F7)],
-              begin: Alignment.centerLeft,
-              end: Alignment.centerRight,
-            ),
+            gradient: t.accentGradient,
             borderRadius: BorderRadius.circular(16),
           ),
           child: ElevatedButton(
@@ -1007,31 +997,31 @@ class _LoginScreenState extends State<LoginScreen>
                 ? Row(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
-                      const SizedBox(
+                      SizedBox(
                         height: 20,
                         width: 20,
                         child: CircularProgressIndicator(
                           strokeWidth: 2,
-                          valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                          valueColor: AlwaysStoppedAnimation<Color>(t.accentForeground),
                         ),
                       ),
                       const SizedBox(width: 12),
                       Text(
                         AppLocalizations.of(context)!.logging_in_button,
-                        style: const TextStyle(
+                        style: TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.w600,
-                          color: Colors.white,
+                          color: t.accentForeground,
                         ),
                       ),
                     ],
                   )
                 : Text(
                     AppLocalizations.of(context)!.login_button,
-                    style: const TextStyle(
+                    style: TextStyle(
                       fontSize: 16,
                       fontWeight: FontWeight.w600,
-                      color: Colors.white,
+                      color: t.accentForeground,
                     ),
                   ),
           ),
@@ -1041,7 +1031,7 @@ class _LoginScreenState extends State<LoginScreen>
   }
 
 
-  Widget _buildServerInfo() {
+  Widget _buildServerInfo(AppTokens t) {
     return Consumer<ServerProvider>(
       builder: (context, serverProvider, child) {
         // Update server URL if it has changed
@@ -1054,13 +1044,13 @@ class _LoginScreenState extends State<LoginScreen>
             _loadInitialUsers();
           });
         }
-        
+
         return Container(
           padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
           decoration: BoxDecoration(
-            color: Colors.white.withValues(alpha: 0.05),
+            color: t.inputFill,
             borderRadius: BorderRadius.circular(12),
-            border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
+            border: Border.all(color: t.outline),
           ),
           child: Row(
             mainAxisAlignment: MainAxisAlignment.center,
@@ -1069,22 +1059,22 @@ class _LoginScreenState extends State<LoginScreen>
               Icon(
                 Icons.dns,
                 size: 16,
-                color: Colors.white.withValues(alpha: 0.7),
+                color: t.textPrimary.withValues(alpha: 0.7),
               ),
               const SizedBox(width: 8),
               Text(
                 AppLocalizations.of(context)!.server_prefix,
                 style: TextStyle(
                   fontSize: 14,
-                  color: Colors.white.withValues(alpha: 0.7),
+                  color: t.textPrimary.withValues(alpha: 0.7),
                 ),
               ),
               Flexible(
                 child: Text(
                   serverProvider.serverDisplayName,
-                  style: const TextStyle(
+                  style: TextStyle(
                     fontSize: 14,
-                    color: Colors.white,
+                    color: t.textPrimary,
                     fontWeight: FontWeight.w500,
                   ),
                   overflow: TextOverflow.ellipsis,
@@ -1098,13 +1088,13 @@ class _LoginScreenState extends State<LoginScreen>
     );
   }
 
-  Widget _buildHelpInfo() {
+  Widget _buildHelpInfo(AppTokens t) {
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.05),
+        color: t.inputFill,
         borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
+        border: Border.all(color: t.outline),
       ),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
@@ -1113,7 +1103,7 @@ class _LoginScreenState extends State<LoginScreen>
             AppLocalizations.of(context)!.no_account_question,
             style: TextStyle(
               fontSize: 16,
-              color: Colors.white.withValues(alpha: 0.7),
+              color: t.textPrimary.withValues(alpha: 0.7),
             ),
           ),
           GestureDetector(
@@ -1125,12 +1115,12 @@ class _LoginScreenState extends State<LoginScreen>
             },
             child: Text(
               AppLocalizations.of(context)!.register_link,
-              style: const TextStyle(
+              style: TextStyle(
                 fontSize: 16,
-                color: Colors.white,
+                color: t.textPrimary,
                 fontWeight: FontWeight.w600,
                 decoration: TextDecoration.underline,
-                decorationColor: Colors.white,
+                decorationColor: t.textPrimary,
               ),
             ),
           ),
@@ -1139,24 +1129,24 @@ class _LoginScreenState extends State<LoginScreen>
     );
   }
 
-  Widget _buildTopNavigation() {
+  Widget _buildTopNavigation(AppTokens t) {
     return Padding(
       padding: const EdgeInsets.only(top: 16, left: 24, right: 24),
       child: Row(
         children: [
           Container(
             decoration: BoxDecoration(
-              color: Colors.white.withValues(alpha: 0.08),
+              color: t.surface,
               borderRadius: BorderRadius.circular(12),
               border: Border.all(
-                color: Colors.white.withValues(alpha: 0.1),
+                color: t.outline,
               ),
             ),
             child: IconButton(
               onPressed: () => Navigator.pop(context),
-              icon: const Icon(
+              icon: Icon(
                 Icons.arrow_back_ios,
-                color: Colors.white,
+                color: t.textPrimary,
                 size: 20,
               ),
               padding: const EdgeInsets.all(12),
@@ -1174,24 +1164,25 @@ class _LoginScreenState extends State<LoginScreen>
 
 // Show authentication errors
 void _showErrorDialog(BuildContext context, String error) {
+  final t = context.tokens;
   showDialog(
     context: context,
     builder: (context) => AlertDialog(
-      backgroundColor: const Color(0xFF1A1D47),
+      backgroundColor: t.dialogBackground,
       title: Text(
         AppLocalizations.of(context)!.login_error_prefix.replaceAll(': ', ''),
-        style: const TextStyle(color: Colors.white),
+        style: TextStyle(color: t.textPrimary),
       ),
       content: Text(
         error,
-        style: TextStyle(color: Colors.white.withValues(alpha: 0.8)),
+        style: TextStyle(color: t.textPrimary.withValues(alpha: 0.8)),
       ),
       actions: [
         TextButton(
           onPressed: () => Navigator.pop(context),
           child: Text(
             AppLocalizations.of(context)!.close_dialog,
-            style: const TextStyle(color: Color(0xFF2D3FE7)),
+            style: TextStyle(color: t.accentSolid),
           ),
         ),
       ],

--- a/lib/screens/5signup_screen.dart
+++ b/lib/screens/5signup_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import '../providers/auth_provider.dart';
 import '../providers/server_provider.dart';
 import '../l10n/generated/app_localizations.dart';
+import '../theme/app_tokens.dart';
 import '6home_screen.dart';
 
 class SignupScreen extends StatefulWidget {
@@ -81,13 +82,13 @@ class _SignupScreenState extends State<SignupScreen>
       if (success && mounted) {
         // Show success message
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Cuenta creada exitosamente! Bienvenido.'),
-            backgroundColor: Color(0xFF2D3FE7),
-            duration: Duration(seconds: 1),
+          SnackBar(
+            content: const Text('Cuenta creada exitosamente! Bienvenido.'),
+            backgroundColor: context.tokens.accentSolid,
+            duration: const Duration(seconds: 1),
           ),
         );
-        
+
         // Navigate to HomeScreen and clear navigation stack
         Navigator.pushAndRemoveUntil(
           context,
@@ -109,24 +110,25 @@ class _SignupScreenState extends State<SignupScreen>
   }
 
   void _showErrorDialog(String message) {
+    final t = context.tokens;
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
-        backgroundColor: const Color(0xFF1A1D47),
-        title: const Text(
+        backgroundColor: t.dialogBackground,
+        title: Text(
           'Error',
-          style: TextStyle(color: Colors.white),
+          style: TextStyle(color: t.textPrimary),
         ),
         content: Text(
           message,
-          style: TextStyle(color: Colors.white.withValues(alpha: 0.8)),
+          style: TextStyle(color: t.textPrimary.withValues(alpha: 0.8)),
         ),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context),
-            child: const Text(
+            child: Text(
               'Cerrar',
-              style: TextStyle(color: Color(0xFF2D3FE7)),
+              style: TextStyle(color: t.accentSolid),
             ),
           ),
         ],
@@ -136,24 +138,15 @@ class _SignupScreenState extends State<SignupScreen>
 
   @override
   Widget build(BuildContext context) {
+    final t = context.tokens;
     return Scaffold(
       body: Container(
-        decoration: const BoxDecoration(
-          gradient: LinearGradient(
-            colors: [
-              Color(0xFF0F1419),
-              Color(0xFF1A1D47),
-              Color(0xFF2D3FE7),
-            ],
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-          ),
-        ),
+        decoration: BoxDecoration(gradient: t.backgroundGradient),
         child: SafeArea(
           child: Column(
             children: [
               // Top navigation arrow
-              _buildTopNavigation(),
+              _buildTopNavigation(t),
               // Scrollable content
               Expanded(
                 child: SingleChildScrollView(
@@ -161,13 +154,13 @@ class _SignupScreenState extends State<SignupScreen>
                   child: Column(
                     children: [
                       const SizedBox(height: 20),
-                      _buildHeader(),
+                      _buildHeader(t),
                       const SizedBox(height: 40),
-                      _buildSignupForm(),
+                      _buildSignupForm(t),
                       const SizedBox(height: 20),
-                      _buildTermsCheckbox(),
+                      _buildTermsCheckbox(t),
                       const SizedBox(height: 20),
-                      _buildServerInfo(),
+                      _buildServerInfo(t),
                       const SizedBox(height: 40),
                     ],
                   ),
@@ -180,7 +173,7 @@ class _SignupScreenState extends State<SignupScreen>
     );
   }
 
-  Widget _buildHeader() {
+  Widget _buildHeader(AppTokens t) {
     return Column(
       children: [
         AnimatedBuilder(
@@ -190,7 +183,7 @@ class _SignupScreenState extends State<SignupScreen>
               decoration: BoxDecoration(
                 boxShadow: [
                   BoxShadow(
-                    color: const Color(0xFF2D3FE7).withValues(alpha: _glowAnimation.value * 0.3),
+                    color: t.accentSolid.withValues(alpha: _glowAnimation.value * 0.3),
                     blurRadius: 20,
                     spreadRadius: 5,
                   ),
@@ -201,10 +194,10 @@ class _SignupScreenState extends State<SignupScreen>
                 style: TextStyle(
                   fontSize: 32,
                   fontWeight: FontWeight.w700,
-                  color: Colors.white,
+                  color: t.textPrimary,
                   shadows: [
                     Shadow(
-                      color: const Color(0xFF2D3FE7).withValues(alpha: _glowAnimation.value * 0.8),
+                      color: t.accentSolid.withValues(alpha: _glowAnimation.value * 0.8),
                       blurRadius: 10,
                       offset: const Offset(0, 2),
                     ),
@@ -220,20 +213,20 @@ class _SignupScreenState extends State<SignupScreen>
           textAlign: TextAlign.center,
           style: TextStyle(
             fontSize: 16,
-            color: Colors.white.withValues(alpha: 0.7),
+            color: t.textPrimary.withValues(alpha: 0.7),
           ),
         ),
       ],
     );
   }
 
-  Widget _buildSignupForm() {
+  Widget _buildSignupForm(AppTokens t) {
     return Container(
       decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.08),
+        color: t.surface,
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
-          color: Colors.white.withValues(alpha: 0.1),
+          color: t.outline,
         ),
       ),
       padding: const EdgeInsets.all(24),
@@ -242,20 +235,20 @@ class _SignupScreenState extends State<SignupScreen>
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            _buildUsernameField(),
+            _buildUsernameField(t),
             const SizedBox(height: 20),
-            _buildPasswordField(),
+            _buildPasswordField(t),
             const SizedBox(height: 20),
-            _buildConfirmPasswordField(),
+            _buildConfirmPasswordField(t),
             const SizedBox(height: 32),
-            _buildSignupButton(),
+            _buildSignupButton(t),
           ],
         ),
       ),
     );
   }
 
-  Widget _buildUsernameField() {
+  Widget _buildUsernameField(AppTokens t) {
     return TextFormField(
       controller: _usernameController,
       validator: (value) {
@@ -278,30 +271,30 @@ class _SignupScreenState extends State<SignupScreen>
       decoration: InputDecoration(
         labelText: AppLocalizations.of(context)!.signup_username_label,
         hintText: AppLocalizations.of(context)!.signup_username_placeholder,
-        labelStyle: TextStyle(color: Colors.white.withValues(alpha: 0.7)),
-        hintStyle: TextStyle(color: Colors.white.withValues(alpha: 0.5)),
-        prefixIcon: Icon(Icons.person, color: Colors.white.withValues(alpha: 0.7)),
+        labelStyle: TextStyle(color: t.textPrimary.withValues(alpha: 0.7)),
+        hintStyle: TextStyle(color: t.textSecondary),
+        prefixIcon: Icon(Icons.person, color: t.textPrimary.withValues(alpha: 0.7)),
         filled: true,
-        fillColor: Colors.white.withValues(alpha: 0.05),
+        fillColor: t.inputFill,
         border: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
-          borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.1)),
+          borderSide: BorderSide(color: t.outline),
         ),
         enabledBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
-          borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.1)),
+          borderSide: BorderSide(color: t.outline),
         ),
         focusedBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
-          borderSide: const BorderSide(color: Color(0xFF2D3FE7)),
+          borderSide: BorderSide(color: t.accentSolid),
         ),
       ),
-      style: const TextStyle(color: Colors.white),
+      style: TextStyle(color: t.textPrimary),
       textInputAction: TextInputAction.next,
     );
   }
 
-  Widget _buildPasswordField() {
+  Widget _buildPasswordField(AppTokens t) {
     return TextFormField(
       controller: _passwordController,
       validator: (value) {
@@ -328,13 +321,13 @@ class _SignupScreenState extends State<SignupScreen>
       decoration: InputDecoration(
         labelText: AppLocalizations.of(context)!.signup_password_label,
         hintText: AppLocalizations.of(context)!.signup_password_placeholder,
-        labelStyle: TextStyle(color: Colors.white.withValues(alpha: 0.7)),
-        hintStyle: TextStyle(color: Colors.white.withValues(alpha: 0.5)),
-        prefixIcon: Icon(Icons.lock, color: Colors.white.withValues(alpha: 0.7)),
+        labelStyle: TextStyle(color: t.textPrimary.withValues(alpha: 0.7)),
+        hintStyle: TextStyle(color: t.textSecondary),
+        prefixIcon: Icon(Icons.lock, color: t.textPrimary.withValues(alpha: 0.7)),
         suffixIcon: IconButton(
           icon: Icon(
             _isPasswordVisible ? Icons.visibility : Icons.visibility_off,
-            color: Colors.white.withValues(alpha: 0.7),
+            color: t.textPrimary.withValues(alpha: 0.7),
           ),
           onPressed: () {
             setState(() {
@@ -343,26 +336,26 @@ class _SignupScreenState extends State<SignupScreen>
           },
         ),
         filled: true,
-        fillColor: Colors.white.withValues(alpha: 0.05),
+        fillColor: t.inputFill,
         border: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
-          borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.1)),
+          borderSide: BorderSide(color: t.outline),
         ),
         enabledBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
-          borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.1)),
+          borderSide: BorderSide(color: t.outline),
         ),
         focusedBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
-          borderSide: const BorderSide(color: Color(0xFF2D3FE7)),
+          borderSide: BorderSide(color: t.accentSolid),
         ),
       ),
-      style: const TextStyle(color: Colors.white),
+      style: TextStyle(color: t.textPrimary),
       textInputAction: TextInputAction.next,
     );
   }
 
-  Widget _buildConfirmPasswordField() {
+  Widget _buildConfirmPasswordField(AppTokens t) {
     return TextFormField(
       controller: _confirmPasswordController,
       validator: (value) {
@@ -378,13 +371,13 @@ class _SignupScreenState extends State<SignupScreen>
       decoration: InputDecoration(
         labelText: AppLocalizations.of(context)!.confirm_password_label,
         hintText: AppLocalizations.of(context)!.confirm_password_placeholder,
-        labelStyle: TextStyle(color: Colors.white.withValues(alpha: 0.7)),
-        hintStyle: TextStyle(color: Colors.white.withValues(alpha: 0.5)),
-        prefixIcon: Icon(Icons.lock_outline, color: Colors.white.withValues(alpha: 0.7)),
+        labelStyle: TextStyle(color: t.textPrimary.withValues(alpha: 0.7)),
+        hintStyle: TextStyle(color: t.textSecondary),
+        prefixIcon: Icon(Icons.lock_outline, color: t.textPrimary.withValues(alpha: 0.7)),
         suffixIcon: IconButton(
           icon: Icon(
             _isConfirmPasswordVisible ? Icons.visibility : Icons.visibility_off,
-            color: Colors.white.withValues(alpha: 0.7),
+            color: t.textPrimary.withValues(alpha: 0.7),
           ),
           onPressed: () {
             setState(() {
@@ -393,37 +386,33 @@ class _SignupScreenState extends State<SignupScreen>
           },
         ),
         filled: true,
-        fillColor: Colors.white.withValues(alpha: 0.05),
+        fillColor: t.inputFill,
         border: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
-          borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.1)),
+          borderSide: BorderSide(color: t.outline),
         ),
         enabledBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
-          borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.1)),
+          borderSide: BorderSide(color: t.outline),
         ),
         focusedBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
-          borderSide: const BorderSide(color: Color(0xFF2D3FE7)),
+          borderSide: BorderSide(color: t.accentSolid),
         ),
       ),
-      style: const TextStyle(color: Colors.white),
+      style: TextStyle(color: t.textPrimary),
       textInputAction: TextInputAction.done,
       onFieldSubmitted: (_) => _handleSignup(),
     );
   }
 
-  Widget _buildSignupButton() {
+  Widget _buildSignupButton(AppTokens t) {
     return Consumer<AuthProvider>(
       builder: (context, authProvider, child) {
         return Container(
           height: 56,
           decoration: BoxDecoration(
-            gradient: const LinearGradient(
-              colors: [Color(0xFF2D3FE7), Color(0xFF4C63F7)],
-              begin: Alignment.centerLeft,
-              end: Alignment.centerRight,
-            ),
+            gradient: t.accentGradient,
             borderRadius: BorderRadius.circular(16),
           ),
           child: ElevatedButton(
@@ -436,20 +425,20 @@ class _SignupScreenState extends State<SignupScreen>
               ),
             ),
             child: (_isLoading || authProvider.isLoading)
-                ? const SizedBox(
+                ? SizedBox(
                     height: 20,
                     width: 20,
                     child: CircularProgressIndicator(
                       strokeWidth: 2,
-                      valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                      valueColor: AlwaysStoppedAnimation<Color>(t.accentForeground),
                     ),
                   )
                 : Text(
                     AppLocalizations.of(context)!.create_account_button,
-                    style: const TextStyle(
+                    style: TextStyle(
                       fontSize: 16,
                       fontWeight: FontWeight.w600,
-                      color: Colors.white,
+                      color: t.accentForeground,
                     ),
                   ),
           ),
@@ -458,12 +447,12 @@ class _SignupScreenState extends State<SignupScreen>
     );
   }
 
-  Widget _buildTermsCheckbox() {
+  Widget _buildTermsCheckbox(AppTokens t) {
     return Container(
       decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.05),
+        color: t.inputFill,
         borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
+        border: Border.all(color: t.outline),
       ),
       padding: const EdgeInsets.all(16),
       child: Row(
@@ -471,14 +460,14 @@ class _SignupScreenState extends State<SignupScreen>
           Theme(
             data: Theme.of(context).copyWith(
               checkboxTheme: CheckboxThemeData(
-                fillColor: MaterialStateProperty.resolveWith<Color?>((states) {
-                  if (states.contains(MaterialState.selected)) {
-                    return const Color(0xFF2D3FE7);
+                fillColor: WidgetStateProperty.resolveWith<Color?>((states) {
+                  if (states.contains(WidgetState.selected)) {
+                    return t.accentSolid;
                   }
                   return Colors.transparent;
                 }),
-                checkColor: MaterialStateProperty.all(Colors.white),
-                side: BorderSide(color: Colors.white.withValues(alpha: 0.3)),
+                checkColor: WidgetStateProperty.all(t.accentForeground),
+                side: BorderSide(color: t.textPrimary.withValues(alpha: 0.3)),
               ),
             ),
             child: Checkbox(
@@ -496,7 +485,7 @@ class _SignupScreenState extends State<SignupScreen>
               'He anotado mi contraseña en un lugar seguro',
               style: TextStyle(
                 fontSize: 14,
-                color: Colors.white.withValues(alpha: 0.8),
+                color: t.textPrimary.withValues(alpha: 0.8),
               ),
             ),
           ),
@@ -506,15 +495,15 @@ class _SignupScreenState extends State<SignupScreen>
   }
 
 
-  Widget _buildServerInfo() {
+  Widget _buildServerInfo(AppTokens t) {
     return Consumer<ServerProvider>(
       builder: (context, serverProvider, child) {
         return Container(
           padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
           decoration: BoxDecoration(
-            color: Colors.white.withValues(alpha: 0.05),
+            color: t.inputFill,
             borderRadius: BorderRadius.circular(12),
-            border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
+            border: Border.all(color: t.outline),
           ),
           child: Row(
             mainAxisAlignment: MainAxisAlignment.center,
@@ -522,21 +511,21 @@ class _SignupScreenState extends State<SignupScreen>
               Icon(
                 Icons.dns,
                 size: 16,
-                color: Colors.white.withValues(alpha: 0.7),
+                color: t.textPrimary.withValues(alpha: 0.7),
               ),
               const SizedBox(width: 8),
               Text(
                 'Servidor: ',
                 style: TextStyle(
                   fontSize: 14,
-                  color: Colors.white.withValues(alpha: 0.7),
+                  color: t.textPrimary.withValues(alpha: 0.7),
                 ),
               ),
               Text(
                 serverProvider.serverDisplayName,
-                style: const TextStyle(
+                style: TextStyle(
                   fontSize: 14,
-                  color: Colors.white,
+                  color: t.textPrimary,
                   fontWeight: FontWeight.w500,
                 ),
               ),
@@ -547,24 +536,24 @@ class _SignupScreenState extends State<SignupScreen>
     );
   }
 
-  Widget _buildTopNavigation() {
+  Widget _buildTopNavigation(AppTokens t) {
     return Padding(
       padding: const EdgeInsets.only(top: 16, left: 24, right: 24),
       child: Row(
         children: [
           Container(
             decoration: BoxDecoration(
-              color: Colors.white.withValues(alpha: 0.08),
+              color: t.surface,
               borderRadius: BorderRadius.circular(12),
               border: Border.all(
-                color: Colors.white.withValues(alpha: 0.1),
+                color: t.outline,
               ),
             ),
             child: IconButton(
               onPressed: () => Navigator.pop(context),
-              icon: const Icon(
+              icon: Icon(
                 Icons.arrow_back_ios,
-                color: Colors.white,
+                color: t.textPrimary,
                 size: 20,
               ),
               padding: const EdgeInsets.all(12),

--- a/lib/screens/6home_screen.dart
+++ b/lib/screens/6home_screen.dart
@@ -328,7 +328,8 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
             SnackBar(
               content: Row(
                 children: [
-                  Icon(Icons.check_circle, color: context.tokens.statusHealthy),
+                  // White content on saturated status background; not a themable surface.
+                  const Icon(Icons.check_circle, color: Colors.white),
                   const SizedBox(width: 8),
                   Text('${AppLocalizations.of(context)!.received_label}! +$difference sats'),
                 ],
@@ -935,9 +936,9 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
               ),
             ),
             child: IconButton(
-              icon: const Icon(
+              icon: Icon(
                 Icons.auto_awesome,
-                color: Colors.orange,
+                color: context.tokens.statusWarning,
                 size: 24,
               ),
               onPressed: _triggerTestSpark,
@@ -962,10 +963,10 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                   child: Container(
                     padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
                     decoration: BoxDecoration(
-                      color: context.tokens.outline,
+                      color: context.tokens.surface,
                       borderRadius: BorderRadius.circular(16),
                       border: Border.all(
-                        color: context.tokens.outlineStrong,
+                        color: context.tokens.outline,
                       ),
                     ),
                     child: Row(
@@ -1682,10 +1683,10 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                       Container(
                         padding: const EdgeInsets.all(16),
                         decoration: BoxDecoration(
-                          color: context.tokens.outline,
+                          color: context.tokens.surface,
                           borderRadius: BorderRadius.circular(12),
                           border: Border.all(
-                            color: context.tokens.outlineStrong,
+                            color: context.tokens.outline,
                           ),
                         ),
                         child: Row(
@@ -1845,8 +1846,9 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
           width: 40,
           height: 40,
           decoration: BoxDecoration(
-            color: context.tokens.outline,
+            color: context.tokens.surface,
             borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: context.tokens.outline, width: 1),
           ),
           child: Icon(
             icon,

--- a/lib/screens/6home_screen.dart
+++ b/lib/screens/6home_screen.dart
@@ -9,6 +9,7 @@ import '../services/transaction_detector.dart';
 import '../providers/currency_settings_provider.dart';
 import '../services/app_info_service.dart';
 import '../l10n/generated/app_localizations.dart';
+import '../theme/app_tokens.dart';
 import '7history_screen.dart';
 import '7ln_address_screen.dart';
 import '9receive_screen.dart';
@@ -327,12 +328,12 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
             SnackBar(
               content: Row(
                 children: [
-                  const Icon(Icons.check_circle, color: Colors.green),
+                  Icon(Icons.check_circle, color: context.tokens.statusHealthy),
                   const SizedBox(width: 8),
                   Text('${AppLocalizations.of(context)!.received_label}! +$difference sats'),
                 ],
               ),
-              backgroundColor: Colors.green.withValues(alpha: 0.9),
+              backgroundColor: context.tokens.statusHealthy.withValues(alpha: 0.9),
               duration: const Duration(seconds: 3),
             ),
           );
@@ -455,10 +456,9 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
           mainBalance,
           textAlign: TextAlign.center,
           style: TextStyle(
-            fontFamily: 'Manrope',
-            fontSize: _getBalanceFontSize(isMobile, currencyProvider),
+                        fontSize: _getBalanceFontSize(isMobile, currencyProvider),
             fontWeight: FontWeight.bold,
-            color: Colors.white,
+            color: context.tokens.textPrimary,
           ),
         ),
         // Secondary balance (sats) when not in sats mode
@@ -468,10 +468,9 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
             secondaryBalance,
             textAlign: TextAlign.center,
             style: TextStyle(
-              fontFamily: 'Manrope',
-              fontSize: isMobile ? 16 : 18,
+                            fontSize: isMobile ? 16 : 18,
               fontWeight: FontWeight.w500,
-              color: Colors.white.withValues(alpha: 0.7),
+              color: context.tokens.textPrimary.withValues(alpha: 0.7),
             ),
           ),
         ],
@@ -711,18 +710,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
         return Scaffold(
           backgroundColor: Colors.transparent,
           body: Container(
-            decoration: const BoxDecoration(
-              gradient: LinearGradient(
-                begin: Alignment.topLeft,
-                end: Alignment.bottomRight,
-                colors: [
-                  Color(0xFF0F1419), // Azul oscuro profundo
-                  Color(0xFF1A1D47), // Azul medio
-                  Color(0xFF2D3FE7), // Azul vibrante
-                ],
-                stops: [0.0, 0.5, 1.0],
-              ),
-            ),
+            decoration: BoxDecoration(gradient: context.tokens.backgroundGradient),
             child: Column(
               children: [
                 // Main content
@@ -879,17 +867,17 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
             width: 48,
             height: 48,
             decoration: BoxDecoration(
-              color: Colors.white.withValues(alpha: 0.08),
+              color: context.tokens.surface,
               borderRadius: BorderRadius.circular(12),
               border: Border.all(
-                color: Colors.white.withValues(alpha: 0.1),
+                color: context.tokens.outline,
                 width: 1,
               ),
             ),
             child: IconButton(
-              icon: const Icon(
+              icon: Icon(
                 Icons.menu,
-                color: Colors.white,
+                color: context.tokens.textPrimary,
                 size: 24,
               ),
               onPressed: () => Scaffold.of(context).openDrawer(),
@@ -907,22 +895,21 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                 child: Text(
                   'LaChispa',
                   style: TextStyle(
-                    fontFamily: 'Manrope',
-                    fontSize: 40,
+                                        fontSize: 40,
                     fontWeight: FontWeight.bold,
-                    color: Colors.white,
+                    color: context.tokens.textPrimary,
                   shadows: [
                     Shadow(
                       offset: const Offset(0, 0),
                       blurRadius: 20 + (10 * _glowAnimation.value), // 20-30px blur
-                      color: const Color(0xFF2D3FE7).withValues(
+                      color: context.tokens.accentSolid.withValues(
                         alpha: 0.3 + (0.4 * _glowAnimation.value), // More intensity
                       ),
                     ),
                     Shadow(
                       offset: const Offset(0, 0),
                       blurRadius: 10 + (5 * _glowAnimation.value), // Glow adicional
-                      color: const Color(0xFF4C63F7).withValues(
+                      color: context.tokens.accentSolid.withValues(
                         alpha: 0.2 + (0.3 * _glowAnimation.value),
                       ),
                     ),
@@ -940,10 +927,10 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
             width: 48,
             height: 48,
             decoration: BoxDecoration(
-              color: Colors.white.withValues(alpha: 0.08),
+              color: context.tokens.surface,
               borderRadius: BorderRadius.circular(12),
               border: Border.all(
-                color: Colors.white.withValues(alpha: 0.1),
+                color: context.tokens.outline,
                 width: 1,
               ),
             ),
@@ -975,35 +962,34 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                   child: Container(
                     padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
                     decoration: BoxDecoration(
-                      color: Colors.white.withValues(alpha: 0.1),
+                      color: context.tokens.outline,
                       borderRadius: BorderRadius.circular(16),
                       border: Border.all(
-                        color: Colors.white.withValues(alpha: 0.2),
+                        color: context.tokens.outlineStrong,
                       ),
                     ),
                     child: Row(
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        const Icon(
+                        Icon(
                           Icons.account_balance_wallet,
                           size: 14,
-                          color: Colors.white70,
+                          color: context.tokens.textPrimary.withValues(alpha: 0.7),
                         ),
                         const SizedBox(width: 6),
                         Text(
                           walletProvider.primaryWallet!.name,
-                          style: const TextStyle(
-                            fontFamily: 'Manrope',
-                            fontSize: 12,
+                          style: TextStyle(
+                                                        fontSize: 12,
                             fontWeight: FontWeight.w500,
-                            color: Colors.white,
+                            color: context.tokens.textPrimary,
                           ),
                         ),
                         const SizedBox(width: 6),
-                        const Icon(
+                        Icon(
                           Icons.keyboard_arrow_down,
                           size: 16,
-                          color: Colors.white70,
+                          color: context.tokens.textPrimary.withValues(alpha: 0.7),
                         ),
                       ],
                     ),
@@ -1019,16 +1005,15 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                       height: 12,
                       child: CircularProgressIndicator(
                         strokeWidth: 1,
-                        valueColor: AlwaysStoppedAnimation<Color>(Colors.white70),
+                        valueColor: AlwaysStoppedAnimation<Color>(context.tokens.textPrimary.withValues(alpha: 0.7)),
                       ),
                     ),
                     SizedBox(width: 8),
                     Text(
                       AppLocalizations.of(context)!.loading_text,
                       style: TextStyle(
-                        fontFamily: 'Manrope',
-                        fontSize: 12,
-                        color: Colors.white70,
+                                                fontSize: 12,
+                        color: context.tokens.textPrimary.withValues(alpha: 0.7),
                       ),
                     ),
                   ],
@@ -1066,10 +1051,10 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                   vertical: 32,
                 ),
                 decoration: BoxDecoration(
-                  color: Colors.white.withValues(alpha: 0.08),
+                  color: context.tokens.surface,
                   borderRadius: BorderRadius.circular(16),
                   border: Border.all(
-                    color: Colors.white.withValues(alpha: 0.1),
+                    color: context.tokens.outline,
                     width: 1,
                   ),
                   boxShadow: [
@@ -1085,10 +1070,9 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                     Text(
                       AppLocalizations.of(context)!.balance_label,
                       style: TextStyle(
-                        fontFamily: 'Manrope',
-                        fontSize: 16,
+                                                fontSize: 16,
                         fontWeight: FontWeight.w500,
-                        color: Colors.white.withValues(alpha: 0.8),
+                        color: context.tokens.textPrimary.withValues(alpha: 0.8),
                       ),
                     ),
                     const SizedBox(height: 16),
@@ -1180,7 +1164,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                         AnimatedContainer(
                           duration: const Duration(milliseconds: 200),
                           decoration: BoxDecoration(
-                            color: Colors.white.withValues(alpha: 0.08),
+                            color: context.tokens.surface,
                             borderRadius: BorderRadius.circular(12),
                           ),
                           child: IconButton(
@@ -1191,7 +1175,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                                     ? Icons.visibility
                                     : Icons.visibility_off,
                                 key: ValueKey(_balanceVisible),
-                                color: Colors.white.withValues(alpha: 0.6),
+                                color: context.tokens.textSecondary,
                                 size: 24,
                               ),
                             ),
@@ -1225,18 +1209,11 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                 transform: Matrix4.identity()
                   ..scale(_sendButtonPressed ? 0.95 : 1.0),
                 decoration: BoxDecoration(
-                  gradient: const LinearGradient(
-                    begin: Alignment.centerLeft,
-                    end: Alignment.centerRight,
-                    colors: [
-                      Color(0xFF2D3FE7),
-                      Color(0xFF4C63F7),
-                    ],
-                  ),
+                  gradient: context.tokens.accentGradient,
                   borderRadius: BorderRadius.circular(16),
                   boxShadow: [
                     BoxShadow(
-                      color: const Color(0xFF2D3FE7).withValues(
+                      color: context.tokens.accentSolid.withValues(
                         alpha: _sendButtonPressed ? 0.5 : 0.3,
                       ),
                       blurRadius: _sendButtonPressed ? 8 : 12,
@@ -1261,16 +1238,15 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                         Text(
                           AppLocalizations.of(context)!.send_button,
                           style: TextStyle(
-                            fontFamily: 'Manrope',
-                            fontSize: 16,
+                                                        fontSize: 16,
                             fontWeight: FontWeight.w600,
-                            color: Colors.white,
+                            color: context.tokens.textPrimary,
                           ),
                         ),
                         SizedBox(width: 8),
                         Icon(
                           Icons.north_east,
-                          color: Colors.white,
+                          color: context.tokens.textPrimary,
                           size: 20,
                         ),
                       ],
@@ -1288,19 +1264,19 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                 transform: Matrix4.identity()
                   ..scale(_receiveButtonPressed ? 0.95 : 1.0),
                 decoration: BoxDecoration(
-                  color: Colors.white.withValues(
+                  color: context.tokens.textPrimary.withValues(
                     alpha: _receiveButtonPressed ? 0.12 : 0.08,
                   ),
                   borderRadius: BorderRadius.circular(16),
                   border: Border.all(
-                    color: Colors.white.withValues(
+                    color: context.tokens.textPrimary.withValues(
                       alpha: _receiveButtonPressed ? 0.2 : 0.1,
                     ),
                     width: 1,
                   ),
                   boxShadow: _receiveButtonPressed ? [
                     BoxShadow(
-                      color: Colors.white.withValues(alpha: 0.1),
+                      color: context.tokens.outline,
                       blurRadius: 8,
                       offset: const Offset(0, 3),
                     ),
@@ -1322,17 +1298,16 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                       children: [
                         Icon(
                           Icons.south_east,
-                          color: Colors.white,
+                          color: context.tokens.textPrimary,
                           size: 20,
                         ),
                         SizedBox(width: 8),
                         Text(
                           AppLocalizations.of(context)!.receive_button,
                           style: TextStyle(
-                            fontFamily: 'Manrope',
-                            fontSize: 16,
+                                                        fontSize: 16,
                             fontWeight: FontWeight.w600,
-                            color: Colors.white,
+                            color: context.tokens.textPrimary,
                           ),
                         ),
                       ],
@@ -1373,9 +1348,9 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                 padding: const EdgeInsets.all(24),
                 child: Row(
                   children: [
-                    const Icon(
+                    Icon(
                       Icons.account_balance_wallet,
-                      color: Colors.white,
+                      color: context.tokens.textPrimary,
                       size: 24,
                     ),
                     const SizedBox(width: 12),
@@ -1384,15 +1359,15 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                       style: TextStyle(
                         fontSize: 20,
                         fontWeight: FontWeight.w600,
-                        color: Colors.white,
+                        color: context.tokens.textPrimary,
                       ),
                     ),
                     const Spacer(),
                     IconButton(
                       onPressed: () => Navigator.pop(context),
-                      icon: const Icon(
+                      icon: Icon(
                         Icons.close,
-                        color: Colors.white,
+                        color: context.tokens.textPrimary,
                       ),
                     ),
                   ],
@@ -1413,13 +1388,13 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                       margin: const EdgeInsets.only(bottom: 12),
                       decoration: BoxDecoration(
                         color: isSelected 
-                            ? const Color(0xFF2D3FE7).withValues(alpha: 0.3)
-                            : Colors.white.withValues(alpha: 0.05),
+                            ? context.tokens.accentSolid.withValues(alpha: 0.3)
+                            : context.tokens.inputFill,
                         borderRadius: BorderRadius.circular(16),
                         border: Border.all(
                           color: isSelected 
-                              ? const Color(0xFF2D3FE7)
-                              : Colors.white.withValues(alpha: 0.1),
+                              ? context.tokens.accentSolid
+                              : context.tokens.outline,
                         ),
                       ),
                       child: ListTile(
@@ -1429,20 +1404,20 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                           height: 48,
                           decoration: BoxDecoration(
                             color: isSelected 
-                                ? const Color(0xFF2D3FE7).withValues(alpha: 0.3)
-                                : Colors.white.withValues(alpha: 0.1),
+                                ? context.tokens.accentSolid.withValues(alpha: 0.3)
+                                : context.tokens.outline,
                             borderRadius: BorderRadius.circular(12),
                           ),
                           child: Icon(
                             Icons.account_balance_wallet,
-                            color: isSelected ? const Color(0xFF5B73FF) : Colors.white70,
+                            color: isSelected ? context.tokens.accentBright : context.tokens.textPrimary.withValues(alpha: 0.7),
                             size: 24,
                           ),
                         ),
                         title: Text(
                           wallet.name,
                           style: TextStyle(
-                            color: Colors.white,
+                            color: context.tokens.textPrimary,
                             fontSize: 16,
                             fontWeight: isSelected ? FontWeight.w600 : FontWeight.w500,
                           ),
@@ -1450,15 +1425,15 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                         subtitle: Text(
                           wallet.balanceFormatted,
                           style: TextStyle(
-                            color: isSelected ? const Color(0xFF5B73FF) : Colors.white70,
+                            color: isSelected ? context.tokens.accentBright : context.tokens.textPrimary.withValues(alpha: 0.7),
                             fontSize: 14,
                             fontWeight: FontWeight.w500,
                           ),
                         ),
-                        trailing: isSelected 
-                            ? const Icon(
+                        trailing: isSelected
+                            ? Icon(
                                 Icons.check_circle,
-                                color: Color(0xFF5B73FF),
+                                color: context.tokens.accentBright,
                                 size: 24,
                               )
                             : null,
@@ -1470,7 +1445,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                           ScaffoldMessenger.of(context).showSnackBar(
                             SnackBar(
                               content: Text('${AppLocalizations.of(context)!.wallet_title} "${wallet.name}" seleccionada'),
-                              backgroundColor: const Color(0xFF2D3FE7),
+                              backgroundColor: context.tokens.accentSolid,
                               duration: const Duration(seconds: 2),
                             ),
                           );
@@ -1486,10 +1461,10 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                 margin: const EdgeInsets.all(24),
                 padding: const EdgeInsets.all(16),
                 decoration: BoxDecoration(
-                  color: Colors.white.withValues(alpha: 0.05),
+                  color: context.tokens.inputFill,
                   borderRadius: BorderRadius.circular(12),
                   border: Border.all(
-                    color: Colors.white.withValues(alpha: 0.1),
+                    color: context.tokens.outline,
                   ),
                 ),
                 child: Column(
@@ -1497,16 +1472,16 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                   children: [
                     Row(
                       children: [
-                        const Icon(
+                        Icon(
                           Icons.info_outline,
-                          color: Color(0xFF5B73FF),
+                          color: context.tokens.accentBright,
                           size: 16,
                         ),
                         const SizedBox(width: 8),
                         Text(
                           AppLocalizations.of(context)!.create_new_wallet_title,
                           style: TextStyle(
-                            color: Colors.white,
+                            color: context.tokens.textPrimary,
                             fontSize: 14,
                             fontWeight: FontWeight.w600,
                           ),
@@ -1516,8 +1491,8 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                     const SizedBox(height: 8),
                     Text(
                       AppLocalizations.of(context)!.create_wallet_short_description,
-                      style: const TextStyle(
-                        color: Colors.white70,
+                      style: TextStyle(
+                        color: context.tokens.textPrimary.withValues(alpha: 0.7),
                         fontSize: 12,
                       ),
                     ),
@@ -1530,8 +1505,8 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                           _showWalletCreationInfo();
                         },
                         style: ElevatedButton.styleFrom(
-                          backgroundColor: const Color(0xFF2D3FE7),
-                          foregroundColor: Colors.white,
+                          backgroundColor: context.tokens.accentSolid,
+                          foregroundColor: context.tokens.accentForeground,
                           shape: RoundedRectangleBorder(
                             borderRadius: BorderRadius.circular(8),
                           ),
@@ -1557,24 +1532,24 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
-        backgroundColor: const Color(0xFF1A1D47),
+        backgroundColor: context.tokens.dialogBackground,
         title: Row(
           children: [
             Icon(
               Icons.add_circle_outline,
-              color: Color(0xFF5B73FF),
+              color: context.tokens.accentBright,
             ),
             SizedBox(width: 8),
             Text(
               AppLocalizations.of(context)!.create_new_wallet_title,
-              style: TextStyle(color: Colors.white),
+              style: TextStyle(color: context.tokens.textPrimary),
             ),
           ],
         ),
         content: Text(
           AppLocalizations.of(context)!.create_wallet_detailed_instructions,
-          style: const TextStyle(
-            color: Colors.white70,
+          style: TextStyle(
+            color: context.tokens.textPrimary.withValues(alpha: 0.7),
             fontSize: 14,
           ),
         ),
@@ -1583,7 +1558,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
             onPressed: () => Navigator.pop(context),
             child: Text(
               AppLocalizations.of(context)!.cancel_button,
-              style: TextStyle(color: Color(0xFF5B73FF)),
+              style: TextStyle(color: context.tokens.accentBright),
             ),
           ),
         ],
@@ -1598,10 +1573,10 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
       child: Container(
         height: 56, // Standard button height
         decoration: BoxDecoration(
-          color: Colors.white.withValues(alpha: 0.08), // Glassmorphism
+          color: context.tokens.surface, // Glassmorphism
           borderRadius: BorderRadius.circular(16), // Standard border radius
           border: Border.all(
-            color: Colors.white.withValues(alpha: 0.1),
+            color: context.tokens.outline,
             width: 1,
           ),
           boxShadow: [
@@ -1622,17 +1597,16 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
               children: [
                 Icon(
                   Icons.history,
-                  color: _isInHistory ? const Color(0xFF5B73FF) : Colors.white,
+                  color: _isInHistory ? context.tokens.accentBright : context.tokens.textPrimary,
                   size: 20, // Icon size according to guide
                 ),
                 const SizedBox(width: 12),
                 Text(
                   AppLocalizations.of(context)!.history_title,
                   style: TextStyle(
-                    fontFamily: 'Manrope',
-                    fontSize: 16,
+                                        fontSize: 16,
                     fontWeight: FontWeight.w500, // Weight for secondary buttons
-                    color: _isInHistory ? const Color(0xFF5B73FF) : Colors.white,
+                    color: _isInHistory ? context.tokens.accentBright : context.tokens.textPrimary,
                   ),
                 ),
               ],
@@ -1645,20 +1619,9 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
 
   Widget _buildDrawer(BuildContext context, AuthProvider authProvider, WalletProvider walletProvider) {
     return Drawer(
-      backgroundColor: const Color(0xFF1A1D47),
+      backgroundColor: context.tokens.dialogBackground,
       child: Container(
-        decoration: const BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-            colors: [
-              Color(0xFF0F1419),
-              Color(0xFF1A1D47),
-              Color(0xFF2D3FE7),
-            ],
-            stops: [0.0, 0.5, 1.0],
-          ),
-        ),
+        decoration: BoxDecoration(gradient: context.tokens.backgroundGradient),
         child: SafeArea(
           child: Column(
             children: [
@@ -1676,12 +1639,12 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                           width: 56,
                           height: 56,
                           decoration: BoxDecoration(
-                            color: const Color(0xFF2D3FE7),
+                            color: context.tokens.accentSolid,
                             borderRadius: BorderRadius.circular(16),
                           ),
-                          child: const Icon(
+                          child: Icon(
                             Icons.person,
-                            color: Colors.white,
+                            color: context.tokens.textPrimary,
                             size: 28,
                           ),
                         ),
@@ -1692,10 +1655,10 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                             children: [
                               Text(
                                 authProvider.currentUser ?? 'User',
-                                style: const TextStyle(
+                                style: TextStyle(
                                   fontSize: 18,
                                   fontWeight: FontWeight.w600,
-                                  color: Colors.white,
+                                  color: context.tokens.textPrimary,
                                 ),
                               ),
                               const SizedBox(height: 4),
@@ -1703,7 +1666,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                                 _extractDomain(authProvider.currentServer ?? ''),
                                 style: TextStyle(
                                   fontSize: 12,
-                                  color: Colors.white.withValues(alpha: 0.7),
+                                  color: context.tokens.textPrimary.withValues(alpha: 0.7),
                                 ),
                               ),
                             ],
@@ -1719,17 +1682,17 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                       Container(
                         padding: const EdgeInsets.all(16),
                         decoration: BoxDecoration(
-                          color: Colors.white.withValues(alpha: 0.1),
+                          color: context.tokens.outline,
                           borderRadius: BorderRadius.circular(12),
                           border: Border.all(
-                            color: Colors.white.withValues(alpha: 0.2),
+                            color: context.tokens.outlineStrong,
                           ),
                         ),
                         child: Row(
                           children: [
-                            const Icon(
+                            Icon(
                               Icons.account_balance_wallet,
-                              color: Color(0xFF5B73FF),
+                              color: context.tokens.accentBright,
                               size: 16,
                             ),
                             const SizedBox(width: 8),
@@ -1739,17 +1702,17 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                                 children: [
                                   Text(
                                     walletProvider.primaryWallet!.name,
-                                    style: const TextStyle(
+                                    style: TextStyle(
                                       fontSize: 14,
                                       fontWeight: FontWeight.w500,
-                                      color: Colors.white,
+                                      color: context.tokens.textPrimary,
                                     ),
                                   ),
                                   Text(
                                     walletProvider.primaryWallet!.balanceFormatted,
-                                    style: const TextStyle(
+                                    style: TextStyle(
                                       fontSize: 12,
-                                      color: Color(0xFF5B73FF),
+                                      color: context.tokens.accentBright,
                                       fontWeight: FontWeight.w600,
                                     ),
                                   ),
@@ -1831,7 +1794,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                     Container(
                       width: double.infinity,
                       height: 1,
-                      color: Colors.white.withValues(alpha: 0.1),
+                      color: context.tokens.outline,
                     ),
                     const SizedBox(height: 16),
                     SizedBox(
@@ -1842,8 +1805,8 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                           _showLogoutConfirmation(authProvider);
                         },
                         style: ElevatedButton.styleFrom(
-                          backgroundColor: Colors.red.withValues(alpha: 0.2),
-                          foregroundColor: Colors.red,
+                          backgroundColor: context.tokens.statusUnhealthy.withValues(alpha: 0.2),
+                          foregroundColor: context.tokens.statusUnhealthy,
                           shape: RoundedRectangleBorder(
                             borderRadius: BorderRadius.circular(12),
                           ),
@@ -1882,21 +1845,21 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
           width: 40,
           height: 40,
           decoration: BoxDecoration(
-            color: Colors.white.withValues(alpha: 0.1),
+            color: context.tokens.outline,
             borderRadius: BorderRadius.circular(8),
           ),
           child: Icon(
             icon,
-            color: const Color(0xFF5B73FF),
+            color: context.tokens.accentBright,
             size: 20,
           ),
         ),
         title: Text(
           title,
-          style: const TextStyle(
+          style: TextStyle(
             fontSize: 16,
             fontWeight: FontWeight.w500,
-            color: Colors.white,
+            color: context.tokens.textPrimary,
           ),
         ),
         subtitle: subtitle != null 
@@ -1904,7 +1867,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
               subtitle,
               style: TextStyle(
                 fontSize: 14,
-                color: Colors.white.withValues(alpha: 0.7),
+                color: context.tokens.textPrimary.withValues(alpha: 0.7),
               ),
             )
           : null,
@@ -1958,7 +1921,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
-        backgroundColor: const Color(0xFF1A1D47),
+        backgroundColor: context.tokens.dialogBackground,
         title: Row(
           children: [
             Container(
@@ -1978,9 +1941,9 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
               ),
             ),
             const SizedBox(width: 12),
-            const Text(
+            Text(
               'LaChispa',
-              style: TextStyle(color: Colors.white),
+              style: TextStyle(color: context.tokens.textPrimary),
             ),
           ],
         ),
@@ -1990,8 +1953,8 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
           children: [
             Text(
               subtitle,
-              style: const TextStyle(
-                color: Colors.white,
+              style: TextStyle(
+                color: context.tokens.textPrimary,
                 fontSize: 16,
                 fontWeight: FontWeight.w600,
               ),
@@ -1999,8 +1962,8 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
             const SizedBox(height: 8),
             Text(
               description,
-              style: const TextStyle(
-                color: Colors.white70,
+              style: TextStyle(
+                color: context.tokens.textPrimary.withValues(alpha: 0.7),
                 fontSize: 14,
               ),
             ),
@@ -2008,21 +1971,21 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
             Container(
               padding: const EdgeInsets.all(12),
               decoration: BoxDecoration(
-                color: const Color(0xFF2D3FE7).withValues(alpha: 0.2),
+                color: context.tokens.accentSolid.withValues(alpha: 0.2),
                 borderRadius: BorderRadius.circular(8),
               ),
               child: Row(
                 children: [
-                  const Icon(
+                  Icon(
                     Icons.code,
-                    color: Color(0xFF5B73FF),
+                    color: context.tokens.accentBright,
                     size: 16,
                   ),
                   const SizedBox(width: 8),
                   Text(
                     AppInfoService.getVersionDisplay(languageProvider.currentLocale.languageCode),
-                    style: const TextStyle(
-                      color: Color(0xFF5B73FF),
+                    style: TextStyle(
+                      color: context.tokens.accentBright,
                       fontSize: 12,
                       fontWeight: FontWeight.w500,
                     ),
@@ -2037,7 +2000,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
             onPressed: () => Navigator.pop(context),
             child: Text(
               AppLocalizations.of(context)!.cancel_button,
-              style: TextStyle(color: Color(0xFF5B73FF)),
+              style: TextStyle(color: context.tokens.accentBright),
             ),
           ),
         ],
@@ -2049,21 +2012,21 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
-        backgroundColor: const Color(0xFF1A1D47),
+        backgroundColor: context.tokens.dialogBackground,
         title: Text(
           AppLocalizations.of(context)!.logout_option,
-          style: TextStyle(color: Colors.white),
+          style: TextStyle(color: context.tokens.textPrimary),
         ),
         content: Text(
           AppLocalizations.of(context)!.confirm_logout_message,
-          style: TextStyle(color: Colors.white70),
+          style: TextStyle(color: context.tokens.textPrimary.withValues(alpha: 0.7)),
         ),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context),
             child: Text(
               AppLocalizations.of(context)!.cancel_button,
-              style: TextStyle(color: Colors.white54),
+              style: TextStyle(color: context.tokens.textTertiary),
             ),
           ),
           TextButton(
@@ -2083,7 +2046,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
             },
             child: Text(
               AppLocalizations.of(context)!.logout_option,
-              style: TextStyle(color: Colors.red),
+              style: TextStyle(color: context.tokens.statusUnhealthy),
             ),
           ),
         ],
@@ -2120,7 +2083,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
               width: 40,
               height: 4,
               decoration: BoxDecoration(
-                color: Colors.white.withValues(alpha: 0.3),
+                color: context.tokens.textTertiary,
                 borderRadius: BorderRadius.circular(2),
               ),
             ),
@@ -2130,10 +2093,10 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
               padding: const EdgeInsets.all(20),
               child: Text(
                 AppLocalizations.of(context)!.select_language,
-                style: const TextStyle(
+                style: TextStyle(
                   fontSize: 20,
                   fontWeight: FontWeight.bold,
-                  color: Colors.white,
+                  color: context.tokens.textPrimary,
                 ),
               ),
             ),
@@ -2165,14 +2128,14 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                             style: TextStyle(
                               fontSize: 18,
                               fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400,
-                              color: isSelected ? const Color(0xFF4C63F7) : Colors.white,
+                              color: isSelected ? context.tokens.accentSolid : context.tokens.textPrimary,
                             ),
                           ),
                         ),
                         if (isSelected)
-                          const Icon(
+                          Icon(
                             Icons.check_circle,
-                            color: Color(0xFF4C63F7),
+                            color: context.tokens.accentSolid,
                             size: 24,
                           ),
                       ],
@@ -2236,7 +2199,7 @@ class SparkPainter extends CustomPainter {
     // Optimized particle rendering
     if (particles.isEmpty) return;
     
-    // Predefined Chispa colors for performance
+    // Particle colors are intrinsic to the visual effect (CustomPainter, no context)
     const primaryColor = Color(0xFF5B73FF); // Glow exterior
     const secondaryColor = Color(0xFF4C63F7); // Glow interior
     

--- a/lib/screens/7history_screen.dart
+++ b/lib/screens/7history_screen.dart
@@ -7,6 +7,7 @@ import '../providers/wallet_provider.dart';
 import '../services/wallet_service.dart';
 import '../models/transaction_info.dart';
 import '../l10n/generated/app_localizations.dart';
+import '../theme/app_tokens.dart';
 
 class HistoryScreen extends StatefulWidget {
   const HistoryScreen({super.key});
@@ -175,19 +176,10 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
 
   @override
   Widget build(BuildContext context) {
+    final t = context.tokens;
     return Scaffold(
       body: Container(
-        decoration: const BoxDecoration(
-          gradient: LinearGradient(
-            colors: [
-              Color(0xFF0F1419),
-              Color(0xFF1A1D47),
-              Color(0xFF2D3FE7),
-            ],
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-          ),
-        ),
+        decoration: BoxDecoration(gradient: t.backgroundGradient),
         child: SafeArea(
           child: Column(
             children: [
@@ -201,12 +193,12 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
                     ).animate(_headerAnimation),
                     child: FadeTransition(
                       opacity: _headerAnimation,
-                      child: _buildHeader(),
+                      child: _buildHeader(t),
                     ),
                   );
                 },
               ),
-              
+
               AnimatedBuilder(
                 animation: _headerAnimation,
                 builder: (context, child) {
@@ -217,12 +209,12 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
                     ).animate(_headerAnimation),
                     child: FadeTransition(
                       opacity: _headerAnimation,
-                      child: _buildFilters(),
+                      child: _buildFilters(t),
                     ),
                   );
                 },
               ),
-              
+
               Expanded(
                 child: AnimatedBuilder(
                   animation: _listAnimation,
@@ -234,7 +226,7 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
                       ).animate(_listAnimation),
                       child: FadeTransition(
                         opacity: _listAnimation,
-                        child: _buildTransactionsList(),
+                        child: _buildTransactionsList(t),
                       ),
                     );
                   },
@@ -247,24 +239,24 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
     );
   }
 
-  Widget _buildHeader() {
+  Widget _buildHeader(AppTokens t) {
     return Container(
       padding: const EdgeInsets.all(24),
       child: Row(
         children: [
           Container(
             decoration: BoxDecoration(
-              color: Colors.white.withValues(alpha: 0.08),
+              color: t.surface,
               borderRadius: BorderRadius.circular(12),
               border: Border.all(
-                color: Colors.white.withValues(alpha: 0.1),
+                color: t.outline,
               ),
             ),
             child: IconButton(
               onPressed: () => Navigator.pop(context),
-              icon: const Icon(
+              icon: Icon(
                 Icons.arrow_back_ios,
-                color: Colors.white,
+                color: t.textPrimary,
                 size: 20,
               ),
               padding: const EdgeInsets.all(12),
@@ -274,9 +266,9 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
               ),
             ),
           ),
-          
+
           const SizedBox(width: 16),
-          
+
           Expanded(
             child: AnimatedBuilder(
               animation: _glowAnimation,
@@ -285,7 +277,7 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
                   decoration: BoxDecoration(
                     boxShadow: [
                       BoxShadow(
-                        color: const Color(0xFF2D3FE7).withValues(alpha: _glowAnimation.value * 0.3),
+                        color: t.accentSolid.withValues(alpha: _glowAnimation.value * 0.3),
                         blurRadius: 20,
                         spreadRadius: 2,
                       ),
@@ -296,10 +288,10 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
                     style: TextStyle(
                       fontSize: 28,
                       fontWeight: FontWeight.w700,
-                      color: Colors.white,
+                      color: t.textPrimary,
                       shadows: [
                         Shadow(
-                          color: const Color(0xFF2D3FE7).withValues(alpha: _glowAnimation.value * 0.8),
+                          color: t.accentSolid.withValues(alpha: _glowAnimation.value * 0.8),
                           blurRadius: 8,
                           offset: const Offset(0, 2),
                         ),
@@ -310,29 +302,29 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
               },
             ),
           ),
-          
+
           Container(
             decoration: BoxDecoration(
-              color: Colors.white.withValues(alpha: 0.08),
+              color: t.surface,
               borderRadius: BorderRadius.circular(12),
               border: Border.all(
-                color: Colors.white.withValues(alpha: 0.1),
+                color: t.outline,
               ),
             ),
             child: IconButton(
               onPressed: _isLoading ? null : _loadTransactions,
               icon: _isLoading
-                  ? const SizedBox(
+                  ? SizedBox(
                       width: 20,
                       height: 20,
                       child: CircularProgressIndicator(
                         strokeWidth: 2,
-                        valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                        valueColor: AlwaysStoppedAnimation<Color>(t.textPrimary),
                       ),
                     )
-                  : const Icon(
+                  : Icon(
                       Icons.refresh,
-                      color: Colors.white,
+                      color: t.textPrimary,
                       size: 20,
                     ),
               padding: const EdgeInsets.all(12),
@@ -347,7 +339,7 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
     );
   }
 
-  Widget _buildFilters() {
+  Widget _buildFilters(AppTokens t) {
     return Container(
       height: 50,
       margin: const EdgeInsets.symmetric(horizontal: 24),
@@ -361,7 +353,7 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
                   final isSelected = _currentFilter == filter;
                   return Padding(
                     padding: const EdgeInsets.only(right: 12),
-                    child: _buildFilterChip(filter, isSelected),
+                    child: _buildFilterChip(filter, isSelected, t),
                   );
                 }).toList(),
               ),
@@ -372,7 +364,7 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
     );
   }
 
-  Widget _buildFilterChip(TransactionFilter filter, bool isSelected) {
+  Widget _buildFilterChip(TransactionFilter filter, bool isSelected, AppTokens t) {
     return GestureDetector(
       onTap: () {
         setState(() {
@@ -383,14 +375,14 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
         duration: const Duration(milliseconds: 200),
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         decoration: BoxDecoration(
-          color: isSelected 
-              ? const Color(0xFF2D3FE7).withValues(alpha: 0.3)
-              : Colors.white.withValues(alpha: 0.05),
+          color: isSelected
+              ? t.accentSolid.withValues(alpha: 0.3)
+              : t.inputFill,
           borderRadius: BorderRadius.circular(20),
           border: Border.all(
-            color: isSelected 
-                ? const Color(0xFF2D3FE7)
-                : Colors.white.withValues(alpha: 0.1),
+            color: isSelected
+                ? t.accentSolid
+                : t.outline,
           ),
         ),
         child: Row(
@@ -399,7 +391,7 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
             Icon(
               _getFilterIcon(filter),
               size: 16,
-              color: isSelected ? Colors.white : Colors.white.withValues(alpha: 0.7),
+              color: isSelected ? t.textPrimary : t.textPrimary.withValues(alpha: 0.7),
             ),
             const SizedBox(width: 8),
             Text(
@@ -407,7 +399,7 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
               style: TextStyle(
                 fontSize: 14,
                 fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400,
-                color: isSelected ? Colors.white : Colors.white.withValues(alpha: 0.7),
+                color: isSelected ? t.textPrimary : t.textPrimary.withValues(alpha: 0.7),
               ),
             ),
           ],
@@ -488,39 +480,39 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
   }
 
   /// Determine appropriate color for transaction based on status and type
-  Color _getTransactionIconColor(TransactionInfo transaction) {
-    // Show orange color for pending transactions regardless of type
+  Color _getTransactionIconColor(TransactionInfo transaction, AppTokens t) {
+    // Show warning color for pending transactions regardless of type
     if (transaction.isPending) {
-      return Colors.orange;
+      return t.statusWarning;
     }
-    
-    // Show red color for failed transactions
+
+    // Show error color for failed transactions
     if (transaction.isFailed) {
-      return Colors.red;
+      return t.statusUnhealthy;
     }
-    
+
     // Show color based on direction for completed transactions
     if (transaction.isIncoming) {
-      return Colors.green;
+      return t.statusHealthy;
     } else {
-      return Colors.red;
+      return t.statusUnhealthy;
     }
   }
 
-  Widget _buildTransactionsList() {
+  Widget _buildTransactionsList(AppTokens t) {
     if (_isLoading) {
       return Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             CircularProgressIndicator(
-              valueColor: AlwaysStoppedAnimation<Color>(Color(0xFF2D3FE7)),
+              valueColor: AlwaysStoppedAnimation<Color>(t.accentSolid),
             ),
-            SizedBox(height: 16),
+            const SizedBox(height: 16),
             Text(
               AppLocalizations.of(context)!.loading_transactions_text,
               style: TextStyle(
-                color: Colors.white,
+                color: t.textPrimary,
                 fontSize: 16,
               ),
             ),
@@ -537,13 +529,13 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
             Icon(
               Icons.error_outline,
               size: 64,
-              color: Colors.red.withValues(alpha: 0.7),
+              color: t.statusUnhealthy.withValues(alpha: 0.7),
             ),
             const SizedBox(height: 16),
             Text(
               AppLocalizations.of(context)!.loading_transactions_error_prefix,
               style: TextStyle(
-                color: Colors.white,
+                color: t.textPrimary,
                 fontSize: 18,
                 fontWeight: FontWeight.w600,
               ),
@@ -553,7 +545,7 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
               _errorMessage,
               textAlign: TextAlign.center,
               style: TextStyle(
-                color: Colors.white.withValues(alpha: 0.7),
+                color: t.textPrimary.withValues(alpha: 0.7),
                 fontSize: 14,
               ),
             ),
@@ -561,8 +553,8 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
             ElevatedButton(
               onPressed: _loadTransactions,
               style: ElevatedButton.styleFrom(
-                backgroundColor: const Color(0xFF2D3FE7),
-                foregroundColor: Colors.white,
+                backgroundColor: t.accentSolid,
+                foregroundColor: t.accentForeground,
               ),
               child: Text(AppLocalizations.of(context)!.connect_button),
             ),
@@ -581,13 +573,13 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
             Icon(
               Icons.receipt_long,
               size: 64,
-              color: Colors.white.withValues(alpha: 0.3),
+              color: t.textPrimary.withValues(alpha: 0.3),
             ),
             const SizedBox(height: 16),
             Text(
               AppLocalizations.of(context)!.no_transactions_text,
               style: TextStyle(
-                color: Colors.white,
+                color: t.textPrimary,
                 fontSize: 18,
                 fontWeight: FontWeight.w600,
               ),
@@ -597,7 +589,7 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
               AppLocalizations.of(context)!.no_transactions_description,
               textAlign: TextAlign.center,
               style: TextStyle(
-                color: Colors.white.withValues(alpha: 0.7),
+                color: t.textPrimary.withValues(alpha: 0.7),
                 fontSize: 14,
               ),
             ),
@@ -608,27 +600,28 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
 
     return RefreshIndicator(
       onRefresh: _loadTransactions,
-      color: const Color(0xFF2D3FE7),
+      color: t.accentSolid,
       child: ListView.builder(
         controller: _scrollController,
         padding: const EdgeInsets.all(24),
         itemCount: filteredTransactions.length,
         itemBuilder: (context, index) {
           final transaction = filteredTransactions[index];
-          return _buildTransactionCard(transaction, index);
+          return _buildTransactionCard(transaction, index, t);
         },
       ),
     );
   }
 
-  Widget _buildTransactionCard(TransactionInfo transaction, int index) {
+  Widget _buildTransactionCard(TransactionInfo transaction, int index, AppTokens t) {
+    final iconColor = _getTransactionIconColor(transaction, t);
     return Container(
       margin: const EdgeInsets.only(bottom: 16),
       decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.08),
+        color: t.surface,
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
-          color: Colors.white.withValues(alpha: 0.1),
+          color: t.outline,
         ),
       ),
       child: InkWell(
@@ -643,18 +636,18 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
                 width: 48,
                 height: 48,
                 decoration: BoxDecoration(
-                  color: _getTransactionIconColor(transaction).withValues(alpha: 0.2),
+                  color: iconColor.withValues(alpha: 0.2),
                   borderRadius: BorderRadius.circular(12),
                 ),
                 child: Icon(
                   _getTransactionIcon(transaction),
-                  color: _getTransactionIconColor(transaction),
+                  color: iconColor,
                   size: 24,
                 ),
               ),
-              
+
               const SizedBox(width: 16),
-              
+
               // Content
               Expanded(
                 child: Column(
@@ -662,8 +655,8 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
                   children: [
                     Text(
                       transaction.memo.isEmpty ? AppLocalizations.of(context)!.no_description_text : transaction.memo,
-                      style: const TextStyle(
-                        color: Colors.white,
+                      style: TextStyle(
+                        color: t.textPrimary,
                         fontSize: 16,
                         fontWeight: FontWeight.w600,
                       ),
@@ -673,7 +666,7 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
                     Text(
                       transaction.formattedDate,
                       style: TextStyle(
-                        color: Colors.white.withValues(alpha: 0.6),
+                        color: t.textSecondary,
                         fontSize: 12,
                       ),
                     ),
@@ -685,7 +678,7 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
                             width: 8,
                             height: 8,
                             decoration: BoxDecoration(
-                              color: Colors.orange,
+                              color: t.statusWarning,
                               borderRadius: BorderRadius.circular(4),
                             ),
                           ),
@@ -693,7 +686,7 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
                           Text(
                             AppLocalizations.of(context)!.pending_label,
                             style: TextStyle(
-                              color: Colors.orange,
+                              color: t.statusWarning,
                               fontSize: 12,
                               fontWeight: FontWeight.w500,
                             ),
@@ -704,7 +697,7 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
                   ],
                 ),
               ),
-              
+
               // Amount column
               Column(
                 crossAxisAlignment: CrossAxisAlignment.end,
@@ -712,7 +705,7 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
                   Text(
                     transaction.displayAmount.split('\n').first, // Show sats amount
                     style: TextStyle(
-                      color: _getTransactionIconColor(transaction),
+                      color: iconColor,
                       fontSize: 16,
                       fontWeight: FontWeight.w700,
                     ),
@@ -721,7 +714,7 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
                     Text(
                       '${transaction.type == TransactionType.incoming ? '+' : '-'}${transaction.fiatAmount!.toStringAsFixed(2)} ${transaction.fiatCurrency}',
                       style: TextStyle(
-                        color: _getTransactionIconColor(transaction).withValues(alpha: 0.8),
+                        color: iconColor.withValues(alpha: 0.8),
                         fontSize: 16,
                         fontWeight: FontWeight.w600,
                       ),
@@ -730,7 +723,7 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
                     Text(
                       '${transaction.originalFiatAmount!.toStringAsFixed(2)} ${transaction.originalFiatCurrency}',
                       style: TextStyle(
-                        color: Colors.white.withValues(alpha: 0.7),
+                        color: t.textPrimary.withValues(alpha: 0.7),
                         fontSize: 15,
                         fontWeight: FontWeight.w500,
                       ),
@@ -745,6 +738,8 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
   }
 
   void _showTransactionDetails(TransactionInfo transaction) {
+    final t = context.tokens;
+    final iconColor = _getTransactionIconColor(transaction, t);
     showModalBottomSheet(
       context: context,
       backgroundColor: Colors.transparent,
@@ -754,9 +749,9 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
         maxChildSize: 0.9,
         minChildSize: 0.5,
         builder: (context, scrollController) => Container(
-          decoration: const BoxDecoration(
-            color: Color(0xFF1A1D47),
-            borderRadius: BorderRadius.only(
+          decoration: BoxDecoration(
+            color: t.dialogBackground,
+            borderRadius: const BorderRadius.only(
               topLeft: Radius.circular(20),
               topRight: Radius.circular(20),
             ),
@@ -775,12 +770,12 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
                   width: 48,
                   height: 48,
                   decoration: BoxDecoration(
-                    color: _getTransactionIconColor(transaction).withValues(alpha: 0.2),
+                    color: iconColor.withValues(alpha: 0.2),
                     borderRadius: BorderRadius.circular(12),
                   ),
                   child: Icon(
                     _getTransactionIcon(transaction),
-                    color: _getTransactionIconColor(transaction),
+                    color: iconColor,
                     size: 24,
                   ),
                 ),
@@ -791,8 +786,8 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
                     children: [
                       Text(
                         _getTransactionStatusLabel(transaction),
-                        style: const TextStyle(
-                          color: Colors.white,
+                        style: TextStyle(
+                          color: t.textPrimary,
                           fontSize: 18,
                           fontWeight: FontWeight.w600,
                         ),
@@ -803,7 +798,7 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
                           Text(
                             transaction.displayAmount.split('\n').first, // Show sats amount
                             style: TextStyle(
-                              color: _getTransactionIconColor(transaction),
+                              color: iconColor,
                               fontSize: 24,
                               fontWeight: FontWeight.w700,
                             ),
@@ -812,7 +807,7 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
                             Text(
                               '${transaction.type == TransactionType.incoming ? '+' : '-'}${transaction.fiatAmount!.toStringAsFixed(2)} ${transaction.fiatCurrency}',
                               style: TextStyle(
-                                color: _getTransactionIconColor(transaction).withValues(alpha: 0.8),
+                                color: iconColor.withValues(alpha: 0.8),
                                 fontSize: 18,
                                 fontWeight: FontWeight.w500,
                               ),
@@ -821,7 +816,7 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
                             Text(
                               '${transaction.originalFiatAmount!.toStringAsFixed(2)} ${transaction.originalFiatCurrency}',
                               style: TextStyle(
-                                color: Colors.white.withValues(alpha: 0.6),
+                                color: t.textSecondary,
                                 fontSize: 16,
                                 fontWeight: FontWeight.w400,
                               ),
@@ -833,37 +828,37 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
                 ),
               ],
             ),
-            
+
             const SizedBox(height: 24),
-            
-            _buildDetailRow('Date', transaction.formattedDate),
-            _buildDetailRow('Description', transaction.memo.isEmpty ? AppLocalizations.of(context)!.no_description_text : transaction.memo),
+
+            _buildDetailRow(t, 'Date', transaction.formattedDate),
+            _buildDetailRow(t, 'Description', transaction.memo.isEmpty ? AppLocalizations.of(context)!.no_description_text : transaction.memo),
             if (transaction.originalFiatAmount != null && transaction.originalFiatCurrency != null) ...[
-              _buildDetailRow('Original Amount', '${transaction.originalFiatAmount!.toStringAsFixed(2)} ${transaction.originalFiatCurrency}'),
+              _buildDetailRow(t, 'Original Amount', '${transaction.originalFiatAmount!.toStringAsFixed(2)} ${transaction.originalFiatCurrency}'),
               if (transaction.originalFiatRate != null)
-                _buildDetailRow('Original Rate', '${transaction.originalFiatRate!.toStringAsFixed(4)} sats/${transaction.originalFiatCurrency}'),
+                _buildDetailRow(t, 'Original Rate', '${transaction.originalFiatRate!.toStringAsFixed(4)} sats/${transaction.originalFiatCurrency}'),
             ],
             if (transaction.fiatAmount != null && transaction.fiatCurrency != null) ...[
-              _buildDetailRow('Wallet Amount', '${transaction.fiatAmount!.toStringAsFixed(2)} ${transaction.fiatCurrency}'),
+              _buildDetailRow(t, 'Wallet Amount', '${transaction.fiatAmount!.toStringAsFixed(2)} ${transaction.fiatCurrency}'),
               if (transaction.fiatRate != null)
-                _buildDetailRow('Wallet Rate', '${transaction.fiatRate!.toStringAsFixed(2)} sats/${transaction.fiatCurrency}'),
+                _buildDetailRow(t, 'Wallet Rate', '${transaction.fiatRate!.toStringAsFixed(2)} sats/${transaction.fiatCurrency}'),
             ],
             if (transaction.paymentHash != null)
-              _buildDetailRow('Hash', transaction.paymentHash!, copyable: true),
+              _buildDetailRow(t, 'Hash', transaction.paymentHash!, copyable: true),
             if (transaction.fee != null)
-              _buildDetailRow('Fee', '${transaction.fee} msat'),
-            _buildDetailRow(AppLocalizations.of(context)!.invoice_status_label, _getTransactionStatus(transaction)),
-            
+              _buildDetailRow(t, 'Fee', '${transaction.fee} msat'),
+            _buildDetailRow(t, AppLocalizations.of(context)!.invoice_status_label, _getTransactionStatus(transaction)),
+
             const SizedBox(height: 16),
-            
+
             // Close button
             SizedBox(
               width: double.infinity,
               child: ElevatedButton(
                 onPressed: () => Navigator.pop(context),
                 style: ElevatedButton.styleFrom(
-                  backgroundColor: const Color(0xFF2D3FE7),
-                  foregroundColor: Colors.white,
+                  backgroundColor: t.accentSolid,
+                  foregroundColor: t.accentForeground,
                   padding: const EdgeInsets.symmetric(vertical: 16),
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(12),
@@ -881,7 +876,7 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
     );
   }
 
-  Widget _buildDetailRow(String label, String value, {bool copyable = false}) {
+  Widget _buildDetailRow(AppTokens t, String label, String value, {bool copyable = false}) {
     return Padding(
       padding: const EdgeInsets.only(bottom: 12),
       child: Row(
@@ -892,7 +887,7 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
             child: Text(
               label,
               style: TextStyle(
-                color: Colors.white.withValues(alpha: 0.6),
+                color: t.textSecondary,
                 fontSize: 14,
               ),
             ),
@@ -908,7 +903,7 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
               child: Text(
                 value,
                 style: TextStyle(
-                  color: Colors.white,
+                  color: t.textPrimary,
                   fontSize: 14,
                   fontWeight: FontWeight.w500,
                   decoration: copyable ? TextDecoration.underline : null,

--- a/lib/screens/7ln_address_screen.dart
+++ b/lib/screens/7ln_address_screen.dart
@@ -6,6 +6,7 @@ import '../providers/auth_provider.dart';
 import '../providers/wallet_provider.dart';
 import '../models/ln_address.dart';
 import '../l10n/generated/app_localizations.dart';
+import '../theme/app_tokens.dart';
 
 class LNAddressScreen extends StatefulWidget {
   const LNAddressScreen({super.key});
@@ -29,14 +30,13 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
   }
 
   void _initializeScreen() {
-    final authProvider = context.read<AuthProvider>();
     final walletProvider = context.read<WalletProvider>();
     final lnAddressProvider = context.read<LNAddressProvider>();
 
     if (walletProvider.primaryWallet != null) {
       final wallet = walletProvider.primaryWallet!;
       _selectedWalletId = wallet.id;
-      
+
       lnAddressProvider.setAuthHeaders(wallet.inKey, wallet.adminKey);
       lnAddressProvider.setCurrentWallet(_selectedWalletId!);
     }
@@ -52,46 +52,33 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final t = context.tokens;
     return Scaffold(
       backgroundColor: Colors.transparent,
       body: LayoutBuilder(
         builder: (context, constraints) {
-          final screenWidth = constraints.maxWidth;
-          final isMobile = screenWidth < 768;
-          
           return Container(
-            decoration: const BoxDecoration(
-              gradient: LinearGradient(
-                begin: Alignment.topLeft,
-                end: Alignment.bottomRight,
-                colors: [
-                  Color(0xFF0F1419),
-                  Color(0xFF1A1D47),
-                  Color(0xFF2D3FE7),
-                ],
-                stops: [0.0, 0.5, 1.0],
-              ),
-            ),
+            decoration: BoxDecoration(gradient: t.backgroundGradient),
             child: SafeArea(
               child: Column(
                 children: [
-                  
-                  _buildHeader(),
-                  
-                  
+
+                  _buildHeader(t),
+
+
                   Expanded(
                     child: Consumer3<LNAddressProvider, WalletProvider, AuthProvider>(
                       builder: (context, lnAddressProvider, walletProvider, authProvider, child) {
                         return Column(
                           children: [
-                            
-                            _buildWalletInfo(walletProvider, authProvider),
-                            
-                            
+
+                            _buildWalletInfo(walletProvider, authProvider, t),
+
+
                             Expanded(
                               child: _showCreateForm
-                                  ? _buildCreateForm(lnAddressProvider, walletProvider)
-                                  : _buildAddressList(lnAddressProvider),
+                                  ? _buildCreateForm(lnAddressProvider, walletProvider, t)
+                                  : _buildAddressList(lnAddressProvider, t),
                             ),
                           ],
                         );
@@ -107,18 +94,18 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
     );
   }
 
-  Widget _buildHeader() {
+  Widget _buildHeader(AppTokens t) {
     return Container(
       padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
       child: Row(
         children: [
-          
+
           Container(
             decoration: BoxDecoration(
-              color: Colors.white.withValues(alpha: 0.1),
+              color: t.outline,
               borderRadius: BorderRadius.circular(12),
               border: Border.all(
-                color: Colors.white.withValues(alpha: 0.2),
+                color: t.outlineStrong,
                 width: 1,
               ),
             ),
@@ -127,39 +114,39 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
               child: InkWell(
                 borderRadius: BorderRadius.circular(12),
                 onTap: () => Navigator.pop(context),
-                child: const Padding(
-                  padding: EdgeInsets.all(12),
+                child: Padding(
+                  padding: const EdgeInsets.all(12),
                   child: Icon(
                     Icons.arrow_back,
-                    color: Colors.white,
+                    color: t.textPrimary,
                     size: 20,
                   ),
                 ),
               ),
             ),
           ),
-          
+
           const SizedBox(width: 16),
-          
+
           // Title
           Expanded(
             child: Text(
               AppLocalizations.of(context)!.lightning_address_title,
               style: TextStyle(
-                color: Colors.white,
+                color: t.textPrimary,
                 fontSize: 24,
                 fontWeight: FontWeight.w600,
               ),
             ),
           ),
-          
-          
+
+
           Container(
             decoration: BoxDecoration(
-              color: Colors.white.withValues(alpha: 0.1),
+              color: t.outline,
               borderRadius: BorderRadius.circular(12),
               border: Border.all(
-                color: Colors.white.withValues(alpha: 0.2),
+                color: t.outlineStrong,
                 width: 1,
               ),
             ),
@@ -168,11 +155,11 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
               child: InkWell(
                 borderRadius: BorderRadius.circular(12),
                 onTap: _refreshAddresses,
-                child: const Padding(
-                  padding: EdgeInsets.all(12),
+                child: Padding(
+                  padding: const EdgeInsets.all(12),
                   child: Icon(
                     Icons.refresh,
-                    color: Colors.white,
+                    color: t.textPrimary,
                     size: 20,
                   ),
                 ),
@@ -184,7 +171,7 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
     );
   }
 
-  Widget _buildWalletInfo(WalletProvider walletProvider, AuthProvider authProvider) {
+  Widget _buildWalletInfo(WalletProvider walletProvider, AuthProvider authProvider, AppTokens t) {
     final serverDomain = authProvider.sessionData?.serverUrl
         .replaceAll('https://', '')
         .replaceAll('http://', '') ?? 'your-server.com';
@@ -194,10 +181,10 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
       child: Container(
         padding: const EdgeInsets.all(20),
         decoration: BoxDecoration(
-          color: Colors.white.withValues(alpha: 0.08),
+          color: t.surface,
           borderRadius: BorderRadius.circular(16),
           border: Border.all(
-            color: Colors.white.withValues(alpha: 0.1),
+            color: t.outline,
             width: 1,
           ),
         ),
@@ -206,17 +193,17 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
           children: [
             Row(
               children: [
-                const Icon(
+                Icon(
                   Icons.account_balance_wallet,
-                  color: Colors.white,
+                  color: t.textPrimary,
                   size: 20,
                 ),
                 const SizedBox(width: 12),
                 Expanded(
                   child: Text(
                     walletProvider.primaryWallet?.name ?? AppLocalizations.of(context)!.wallet_title,
-                    style: const TextStyle(
-                      color: Colors.white,
+                    style: TextStyle(
+                      color: t.textPrimary,
                       fontSize: 16,
                       fontWeight: FontWeight.w600,
                     ),
@@ -228,7 +215,7 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
             Text(
               '${AppLocalizations.of(context)!.server_settings_title}: $serverDomain',
               style: TextStyle(
-                color: Colors.white.withValues(alpha: 0.7),
+                color: t.textPrimary.withValues(alpha: 0.7),
                 fontSize: 14,
               ),
             ),
@@ -238,11 +225,11 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
     );
   }
 
-  Widget _buildAddressList(LNAddressProvider lnAddressProvider) {
+  Widget _buildAddressList(LNAddressProvider lnAddressProvider, AppTokens t) {
     if (lnAddressProvider.isLoading) {
-      return const Center(
+      return Center(
         child: CircularProgressIndicator(
-          valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+          valueColor: AlwaysStoppedAnimation<Color>(t.textPrimary),
         ),
       );
     }
@@ -254,26 +241,26 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
           child: Container(
             padding: const EdgeInsets.all(20),
             decoration: BoxDecoration(
-              color: Colors.white.withValues(alpha: 0.08),
+              color: t.surface,
               borderRadius: BorderRadius.circular(16),
               border: Border.all(
-                color: Colors.white.withValues(alpha: 0.1),
+                color: t.outline,
                 width: 1,
               ),
             ),
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                const Icon(
+                Icon(
                   Icons.error_outline,
-                  color: Colors.red,
+                  color: t.statusUnhealthy,
                   size: 48,
                 ),
                 const SizedBox(height: 16),
                 Text(
                   AppLocalizations.of(context)!.loading_address_error_prefix,
                   style: TextStyle(
-                    color: Colors.white,
+                    color: t.textPrimary,
                     fontSize: 18,
                     fontWeight: FontWeight.w600,
                   ),
@@ -282,7 +269,7 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
                 Text(
                   lnAddressProvider.error!,
                   style: TextStyle(
-                    color: Colors.white.withValues(alpha: 0.8),
+                    color: t.textPrimary.withValues(alpha: 0.8),
                     fontSize: 14,
                   ),
                   textAlign: TextAlign.center,
@@ -291,6 +278,7 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
                 _buildPrimaryButton(
                   text: AppLocalizations.of(context)!.connect_button,
                   onPressed: _refreshAddresses,
+                  t: t,
                 ),
               ],
             ),
@@ -309,10 +297,10 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
                 child: Container(
                   padding: const EdgeInsets.all(20),
                   decoration: BoxDecoration(
-                    color: Colors.white.withValues(alpha: 0.08),
+                    color: t.surface,
                     borderRadius: BorderRadius.circular(16),
                     border: Border.all(
-                      color: Colors.white.withValues(alpha: 0.1),
+                      color: t.outline,
                       width: 1,
                     ),
                   ),
@@ -321,14 +309,14 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
                     children: [
                       Icon(
                         Icons.alternate_email,
-                        color: Colors.white.withValues(alpha: 0.6),
+                        color: t.textSecondary,
                         size: 64,
                       ),
                       const SizedBox(height: 16),
                       Text(
                         AppLocalizations.of(context)!.not_available_text,
                         style: TextStyle(
-                          color: Colors.white,
+                          color: t.textPrimary,
                           fontSize: 18,
                           fontWeight: FontWeight.w600,
                         ),
@@ -337,7 +325,7 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
                       Text(
                         AppLocalizations.of(context)!.lightning_address_title,
                         style: TextStyle(
-                          color: Colors.white.withValues(alpha: 0.7),
+                          color: t.textPrimary.withValues(alpha: 0.7),
                           fontSize: 14,
                         ),
                       ),
@@ -356,12 +344,12 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
                 final address = lnAddressProvider.currentWalletAddresses[index];
                 return Container(
                   margin: const EdgeInsets.only(bottom: 12),
-                  child: _buildAddressItem(address, lnAddressProvider),
+                  child: _buildAddressItem(address, lnAddressProvider, t),
                 );
               },
             ),
           ),
-        
+
         if (!_showCreateForm)
           Container(
             padding: const EdgeInsets.all(16),
@@ -375,6 +363,7 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
                   });
                 },
                 icon: Icons.add,
+                t: t,
               ),
             ),
           ),
@@ -382,14 +371,16 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
     );
   }
 
-  Widget _buildAddressItem(LNAddress address, LNAddressProvider lnAddressProvider) {
+  Widget _buildAddressItem(LNAddress address, LNAddressProvider lnAddressProvider, AppTokens t) {
+    // Amber star for default address — semantic indicator unique to this screen, kept literal
+    const amber = Colors.amber;
     return Container(
       padding: const EdgeInsets.all(20),
       decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.08),
+        color: t.surface,
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
-          color: Colors.white.withValues(alpha: 0.1),
+          color: t.outline,
           width: 1,
         ),
       ),
@@ -398,9 +389,9 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
         children: [
           Row(
             children: [
-              const Icon(
+              Icon(
                 Icons.alternate_email,
-                color: Color(0xFF4C63F7),
+                color: t.accentSolid,
                 size: 20,
               ),
               const SizedBox(width: 12),
@@ -413,8 +404,8 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
                         Expanded(
                           child: Text(
                             address.fullAddress,
-                            style: const TextStyle(
-                              color: Colors.white,
+                            style: TextStyle(
+                              color: t.textPrimary,
                               fontSize: 16,
                               fontWeight: FontWeight.w600,
                             ),
@@ -426,7 +417,7 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
                           const SizedBox(width: 8),
                           const Icon(
                             Icons.star,
-                            color: Colors.amber,
+                            color: amber,
                             size: 16,
                           ),
                         ],
@@ -436,8 +427,8 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
                       const SizedBox(height: 4),
                       Text(
                         AppLocalizations.of(context)!.lightning_address_title,
-                        style: TextStyle(
-                          color: Colors.amber,
+                        style: const TextStyle(
+                          color: amber,
                           fontSize: 11,
                           fontWeight: FontWeight.w500,
                         ),
@@ -448,7 +439,7 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
               ),
               PopupMenuButton<String>(
                 onSelected: (value) => _handleAddressAction(value, address, lnAddressProvider),
-                iconColor: Colors.white,
+                iconColor: t.textPrimary,
                 itemBuilder: (context) => [
                   PopupMenuItem(
                     value: 'copy',
@@ -467,12 +458,12 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
                         Icon(
                           address.isDefault ? Icons.star : Icons.star_border,
                           size: 18,
-                          color: address.isDefault ? Colors.amber : null,
+                          color: address.isDefault ? amber : null,
                         ),
                         const SizedBox(width: 8),
                         Expanded(
                           child: Text(
-                            address.isDefault 
+                            address.isDefault
                               ? AppLocalizations.of(context)!.lightning_address_is_default
                               : AppLocalizations.of(context)!.lightning_address_set_default,
                             overflow: TextOverflow.ellipsis,
@@ -486,11 +477,11 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
                     value: 'delete',
                     child: Row(
                       children: [
-                        const Icon(Icons.delete, size: 18, color: Colors.red),
+                        Icon(Icons.delete, size: 18, color: t.statusUnhealthy),
                         const SizedBox(width: 8),
                         Text(
-                          AppLocalizations.of(context)!.lightning_address_delete, 
-                          style: const TextStyle(color: Colors.red)
+                          AppLocalizations.of(context)!.lightning_address_delete,
+                          style: TextStyle(color: t.statusUnhealthy),
                         ),
                       ],
                     ),
@@ -499,42 +490,42 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
               ),
             ],
           ),
-          
+
           if (address.description.isNotEmpty) ...[
             const SizedBox(height: 8),
             Text(
               address.description,
               style: TextStyle(
-                color: Colors.white.withValues(alpha: 0.7),
+                color: t.textPrimary.withValues(alpha: 0.7),
                 fontSize: 14,
               ),
             ),
           ],
-          
+
           const SizedBox(height: 12),
           Row(
             children: [
               Container(
                 padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                 decoration: BoxDecoration(
-                  color: address.isDefault 
-                      ? Colors.amber.withValues(alpha: 0.2)
-                      : (address.isActive 
-                          ? Colors.green.withValues(alpha: 0.2) 
+                  color: address.isDefault
+                      ? amber.withValues(alpha: 0.2)
+                      : (address.isActive
+                          ? t.statusHealthy.withValues(alpha: 0.2)
                           : Colors.grey.withValues(alpha: 0.2)),
                   borderRadius: BorderRadius.circular(6),
                   border: Border.all(
-                    color: address.isDefault 
-                        ? Colors.amber.withValues(alpha: 0.3)
-                        : (address.isActive 
-                            ? Colors.green.withValues(alpha: 0.3) 
+                    color: address.isDefault
+                        ? amber.withValues(alpha: 0.3)
+                        : (address.isActive
+                            ? t.statusHealthy.withValues(alpha: 0.3)
                             : Colors.grey.withValues(alpha: 0.3)),
                   ),
                 ),
                 child: Text(
                   address.isDefault ? AppLocalizations.of(context)!.lightning_address_title : (address.isActive ? AppLocalizations.of(context)!.valid_status : AppLocalizations.of(context)!.not_available_text),
                   style: TextStyle(
-                    color: address.isDefault ? Colors.amber : (address.isActive ? Colors.green : Colors.grey),
+                    color: address.isDefault ? amber : (address.isActive ? t.statusHealthy : Colors.grey),
                     fontSize: 12,
                     fontWeight: FontWeight.w500,
                   ),
@@ -544,7 +535,7 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
               Text(
                 'Created: ${_formatDate(address.createdAt)}',
                 style: TextStyle(
-                  color: Colors.white.withValues(alpha: 0.6),
+                  color: t.textSecondary,
                   fontSize: 12,
                 ),
               ),
@@ -555,7 +546,7 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
     );
   }
 
-  Widget _buildCreateForm(LNAddressProvider lnAddressProvider, WalletProvider walletProvider) {
+  Widget _buildCreateForm(LNAddressProvider lnAddressProvider, WalletProvider walletProvider, AppTokens t) {
     final serverDomain = context.read<AuthProvider>().sessionData?.serverUrl
         .replaceAll('https://', '')
         .replaceAll('http://', '') ?? 'your-server.com';
@@ -567,22 +558,22 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            
+
             Container(
               padding: const EdgeInsets.all(20),
               decoration: BoxDecoration(
-                color: Colors.white.withValues(alpha: 0.08),
+                color: t.surface,
                 borderRadius: BorderRadius.circular(16),
                 border: Border.all(
-                  color: Colors.white.withValues(alpha: 0.1),
+                  color: t.outline,
                   width: 1,
                 ),
               ),
               child: Row(
                 children: [
-                  const Icon(
+                  Icon(
                     Icons.add_circle_outline,
-                    color: Color(0xFF4C63F7),
+                    color: t.accentSolid,
                     size: 24,
                   ),
                   const SizedBox(width: 12),
@@ -590,7 +581,7 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
                     child: Text(
                       AppLocalizations.of(context)!.lightning_address_title,
                       style: TextStyle(
-                        color: Colors.white,
+                        color: t.textPrimary,
                         fontSize: 18,
                         fontWeight: FontWeight.w600,
                       ),
@@ -598,7 +589,7 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
                   ),
                   Container(
                     decoration: BoxDecoration(
-                      color: Colors.white.withValues(alpha: 0.1),
+                      color: t.outline,
                       borderRadius: BorderRadius.circular(8),
                     ),
                     child: Material(
@@ -611,11 +602,11 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
                             _usernameController.clear();
                           });
                         },
-                        child: const Padding(
-                          padding: EdgeInsets.all(8),
+                        child: Padding(
+                          padding: const EdgeInsets.all(8),
                           child: Icon(
                             Icons.close,
-                            color: Colors.white,
+                            color: t.textPrimary,
                             size: 20,
                           ),
                         ),
@@ -625,28 +616,28 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
                 ],
               ),
             ),
-            
+
             const SizedBox(height: 16),
-            
-            
+
+
             Container(
               padding: const EdgeInsets.all(20),
               decoration: BoxDecoration(
-                color: Colors.white.withValues(alpha: 0.08),
+                color: t.surface,
                 borderRadius: BorderRadius.circular(16),
                 border: Border.all(
-                  color: Colors.white.withValues(alpha: 0.1),
+                  color: t.outline,
                   width: 1,
                 ),
               ),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  
-                  const Text(
+
+                  Text(
                     'Wallet:',
                     style: TextStyle(
-                      color: Colors.white,
+                      color: t.textPrimary,
                       fontSize: 16,
                       fontWeight: FontWeight.w600,
                     ),
@@ -656,35 +647,35 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
                     width: double.infinity,
                     padding: const EdgeInsets.all(16),
                     decoration: BoxDecoration(
-                      color: Colors.white.withValues(alpha: 0.05),
+                      color: t.inputFill,
                       borderRadius: BorderRadius.circular(12),
                       border: Border.all(
-                        color: Colors.white.withValues(alpha: 0.1),
+                        color: t.outline,
                       ),
                     ),
                     child: DropdownButtonHideUnderline(
                       child: DropdownButton<String>(
                         value: _selectedWalletId,
                         isExpanded: true,
-                        dropdownColor: const Color(0xFF1A1D47),
-                        style: const TextStyle(color: Colors.white),
-                        icon: const Icon(Icons.arrow_drop_down, color: Colors.white),
+                        dropdownColor: t.dialogBackground,
+                        style: TextStyle(color: t.textPrimary),
+                        icon: Icon(Icons.arrow_drop_down, color: t.textPrimary),
                         items: walletProvider.wallets.map((wallet) {
                           return DropdownMenuItem<String>(
                             value: wallet.id,
                             child: Row(
                               children: [
-                                const Icon(
+                                Icon(
                                   Icons.account_balance_wallet,
-                                  color: Color(0xFF4C63F7),
+                                  color: t.accentSolid,
                                   size: 18,
                                 ),
                                 const SizedBox(width: 12),
                                 Expanded(
                                   child: Text(
                                     wallet.name,
-                                    style: const TextStyle(
-                                      color: Colors.white,
+                                    style: TextStyle(
+                                      color: t.textPrimary,
                                       fontSize: 16,
                                     ),
                                     overflow: TextOverflow.ellipsis,
@@ -700,8 +691,8 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
                             setState(() {
                               _selectedWalletId = newValue;
                             });
-                            
-                            
+
+
                             final selectedWallet = walletProvider.wallets.firstWhere(
                               (w) => w.id == newValue,
                             );
@@ -712,49 +703,49 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
                       ),
                     ),
                   ),
-                  
+
                   const SizedBox(height: 20),
-                  
+
                   // Username input
-                  const Text(
+                  Text(
                     'Lightning Address:',
                     style: TextStyle(
-                      color: Colors.white,
+                      color: t.textPrimary,
                       fontSize: 16,
                       fontWeight: FontWeight.w600,
                     ),
                   ),
                   const SizedBox(height: 8),
-                  
+
                   Row(
                     children: [
                       Expanded(
                         child: TextFormField(
                           controller: _usernameController,
-                          style: const TextStyle(color: Colors.white),
+                          style: TextStyle(color: t.textPrimary),
                           decoration: InputDecoration(
                             hintText: 'satoshi',
                             hintStyle: TextStyle(
-                              color: Colors.white.withValues(alpha: 0.5),
+                              color: t.textSecondary,
                             ),
                             filled: true,
-                            fillColor: Colors.white.withValues(alpha: 0.05),
+                            fillColor: t.inputFill,
                             border: OutlineInputBorder(
                               borderRadius: BorderRadius.circular(12),
                               borderSide: BorderSide(
-                                color: Colors.white.withValues(alpha: 0.1),
+                                color: t.outline,
                               ),
                             ),
                             enabledBorder: OutlineInputBorder(
                               borderRadius: BorderRadius.circular(12),
                               borderSide: BorderSide(
-                                color: Colors.white.withValues(alpha: 0.1),
+                                color: t.outline,
                               ),
                             ),
                             focusedBorder: OutlineInputBorder(
                               borderRadius: BorderRadius.circular(12),
-                              borderSide: const BorderSide(
-                                color: Color(0xFF4C63F7),
+                              borderSide: BorderSide(
+                                color: t.accentSolid,
                               ),
                             ),
                           ),
@@ -774,39 +765,39 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
                       Text(
                         '@$serverDomain',
                         style: TextStyle(
-                          color: Colors.white.withValues(alpha: 0.7),
+                          color: t.textPrimary.withValues(alpha: 0.7),
                           fontSize: 16,
                           fontWeight: FontWeight.w500,
                         ),
                       ),
                     ],
                   ),
-                  
+
                   // Error message
                   if (lnAddressProvider.error != null) ...[
                     const SizedBox(height: 12),
                     Container(
                       padding: const EdgeInsets.all(12),
                       decoration: BoxDecoration(
-                        color: Colors.red.withValues(alpha: 0.1),
+                        color: t.statusUnhealthy.withValues(alpha: 0.1),
                         borderRadius: BorderRadius.circular(8),
                         border: Border.all(
-                          color: Colors.red.withValues(alpha: 0.3),
+                          color: t.statusUnhealthy.withValues(alpha: 0.3),
                         ),
                       ),
                       child: Row(
                         children: [
-                          const Icon(
+                          Icon(
                             Icons.error_outline,
-                            color: Colors.red,
+                            color: t.statusUnhealthy,
                             size: 16,
                           ),
                           const SizedBox(width: 8),
                           Expanded(
                             child: Text(
                               lnAddressProvider.error!,
-                              style: const TextStyle(
-                                color: Colors.red,
+                              style: TextStyle(
+                                color: t.statusUnhealthy,
                                 fontSize: 14,
                               ),
                             ),
@@ -815,9 +806,9 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
                       ),
                     ),
                   ],
-                  
+
                   const SizedBox(height: 24),
-                  
+
                   Row(
                     children: [
                       Expanded(
@@ -829,6 +820,7 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
                               _usernameController.clear();
                             });
                           },
+                          t: t,
                         ),
                       ),
                       const SizedBox(width: 12),
@@ -836,6 +828,7 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
                         child: _buildPrimaryButton(
                           text: lnAddressProvider.isCreating ? AppLocalizations.of(context)!.loading_text : AppLocalizations.of(context)!.connect_button,
                           onPressed: lnAddressProvider.isCreating ? null : _createAddress,
+                          t: t,
                         ),
                       ),
                     ],
@@ -852,13 +845,14 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
   Widget _buildPrimaryButton({
     required String text,
     required VoidCallback? onPressed,
+    required AppTokens t,
     IconData? icon,
   }) {
     return ElevatedButton(
       onPressed: onPressed,
       style: ElevatedButton.styleFrom(
-        backgroundColor: const Color(0xFF2D3FE7),
-        foregroundColor: Colors.white,
+        backgroundColor: t.accentSolid,
+        foregroundColor: t.accentForeground,
         padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(12),
@@ -887,13 +881,14 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
   Widget _buildSecondaryButton({
     required String text,
     required VoidCallback? onPressed,
+    required AppTokens t,
   }) {
     return OutlinedButton(
       onPressed: onPressed,
       style: OutlinedButton.styleFrom(
-        foregroundColor: Colors.white,
+        foregroundColor: t.textPrimary,
         side: BorderSide(
-          color: Colors.white.withValues(alpha: 0.3),
+          color: t.textPrimary.withValues(alpha: 0.3),
         ),
         padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
         shape: RoundedRectangleBorder(
@@ -917,7 +912,7 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text('${address.fullAddress} ${AppLocalizations.of(context)!.address_copied_message}'),
-            backgroundColor: Colors.green,
+            backgroundColor: context.tokens.statusHealthy,
             behavior: SnackBarBehavior.floating,
           ),
         );
@@ -936,13 +931,13 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
       // If already default, do nothing
       return;
     }
-    
+
     final success = await lnAddressProvider.setAsDefault(address.id);
     if (success && mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text('${address.fullAddress} ${AppLocalizations.of(context)!.lightning_address_title}'),
-          backgroundColor: Colors.green,
+          backgroundColor: context.tokens.statusHealthy,
           behavior: SnackBarBehavior.floating,
         ),
       );
@@ -950,17 +945,18 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
   }
 
   void _showDeleteConfirmation(LNAddress address, LNAddressProvider lnAddressProvider) {
+    final t = context.tokens;
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
-        backgroundColor: const Color(0xFF1A1D47),
+        backgroundColor: t.dialogBackground,
         title: Text(
           AppLocalizations.of(context)!.lightning_address_title,
-          style: TextStyle(color: Colors.white),
+          style: TextStyle(color: t.textPrimary),
         ),
         content: Text(
           'Are you sure you want to delete ${address.fullAddress}?',
-          style: const TextStyle(color: Colors.white),
+          style: TextStyle(color: t.textPrimary),
         ),
         actions: [
           TextButton(
@@ -975,13 +971,13 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
                 ScaffoldMessenger.of(context).showSnackBar(
                   SnackBar(
                     content: Text(AppLocalizations.of(context)!.lightning_address_title),
-                    backgroundColor: Colors.green,
+                    backgroundColor: context.tokens.statusHealthy,
                     behavior: SnackBarBehavior.floating,
                   ),
                 );
               }
             },
-            child: const Text('Delete', style: TextStyle(color: Colors.red)),
+            child: Text('Delete', style: TextStyle(color: t.statusUnhealthy)),
           ),
         ],
       ),
@@ -993,12 +989,12 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
     if (_selectedWalletId == null) return;
 
     context.read<LNAddressProvider>().clearError();
-    
+
     final walletProvider = context.read<WalletProvider>();
     final selectedWallet = walletProvider.wallets.firstWhere(
       (w) => w.id == _selectedWalletId!,
     );
-    
+
     final success = await context.read<LNAddressProvider>().createLNAddress(
       username: _usernameController.text.trim().toLowerCase(),
       walletId: _selectedWalletId!,
@@ -1011,11 +1007,11 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
         _showCreateForm = false;
         _usernameController.clear();
       });
-      
+
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(AppLocalizations.of(context)!.lightning_address_title),
-          backgroundColor: Colors.green,
+          backgroundColor: context.tokens.statusHealthy,
           behavior: SnackBarBehavior.floating,
         ),
       );

--- a/lib/screens/7ln_address_screen.dart
+++ b/lib/screens/7ln_address_screen.dart
@@ -102,10 +102,10 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
 
           Container(
             decoration: BoxDecoration(
-              color: t.outline,
+              color: t.surface,
               borderRadius: BorderRadius.circular(12),
               border: Border.all(
-                color: t.outlineStrong,
+                color: t.outline,
                 width: 1,
               ),
             ),
@@ -143,10 +143,10 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
 
           Container(
             decoration: BoxDecoration(
-              color: t.outline,
+              color: t.surface,
               borderRadius: BorderRadius.circular(12),
               border: Border.all(
-                color: t.outlineStrong,
+                color: t.outline,
                 width: 1,
               ),
             ),
@@ -512,20 +512,20 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
                       ? amber.withValues(alpha: 0.2)
                       : (address.isActive
                           ? t.statusHealthy.withValues(alpha: 0.2)
-                          : Colors.grey.withValues(alpha: 0.2)),
+                          : t.outline),
                   borderRadius: BorderRadius.circular(6),
                   border: Border.all(
                     color: address.isDefault
                         ? amber.withValues(alpha: 0.3)
                         : (address.isActive
                             ? t.statusHealthy.withValues(alpha: 0.3)
-                            : Colors.grey.withValues(alpha: 0.3)),
+                            : t.outlineStrong),
                   ),
                 ),
                 child: Text(
                   address.isDefault ? AppLocalizations.of(context)!.lightning_address_title : (address.isActive ? AppLocalizations.of(context)!.valid_status : AppLocalizations.of(context)!.not_available_text),
                   style: TextStyle(
-                    color: address.isDefault ? amber : (address.isActive ? t.statusHealthy : Colors.grey),
+                    color: address.isDefault ? amber : (address.isActive ? t.statusHealthy : t.textSecondary),
                     fontSize: 12,
                     fontWeight: FontWeight.w500,
                   ),
@@ -589,8 +589,9 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
                   ),
                   Container(
                     decoration: BoxDecoration(
-                      color: t.outline,
+                      color: t.surface,
                       borderRadius: BorderRadius.circular(8),
+                      border: Border.all(color: t.outline, width: 1),
                     ),
                     child: Material(
                       color: Colors.transparent,

--- a/lib/screens/7ln_address_screen.dart
+++ b/lib/screens/7ln_address_screen.dart
@@ -937,7 +937,7 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
     if (success && mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('${address.fullAddress} ${AppLocalizations.of(context)!.lightning_address_title}'),
+          content: Text(AppLocalizations.of(context)!.lightning_address_set_default_success(address.fullAddress)),
           backgroundColor: context.tokens.statusHealthy,
           behavior: SnackBarBehavior.floating,
         ),
@@ -952,11 +952,11 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
       builder: (context) => AlertDialog(
         backgroundColor: t.dialogBackground,
         title: Text(
-          AppLocalizations.of(context)!.lightning_address_title,
+          AppLocalizations.of(context)!.lightning_address_delete_title,
           style: TextStyle(color: t.textPrimary),
         ),
         content: Text(
-          'Are you sure you want to delete ${address.fullAddress}?',
+          AppLocalizations.of(context)!.lightning_address_delete_confirm(address.fullAddress),
           style: TextStyle(color: t.textPrimary),
         ),
         actions: [
@@ -971,14 +971,17 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
               if (success && mounted) {
                 ScaffoldMessenger.of(context).showSnackBar(
                   SnackBar(
-                    content: Text(AppLocalizations.of(context)!.lightning_address_title),
+                    content: Text(AppLocalizations.of(context)!.lightning_address_deleted_success),
                     backgroundColor: context.tokens.statusHealthy,
                     behavior: SnackBarBehavior.floating,
                   ),
                 );
               }
             },
-            child: Text('Delete', style: TextStyle(color: t.statusUnhealthy)),
+            child: Text(
+              AppLocalizations.of(context)!.lightning_address_delete,
+              style: TextStyle(color: t.statusUnhealthy),
+            ),
           ),
         ],
       ),
@@ -1011,7 +1014,7 @@ class _LNAddressScreenState extends State<LNAddressScreen> {
 
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text(AppLocalizations.of(context)!.lightning_address_title),
+          content: Text(AppLocalizations.of(context)!.lightning_address_created_success),
           backgroundColor: context.tokens.statusHealthy,
           behavior: SnackBarBehavior.floating,
         ),

--- a/lib/screens/8settings_screen.dart
+++ b/lib/screens/8settings_screen.dart
@@ -5,6 +5,7 @@ import '../providers/wallet_provider.dart';
 import '../providers/server_provider.dart';
 import '../providers/language_provider.dart';
 import '../l10n/generated/app_localizations.dart';
+import '../theme/app_tokens.dart';
 import '3server_settings_screen.dart';
 
 class SettingsScreen extends StatefulWidget {
@@ -14,9 +15,9 @@ class SettingsScreen extends StatefulWidget {
   State<SettingsScreen> createState() => _SettingsScreenState();
 }
 
-class _SettingsScreenState extends State<SettingsScreen> 
+class _SettingsScreenState extends State<SettingsScreen>
     with TickerProviderStateMixin {
-  
+
   // Animation controllers
   late AnimationController _staggerController;
   late AnimationController _glowController;
@@ -37,13 +38,13 @@ class _SettingsScreenState extends State<SettingsScreen>
       duration: const Duration(milliseconds: 1600),
       vsync: this,
     );
-    
+
     // Glow controller
     _glowController = AnimationController(
       duration: const Duration(milliseconds: 2000),
       vsync: this,
     )..repeat(reverse: true);
-    
+
     // Specific animations
     _headerAnimation = Tween<double>(
       begin: 0.0,
@@ -52,7 +53,7 @@ class _SettingsScreenState extends State<SettingsScreen>
       parent: _staggerController,
       curve: const Interval(0.0, 0.4, curve: Curves.easeOutCubic),
     ));
-    
+
     _contentAnimation = Tween<double>(
       begin: 0.0,
       end: 1.0,
@@ -60,7 +61,7 @@ class _SettingsScreenState extends State<SettingsScreen>
       parent: _staggerController,
       curve: const Interval(0.3, 0.7, curve: Curves.easeOutCubic),
     ));
-    
+
     _glowAnimation = Tween<double>(
       begin: 0.3,
       end: 1.0,
@@ -84,6 +85,7 @@ class _SettingsScreenState extends State<SettingsScreen>
 
   @override
   Widget build(BuildContext context) {
+    final t = context.tokens;
     return Consumer4<AuthProvider, WalletProvider, ServerProvider, LanguageProvider>(
       builder: (context, authProvider, walletProvider, serverProvider, languageProvider, child) {
         return Scaffold(
@@ -91,18 +93,7 @@ class _SettingsScreenState extends State<SettingsScreen>
           body: Container(
             width: double.infinity,
             height: double.infinity,
-            decoration: const BoxDecoration(
-              gradient: LinearGradient(
-                begin: Alignment.topLeft,
-                end: Alignment.bottomRight,
-                colors: [
-                  Color(0xFF0F1419),
-                  Color(0xFF1A1D47),
-                  Color(0xFF2D3FE7),
-                ],
-                stops: [0.0, 0.5, 1.0],
-              ),
-            ),
+            decoration: BoxDecoration(gradient: t.backgroundGradient),
             child: SafeArea(
               child: Column(
                 children: [
@@ -117,12 +108,12 @@ class _SettingsScreenState extends State<SettingsScreen>
                         ).animate(_headerAnimation),
                         child: FadeTransition(
                           opacity: _headerAnimation,
-                          child: _buildHeader(),
+                          child: _buildHeader(t),
                         ),
                       );
                     },
                   ),
-                  
+
                   // Main content
                   Expanded(
                     child: AnimatedBuilder(
@@ -135,7 +126,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                           ).animate(_contentAnimation),
                           child: FadeTransition(
                             opacity: _contentAnimation,
-                            child: _buildContent(authProvider, walletProvider, serverProvider, languageProvider),
+                            child: _buildContent(authProvider, walletProvider, serverProvider, languageProvider, t),
                           ),
                         );
                       },
@@ -150,7 +141,7 @@ class _SettingsScreenState extends State<SettingsScreen>
     );
   }
 
-  Widget _buildHeader() {
+  Widget _buildHeader(AppTokens t) {
     return Container(
       padding: const EdgeInsets.all(24),
       child: Row(
@@ -160,25 +151,25 @@ class _SettingsScreenState extends State<SettingsScreen>
             width: 48,
             height: 48,
             decoration: BoxDecoration(
-              color: Colors.white.withValues(alpha: 0.08),
+              color: t.surface,
               borderRadius: BorderRadius.circular(12),
               border: Border.all(
-                color: Colors.white.withValues(alpha: 0.1),
+                color: t.outline,
                 width: 1,
               ),
             ),
             child: IconButton(
-              icon: const Icon(
+              icon: Icon(
                 Icons.arrow_back,
-                color: Colors.white,
+                color: t.textPrimary,
                 size: 24,
               ),
               onPressed: () => Navigator.pop(context),
             ),
           ),
-          
+
           const SizedBox(width: 16),
-          
+
           // Title with glow
           Expanded(
             child: AnimatedBuilder(
@@ -187,15 +178,14 @@ class _SettingsScreenState extends State<SettingsScreen>
                 return Text(
                   AppLocalizations.of(context)!.settings_title,
                   style: TextStyle(
-                    fontFamily: 'Manrope',
                     fontSize: 24,
                     fontWeight: FontWeight.bold,
-                    color: Colors.white,
+                    color: t.textPrimary,
                     shadows: [
                       Shadow(
                         offset: const Offset(0, 0),
                         blurRadius: 20 + (10 * _glowAnimation.value),
-                        color: const Color(0xFF2D3FE7).withValues(
+                        color: t.accentSolid.withValues(
                           alpha: 0.3 + (0.4 * _glowAnimation.value),
                         ),
                       ),
@@ -210,48 +200,48 @@ class _SettingsScreenState extends State<SettingsScreen>
     );
   }
 
-  Widget _buildContent(AuthProvider authProvider, WalletProvider walletProvider, ServerProvider serverProvider, LanguageProvider languageProvider) {
+  Widget _buildContent(AuthProvider authProvider, WalletProvider walletProvider, ServerProvider serverProvider, LanguageProvider languageProvider, AppTokens t) {
     return SingleChildScrollView(
       padding: const EdgeInsets.symmetric(horizontal: 24),
       child: Column(
         children: [
           // User section
-          _buildUserSection(authProvider),
-          
+          _buildUserSection(authProvider, t),
+
           const SizedBox(height: 24),
-          
+
           // Server section
-          _buildServerSection(authProvider, serverProvider),
-          
+          _buildServerSection(authProvider, serverProvider, t),
+
           const SizedBox(height: 24),
-          
+
           // Wallet section
-          _buildWalletSection(walletProvider),
-          
+          _buildWalletSection(walletProvider, t),
+
           const SizedBox(height: 24),
-          
+
           // Language section
-          _buildLanguageSection(languageProvider),
-          
+          _buildLanguageSection(languageProvider, t),
+
           const SizedBox(height: 24),
-          
+
           // Information section
-          _buildInfoSection(),
-          
+          _buildInfoSection(t),
+
           const SizedBox(height: 32),
         ],
       ),
     );
   }
 
-  Widget _buildUserSection(AuthProvider authProvider) {
+  Widget _buildUserSection(AuthProvider authProvider, AppTokens t) {
     return Container(
       padding: const EdgeInsets.all(24),
       decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.08),
+        color: t.surface,
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
-          color: Colors.white.withValues(alpha: 0.1),
+          color: t.outline,
           width: 1,
         ),
       ),
@@ -264,12 +254,12 @@ class _SettingsScreenState extends State<SettingsScreen>
                 width: 48,
                 height: 48,
                 decoration: BoxDecoration(
-                  color: const Color(0xFF2D3FE7),
+                  color: t.accentSolid,
                   borderRadius: BorderRadius.circular(12),
                 ),
-                child: const Icon(
+                child: Icon(
                   Icons.person,
-                  color: Colors.white,
+                  color: t.accentForeground,
                   size: 24,
                 ),
               ),
@@ -280,10 +270,10 @@ class _SettingsScreenState extends State<SettingsScreen>
                   children: [
                     Text(
                       authProvider.currentUser ?? 'User',
-                      style: const TextStyle(
+                      style: TextStyle(
                         fontSize: 18,
                         fontWeight: FontWeight.w600,
-                        color: Colors.white,
+                        color: t.textPrimary,
                       ),
                     ),
                     const SizedBox(height: 4),
@@ -291,7 +281,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                       AppLocalizations.of(context)!.login_title,
                       style: TextStyle(
                         fontSize: 14,
-                        color: Colors.white.withValues(alpha: 0.7),
+                        color: t.textPrimary.withValues(alpha: 0.7),
                       ),
                     ),
                   ],
@@ -304,14 +294,14 @@ class _SettingsScreenState extends State<SettingsScreen>
     );
   }
 
-  Widget _buildServerSection(AuthProvider authProvider, ServerProvider serverProvider) {
+  Widget _buildServerSection(AuthProvider authProvider, ServerProvider serverProvider, AppTokens t) {
     return Container(
       padding: const EdgeInsets.all(24),
       decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.08),
+        color: t.surface,
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
-          color: Colors.white.withValues(alpha: 0.1),
+          color: t.outline,
           width: 1,
         ),
       ),
@@ -320,18 +310,18 @@ class _SettingsScreenState extends State<SettingsScreen>
         children: [
           Row(
             children: [
-              const Icon(
+              Icon(
                 Icons.dns,
-                color: Color(0xFF4C63F7),
+                color: t.accentSolid,
                 size: 24,
               ),
               const SizedBox(width: 12),
               Text(
                 AppLocalizations.of(context)!.server_settings_title,
-                style: const TextStyle(
+                style: TextStyle(
                   fontSize: 18,
                   fontWeight: FontWeight.w600,
-                  color: Colors.white,
+                  color: t.textPrimary,
                 ),
               ),
             ],
@@ -340,7 +330,7 @@ class _SettingsScreenState extends State<SettingsScreen>
           Container(
             padding: const EdgeInsets.all(16),
             decoration: BoxDecoration(
-              color: Colors.white.withValues(alpha: 0.05),
+              color: t.inputFill,
               borderRadius: BorderRadius.circular(12),
             ),
             child: Column(
@@ -350,16 +340,16 @@ class _SettingsScreenState extends State<SettingsScreen>
                   AppLocalizations.of(context)!.server_settings_title,
                   style: TextStyle(
                     fontSize: 12,
-                    color: Colors.white.withValues(alpha: 0.7),
+                    color: t.textPrimary.withValues(alpha: 0.7),
                   ),
                 ),
                 const SizedBox(height: 4),
                 Text(
                   _extractDomain(authProvider.currentServer ?? ''),
-                  style: const TextStyle(
+                  style: TextStyle(
                     fontSize: 16,
                     fontWeight: FontWeight.w500,
-                    color: Colors.white,
+                    color: t.textPrimary,
                   ),
                 ),
               ],
@@ -378,8 +368,8 @@ class _SettingsScreenState extends State<SettingsScreen>
                 );
               },
               style: ElevatedButton.styleFrom(
-                backgroundColor: const Color(0xFF4C63F7),
-                foregroundColor: Colors.white,
+                backgroundColor: t.accentSolid,
+                foregroundColor: t.accentForeground,
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(12),
                 ),
@@ -399,14 +389,14 @@ class _SettingsScreenState extends State<SettingsScreen>
     );
   }
 
-  Widget _buildWalletSection(WalletProvider walletProvider) {
+  Widget _buildWalletSection(WalletProvider walletProvider, AppTokens t) {
     return Container(
       padding: const EdgeInsets.all(24),
       decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.08),
+        color: t.surface,
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
-          color: Colors.white.withValues(alpha: 0.1),
+          color: t.outline,
           width: 1,
         ),
       ),
@@ -415,18 +405,18 @@ class _SettingsScreenState extends State<SettingsScreen>
         children: [
           Row(
             children: [
-              const Icon(
+              Icon(
                 Icons.account_balance_wallet,
-                color: Color(0xFF5B73FF),
+                color: t.accentBright,
                 size: 24,
               ),
               const SizedBox(width: 12),
               Text(
                 AppLocalizations.of(context)!.wallet_title,
-                style: const TextStyle(
+                style: TextStyle(
                   fontSize: 18,
                   fontWeight: FontWeight.w600,
-                  color: Colors.white,
+                  color: t.textPrimary,
                 ),
               ),
             ],
@@ -436,7 +426,7 @@ class _SettingsScreenState extends State<SettingsScreen>
             Container(
               padding: const EdgeInsets.all(16),
               decoration: BoxDecoration(
-                color: Colors.white.withValues(alpha: 0.05),
+                color: t.inputFill,
                 borderRadius: BorderRadius.circular(12),
               ),
               child: Column(
@@ -446,24 +436,24 @@ class _SettingsScreenState extends State<SettingsScreen>
                     AppLocalizations.of(context)!.wallet_title,
                     style: TextStyle(
                       fontSize: 12,
-                      color: Colors.white.withValues(alpha: 0.7),
+                      color: t.textPrimary.withValues(alpha: 0.7),
                     ),
                   ),
                   const SizedBox(height: 4),
                   Text(
                     walletProvider.primaryWallet!.name,
-                    style: const TextStyle(
+                    style: TextStyle(
                       fontSize: 16,
                       fontWeight: FontWeight.w500,
-                      color: Colors.white,
+                      color: t.textPrimary,
                     ),
                   ),
                   const SizedBox(height: 8),
                   Text(
                     walletProvider.primaryWallet!.balanceFormatted,
-                    style: const TextStyle(
+                    style: TextStyle(
                       fontSize: 14,
-                      color: Color(0xFF5B73FF),
+                      color: t.accentBright,
                       fontWeight: FontWeight.w600,
                     ),
                   ),
@@ -474,26 +464,26 @@ class _SettingsScreenState extends State<SettingsScreen>
             Container(
               padding: const EdgeInsets.all(16),
               decoration: BoxDecoration(
-                color: Colors.orange.withValues(alpha: 0.1),
+                color: t.statusWarning.withValues(alpha: 0.1),
                 borderRadius: BorderRadius.circular(12),
                 border: Border.all(
-                  color: Colors.orange.withValues(alpha: 0.3),
+                  color: t.statusWarning.withValues(alpha: 0.3),
                 ),
               ),
               child: Row(
                 children: [
-                  const Icon(
+                  Icon(
                     Icons.warning,
-                    color: Colors.orange,
+                    color: t.statusWarning,
                     size: 20,
                   ),
                   const SizedBox(width: 8),
                   Expanded(
                     child: Text(
                       AppLocalizations.of(context)!.wallet_title,
-                      style: const TextStyle(
+                      style: TextStyle(
                         fontSize: 14,
-                        color: Colors.orange,
+                        color: t.statusWarning,
                         fontWeight: FontWeight.w500,
                       ),
                     ),
@@ -507,14 +497,14 @@ class _SettingsScreenState extends State<SettingsScreen>
     );
   }
 
-  Widget _buildLanguageSection(LanguageProvider languageProvider) {
+  Widget _buildLanguageSection(LanguageProvider languageProvider, AppTokens t) {
     return Container(
           padding: const EdgeInsets.all(24),
           decoration: BoxDecoration(
-            color: Colors.white.withValues(alpha: 0.08),
+            color: t.surface,
             borderRadius: BorderRadius.circular(16),
             border: Border.all(
-              color: Colors.white.withValues(alpha: 0.1),
+              color: t.outline,
               width: 1,
             ),
           ),
@@ -523,38 +513,38 @@ class _SettingsScreenState extends State<SettingsScreen>
             children: [
               Row(
                 children: [
-                  const Icon(
+                  Icon(
                     Icons.language,
-                    color: Color(0xFF4C63F7),
+                    color: t.accentSolid,
                     size: 24,
                   ),
                   const SizedBox(width: 12),
                   Text(
                     AppLocalizations.of(context)!.language_selector_title,
-                    style: const TextStyle(
+                    style: TextStyle(
                       fontSize: 18,
                       fontWeight: FontWeight.w600,
-                      color: Colors.white,
+                      color: t.textPrimary,
                     ),
                   ),
                 ],
               ),
               const SizedBox(height: 16),
-              
+
               // Language selector
-              _buildLanguageSelector(languageProvider),
+              _buildLanguageSelector(languageProvider, t),
             ],
           ),
         );
   }
 
-  Widget _buildLanguageSelector(LanguageProvider languageProvider) {
+  Widget _buildLanguageSelector(LanguageProvider languageProvider, AppTokens t) {
     return Container(
       decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.05),
+        color: t.inputFill,
         borderRadius: BorderRadius.circular(12),
         border: Border.all(
-          color: Colors.white.withValues(alpha: 0.1),
+          color: t.outline,
           width: 1,
         ),
       ),
@@ -578,17 +568,17 @@ class _SettingsScreenState extends State<SettingsScreen>
                     children: [
                       Text(
                         languageProvider.getCurrentLanguageName(),
-                        style: const TextStyle(
+                        style: TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.w500,
-                          color: Colors.white,
+                          color: t.textPrimary,
                         ),
                       ),
                       Text(
                         AppLocalizations.of(context)!.language_selector_description,
                         style: TextStyle(
                           fontSize: 14,
-                          color: Colors.white.withValues(alpha: 0.7),
+                          color: t.textPrimary.withValues(alpha: 0.7),
                         ),
                       ),
                     ],
@@ -596,7 +586,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                 ),
                 Icon(
                   Icons.keyboard_arrow_right,
-                  color: Colors.white.withValues(alpha: 0.7),
+                  color: t.textPrimary.withValues(alpha: 0.7),
                   size: 20,
                 ),
               ],
@@ -608,13 +598,15 @@ class _SettingsScreenState extends State<SettingsScreen>
   }
 
   void _showLanguageSelector(LanguageProvider languageProvider) {
+    final t = context.tokens;
     showModalBottomSheet(
       context: context,
       backgroundColor: Colors.transparent,
       builder: (modalContext) => Consumer<LanguageProvider>(
         builder: (context, langProvider, child) => Container(
-        decoration: const BoxDecoration(
-          gradient: LinearGradient(
+        decoration: BoxDecoration(
+          // Modal-specific darker gradient kept literal — unique to this sheet
+          gradient: const LinearGradient(
             begin: Alignment.topLeft,
             end: Alignment.bottomRight,
             colors: [
@@ -623,7 +615,7 @@ class _SettingsScreenState extends State<SettingsScreen>
               Color(0xFF0F0F23),
             ],
           ),
-          borderRadius: BorderRadius.only(
+          borderRadius: const BorderRadius.only(
             topLeft: Radius.circular(20),
             topRight: Radius.circular(20),
           ),
@@ -637,24 +629,24 @@ class _SettingsScreenState extends State<SettingsScreen>
               width: 40,
               height: 4,
               decoration: BoxDecoration(
-                color: Colors.white.withValues(alpha: 0.3),
+                color: t.textPrimary.withValues(alpha: 0.3),
                 borderRadius: BorderRadius.circular(2),
               ),
             ),
-            
+
             // Title
             Padding(
               padding: const EdgeInsets.all(20),
               child: Text(
                 AppLocalizations.of(context)!.select_language,
-                style: const TextStyle(
+                style: TextStyle(
                   fontSize: 20,
                   fontWeight: FontWeight.bold,
-                  color: Colors.white,
+                  color: t.textPrimary,
                 ),
               ),
             ),
-            
+
             // Language options
             ...langProvider.getAvailableLanguages().map((language) {
               final isSelected = langProvider.currentLocale.languageCode == language['code'];
@@ -682,14 +674,14 @@ class _SettingsScreenState extends State<SettingsScreen>
                             style: TextStyle(
                               fontSize: 18,
                               fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400,
-                              color: isSelected ? const Color(0xFF4C63F7) : Colors.white,
+                              color: isSelected ? t.accentSolid : t.textPrimary,
                             ),
                           ),
                         ),
                         if (isSelected)
-                          const Icon(
+                          Icon(
                             Icons.check_circle,
-                            color: Color(0xFF4C63F7),
+                            color: t.accentSolid,
                             size: 24,
                           ),
                       ],
@@ -698,7 +690,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                 ),
               );
             }).toList(),
-            
+
             const SizedBox(height: 20),
           ],
         ),
@@ -707,14 +699,14 @@ class _SettingsScreenState extends State<SettingsScreen>
     );
   }
 
-  Widget _buildInfoSection() {
+  Widget _buildInfoSection(AppTokens t) {
     return Container(
       padding: const EdgeInsets.all(24),
       decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.08),
+        color: t.surface,
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
-          color: Colors.white.withValues(alpha: 0.1),
+          color: t.outline,
           width: 1,
         ),
       ),
@@ -723,26 +715,27 @@ class _SettingsScreenState extends State<SettingsScreen>
         children: [
           Row(
             children: [
-              const Icon(
+              Icon(
                 Icons.info,
-                color: Color(0xFF4C63F7),
+                color: t.accentSolid,
                 size: 24,
               ),
               const SizedBox(width: 12),
               Text(
                 AppLocalizations.of(context)!.settings_title,
-                style: const TextStyle(
+                style: TextStyle(
                   fontSize: 18,
                   fontWeight: FontWeight.w600,
-                  color: Colors.white,
+                  color: t.textPrimary,
                 ),
               ),
             ],
           ),
           const SizedBox(height: 16),
-          
+
           // About the app
           _buildSettingItem(
+            t: t,
             icon: Icons.info_outline,
             title: AppLocalizations.of(context)!.settings_title,
             subtitle: AppLocalizations.of(context)!.settings_title,
@@ -750,11 +743,12 @@ class _SettingsScreenState extends State<SettingsScreen>
               _showAboutDialog();
             },
           ),
-          
+
           const SizedBox(height: 16),
-          
+
           // Help
           _buildSettingItem(
+            t: t,
             icon: Icons.help_outline,
             title: AppLocalizations.of(context)!.settings_title,
             subtitle: AppLocalizations.of(context)!.settings_title,
@@ -772,6 +766,7 @@ class _SettingsScreenState extends State<SettingsScreen>
   }
 
   Widget _buildSettingItem({
+    required AppTokens t,
     required IconData icon,
     required String title,
     required String subtitle,
@@ -782,14 +777,14 @@ class _SettingsScreenState extends State<SettingsScreen>
       child: Container(
         padding: const EdgeInsets.all(16),
         decoration: BoxDecoration(
-          color: Colors.white.withValues(alpha: 0.05),
+          color: t.inputFill,
           borderRadius: BorderRadius.circular(12),
         ),
         child: Row(
           children: [
             Icon(
               icon,
-              color: const Color(0xFF5B73FF),
+              color: t.accentBright,
               size: 20,
             ),
             const SizedBox(width: 12),
@@ -799,10 +794,10 @@ class _SettingsScreenState extends State<SettingsScreen>
                 children: [
                   Text(
                     title,
-                    style: const TextStyle(
+                    style: TextStyle(
                       fontSize: 16,
                       fontWeight: FontWeight.w500,
-                      color: Colors.white,
+                      color: t.textPrimary,
                     ),
                   ),
                   const SizedBox(height: 2),
@@ -810,15 +805,15 @@ class _SettingsScreenState extends State<SettingsScreen>
                     subtitle,
                     style: TextStyle(
                       fontSize: 12,
-                      color: Colors.white.withValues(alpha: 0.7),
+                      color: t.textPrimary.withValues(alpha: 0.7),
                     ),
                   ),
                 ],
               ),
             ),
-            const Icon(
+            Icon(
               Icons.chevron_right,
-              color: Colors.white54,
+              color: t.textTertiary,
               size: 20,
             ),
           ],
@@ -828,13 +823,14 @@ class _SettingsScreenState extends State<SettingsScreen>
   }
 
   void _showAboutDialog() {
+    final t = context.tokens;
     final languageProvider = Provider.of<LanguageProvider>(context, listen: false);
     final currentLanguage = languageProvider.currentLocale.languageCode;
-    
+
     String subtitle;
     String description;
     String closeText;
-    
+
     switch (currentLanguage) {
       case 'en':
         subtitle = 'Lightning Wallet';
@@ -872,11 +868,11 @@ class _SettingsScreenState extends State<SettingsScreen>
         closeText = 'Cerrar';
         break;
     }
-    
+
     showDialog(
         context: context,
         builder: (dialogContext) => AlertDialog(
-          backgroundColor: const Color(0xFF1A1D47),
+          backgroundColor: t.dialogBackground,
           title: Row(
             children: [
               Container(
@@ -896,9 +892,9 @@ class _SettingsScreenState extends State<SettingsScreen>
                 ),
               ),
               const SizedBox(width: 12),
-              const Text(
+              Text(
                 'LaChispa',
-                style: TextStyle(color: Colors.white),
+                style: TextStyle(color: t.textPrimary),
               ),
             ],
           ),
@@ -908,8 +904,8 @@ class _SettingsScreenState extends State<SettingsScreen>
             children: [
               Text(
                 subtitle,
-                style: const TextStyle(
-                  color: Colors.white,
+                style: TextStyle(
+                  color: t.textPrimary,
                   fontSize: 16,
                   fontWeight: FontWeight.w600,
                 ),
@@ -917,8 +913,8 @@ class _SettingsScreenState extends State<SettingsScreen>
               const SizedBox(height: 8),
               Text(
                 description,
-                style: const TextStyle(
-                  color: Colors.white70,
+                style: TextStyle(
+                  color: t.textPrimary.withValues(alpha: 0.7),
                   fontSize: 14,
                 ),
               ),
@@ -926,21 +922,21 @@ class _SettingsScreenState extends State<SettingsScreen>
               Container(
                 padding: const EdgeInsets.all(12),
                 decoration: BoxDecoration(
-                  color: const Color(0xFF2D3FE7).withValues(alpha: 0.2),
+                  color: t.accentSolid.withValues(alpha: 0.2),
                   borderRadius: BorderRadius.circular(8),
                 ),
-                child: const Row(
+                child: Row(
                   children: [
                     Icon(
                       Icons.code,
-                      color: Color(0xFF5B73FF),
+                      color: t.accentBright,
                       size: 16,
                     ),
-                    SizedBox(width: 8),
+                    const SizedBox(width: 8),
                     Text(
                       'Version: 0.0.1',
                       style: TextStyle(
-                        color: Color(0xFF5B73FF),
+                        color: t.accentBright,
                         fontSize: 12,
                         fontWeight: FontWeight.w500,
                       ),
@@ -955,7 +951,7 @@ class _SettingsScreenState extends State<SettingsScreen>
               onPressed: () => Navigator.pop(dialogContext),
               child: Text(
                 closeText,
-                style: const TextStyle(color: Color(0xFF5B73FF)),
+                style: TextStyle(color: t.accentBright),
               ),
             ),
           ],

--- a/lib/screens/9receive_screen.dart
+++ b/lib/screens/9receive_screen.dart
@@ -14,6 +14,7 @@ import '../services/transaction_detector.dart';
 import '../models/lightning_invoice.dart';
 import '../models/wallet_info.dart';
 import '../l10n/generated/app_localizations.dart';
+import '../theme/app_tokens.dart';
 import '../widgets/universal_screen_wrapper.dart';
 import '7ln_address_screen.dart';
 import 'voucher_scan_screen.dart';
@@ -187,18 +188,7 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
     return Scaffold(
       resizeToAvoidBottomInset: true,
       body: Container(
-        decoration: const BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-            colors: [
-              Color(0xFF0F1419),
-              Color(0xFF1A1D47),
-              Color(0xFF2D3FE7),
-            ],
-            stops: [0.0, 0.5, 1.0],
-          ),
-        ),
+        decoration: BoxDecoration(gradient: context.tokens.backgroundGradient),
         child: SafeArea(
           child: withBottomPadding(
             context,
@@ -251,10 +241,10 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                 width: 40,
                 height: 40,
                 decoration: BoxDecoration(
-                  color: Colors.white.withValues(alpha: 0.08),
+                  color: context.tokens.surface,
                   borderRadius: BorderRadius.circular(12),
                   border: Border.all(
-                    color: Colors.white.withValues(alpha: 0.1),
+                    color: context.tokens.outline,
                     width: 1,
                   ),
                   boxShadow: [
@@ -266,9 +256,9 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                   ],
                 ),
                 child: IconButton(
-                  icon: const Icon(
+                  icon: Icon(
                     Icons.arrow_back,
-                    color: Colors.white,
+                    color: context.tokens.textPrimary,
                     size: 20,
                   ),
                   onPressed: () {
@@ -285,10 +275,10 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                 width: 40,
                 height: 40,
                 decoration: BoxDecoration(
-                  color: Colors.white.withValues(alpha: 0.08),
+                  color: context.tokens.surface,
                   borderRadius: BorderRadius.circular(12),
                   border: Border.all(
-                    color: Colors.white.withValues(alpha: 0.1),
+                    color: context.tokens.outline,
                     width: 1,
                   ),
                   boxShadow: [
@@ -300,9 +290,9 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                   ],
                 ),
                 child: IconButton(
-                  icon: const Icon(
+                  icon: Icon(
                     Icons.qr_code_scanner,
-                    color: Colors.white,
+                    color: context.tokens.textPrimary,
                     size: 20,
                   ),
                   onPressed: _navigateToVoucherScreen,
@@ -319,10 +309,9 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
           Text(
             AppLocalizations.of(context)!.receive_title,
             style: TextStyle(
-              fontFamily: 'Manrope',
-              fontSize: isMobile ? 40 : 48,
+                            fontSize: isMobile ? 40 : 48,
               fontWeight: FontWeight.w700,
-              color: Colors.white,
+              color: context.tokens.textPrimary,
               height: 1.1,
             ),
             textAlign: TextAlign.center,
@@ -370,10 +359,9 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
             Text(
               AppLocalizations.of(context)!.loading_address_text,
               style: TextStyle(
-                color: Colors.white.withValues(alpha: 0.8),
+                color: context.tokens.textPrimary.withValues(alpha: 0.8),
                 fontSize: 16,
-                fontFamily: 'Manrope',
-              ),
+                              ),
             ),
           ],
         ),
@@ -385,10 +373,10 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
     return Container(
       padding: const EdgeInsets.all(24),
       decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.08),
+        color: context.tokens.surface,
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
-          color: Colors.white.withValues(alpha: 0.1),
+          color: context.tokens.outline,
           width: 1,
         ),
       ),
@@ -397,27 +385,25 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
         children: [
           Icon(
             Icons.error_outline,
-            color: Colors.red.withValues(alpha: 0.8),
+            color: context.tokens.statusUnhealthy.withValues(alpha: 0.8),
             size: 48,
           ),
           const SizedBox(height: 16),
           Text(
             AppLocalizations.of(context)!.loading_address_error_prefix,
             style: TextStyle(
-              color: Colors.white,
+              color: context.tokens.textPrimary,
               fontSize: 18,
               fontWeight: FontWeight.w600,
-              fontFamily: 'Manrope',
-            ),
+                          ),
           ),
           const SizedBox(height: 8),
           Text(
             error,
             style: TextStyle(
-              color: Colors.white.withValues(alpha: 0.8),
+              color: context.tokens.textPrimary.withValues(alpha: 0.8),
               fontSize: 14,
-              fontFamily: 'Manrope',
-            ),
+                          ),
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 24),
@@ -426,8 +412,8 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
             child: ElevatedButton(
               onPressed: () => context.read<LNAddressProvider>().refresh(),
               style: ElevatedButton.styleFrom(
-                backgroundColor: const Color(0xFF2D3FE7),
-                foregroundColor: Colors.white,
+                backgroundColor: context.tokens.accentSolid,
+                foregroundColor: context.tokens.accentForeground,
                 padding: const EdgeInsets.symmetric(vertical: 16),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(16),
@@ -439,8 +425,7 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                 style: TextStyle(
                   fontSize: 16,
                   fontWeight: FontWeight.w600,
-                  fontFamily: 'Manrope',
-                ),
+                                  ),
               ),
             ),
           ),
@@ -453,10 +438,10 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
     return Container(
       padding: const EdgeInsets.all(24),
       decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.08),
+        color: context.tokens.surface,
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
-          color: Colors.white.withValues(alpha: 0.1),
+          color: context.tokens.outline,
           width: 1,
         ),
       ),
@@ -465,27 +450,25 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
         children: [
           Icon(
             Icons.alternate_email,
-            color: Colors.white.withValues(alpha: 0.6),
+            color: context.tokens.textSecondary,
             size: 64,
           ),
           const SizedBox(height: 24),
           Text(
             AppLocalizations.of(context)!.not_available_text,
             style: TextStyle(
-              color: Colors.white,
+              color: context.tokens.textPrimary,
               fontSize: 20,
               fontWeight: FontWeight.w600,
-              fontFamily: 'Manrope',
-            ),
+                          ),
           ),
           const SizedBox(height: 12),
           Text(
             AppLocalizations.of(context)!.lightning_address_description,
             style: TextStyle(
-              color: Colors.white.withValues(alpha: 0.8),
+              color: context.tokens.textPrimary.withValues(alpha: 0.8),
               fontSize: 16,
-              fontFamily: 'Manrope',
-            ),
+                          ),
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 32),
@@ -493,15 +476,15 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
             width: double.infinity,
             child: Container(
               decoration: BoxDecoration(
-                gradient: const LinearGradient(
-                  colors: [Color(0xFF2D3FE7), Color(0xFF4C63F7)],
+                gradient: LinearGradient(
+                  colors: [context.tokens.accentSolid, context.tokens.accentSolid],
                   begin: Alignment.centerLeft,
                   end: Alignment.centerRight,
                 ),
                 borderRadius: BorderRadius.circular(16),
                 boxShadow: [
                   BoxShadow(
-                    color: const Color(0xFF2D3FE7).withValues(alpha: 0.3),
+                    color: context.tokens.accentSolid.withValues(alpha: 0.3),
                     blurRadius: 12,
                     offset: const Offset(0, 6),
                   ),
@@ -524,14 +507,13 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                     borderRadius: BorderRadius.circular(16),
                   ),
                 ),
-                icon: const Icon(Icons.add, color: Colors.white),
+                icon: Icon(Icons.add, color: context.tokens.textPrimary),
                 label: Text(
                   AppLocalizations.of(context)!.lightning_address_title,
                   style: TextStyle(
                     fontSize: 16,
                     fontWeight: FontWeight.w600,
-                    fontFamily: 'Manrope',
-                    color: Colors.white,
+                                        color: context.tokens.textPrimary,
                   ),
                 ),
               ),
@@ -546,10 +528,10 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
     return Container(
       padding: const EdgeInsets.all(24),
       decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.08),
+        color: context.tokens.surface,
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
-          color: Colors.white.withValues(alpha: 0.1),
+          color: context.tokens.outline,
           width: 1,
         ),
         boxShadow: [
@@ -587,10 +569,10 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.05),
+        color: context.tokens.inputFill,
         borderRadius: BorderRadius.circular(12),
         border: Border.all(
-          color: Colors.white.withValues(alpha: 0.1),
+          color: context.tokens.outline,
         ),
       ),
       child: Row(
@@ -598,12 +580,12 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
           Container(
             padding: const EdgeInsets.all(8),
             decoration: BoxDecoration(
-              color: const Color(0xFF2D3FE7),
+              color: context.tokens.accentSolid,
               borderRadius: BorderRadius.circular(8),
             ),
-            child: const Icon(
+            child: Icon(
               Icons.account_balance_wallet,
-              color: Colors.white,
+              color: context.tokens.textPrimary,
               size: 20,
             ),
           ),
@@ -614,21 +596,19 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
               children: [
                 Text(
                   wallet.name,
-                  style: const TextStyle(
-                    color: Colors.white,
+                  style: TextStyle(
+                    color: context.tokens.textPrimary,
                     fontSize: 16,
                     fontWeight: FontWeight.w600,
-                    fontFamily: 'Manrope',
-                  ),
+                                      ),
                 ),
                 const SizedBox(height: 2),
                 Text(
                   'Balance: ${wallet.balanceFormatted}',
                   style: TextStyle(
-                    color: Colors.white.withValues(alpha: 0.7),
+                    color: context.tokens.textPrimary.withValues(alpha: 0.7),
                     fontSize: 14,
-                    fontFamily: 'Manrope',
-                  ),
+                                      ),
                 ),
               ],
             ),
@@ -643,10 +623,10 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
       width: double.infinity,
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.05),
+        color: context.tokens.inputFill,
         borderRadius: BorderRadius.circular(12),
         border: Border.all(
-          color: Colors.white.withValues(alpha: 0.1),
+          color: context.tokens.outline,
         ),
       ),
       child: Column(
@@ -658,12 +638,11 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
             width: double.infinity,
             child: Text(
               defaultAddress.fullAddress,
-              style: const TextStyle(
-                color: Colors.white,
+              style: TextStyle(
+                color: context.tokens.textPrimary,
                 fontSize: 14,
                 fontWeight: FontWeight.w400,
-                fontFamily: 'Manrope',
-              ),
+                              ),
               textAlign: TextAlign.center,
               softWrap: true,
               overflow: TextOverflow.visible,
@@ -681,10 +660,10 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
         // No fixed width, adjusts to content
         padding: const EdgeInsets.all(8), // Reduced to 8 for tighter frame
         decoration: BoxDecoration(
-          color: Colors.white,
+          color: context.tokens.textPrimary,
           borderRadius: BorderRadius.circular(6), // More square: from 16 to 6
           border: Border.all(
-            color: Colors.white.withValues(alpha: 0.2),
+            color: context.tokens.outlineStrong,
           ),
         ),
         child: _buildQRCodeWithLNURL(defaultAddress),
@@ -722,7 +701,7 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
             width: 32, // Reduced from 40 to 32
             height: 32, // Reduced from 40 to 32
             child: CircularProgressIndicator(
-              color: Color(0xFF2D3FE7),
+              color: context.tokens.accentSolid,
               strokeWidth: 3, // Reduced from 4 to 3
             ),
           ),
@@ -732,8 +711,7 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
             style: TextStyle(
               fontSize: 14, // Reduced from 16 to 14
               color: Colors.grey,
-              fontFamily: 'Manrope',
-            ),
+                          ),
           ),
         ],
       ),
@@ -811,15 +789,15 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
       width: double.infinity,
       child: Container(
         decoration: BoxDecoration(
-          gradient: const LinearGradient(
-            colors: [Color(0xFF2D3FE7), Color(0xFF4C63F7)],
+          gradient: LinearGradient(
+            colors: [context.tokens.accentSolid, context.tokens.accentSolid],
             begin: Alignment.centerLeft,
             end: Alignment.centerRight,
           ),
           borderRadius: BorderRadius.circular(16),
           boxShadow: [
             BoxShadow(
-              color: const Color(0xFF2D3FE7).withValues(alpha: 0.3),
+              color: context.tokens.accentSolid.withValues(alpha: 0.3),
               blurRadius: 12,
               offset: const Offset(0, 6),
             ),
@@ -835,14 +813,13 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
               borderRadius: BorderRadius.circular(16),
             ),
           ),
-          icon: const Icon(Icons.copy, color: Colors.white, size: 20),
+          icon: Icon(Icons.copy, color: context.tokens.textPrimary, size: 20),
           label: Text(
             _generatedInvoice != null ? AppLocalizations.of(context)!.copy_button : AppLocalizations.of(context)!.copy_lightning_address,
-            style: const TextStyle(
+            style: TextStyle(
               fontSize: 16,
               fontWeight: FontWeight.w600,
-              fontFamily: 'Manrope',
-              color: Colors.white,
+                            color: context.tokens.textPrimary,
             ),
           ),
         ),
@@ -880,10 +857,10 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
   Widget _buildCollapsibleInfoSection() {
     return Container(
       decoration: BoxDecoration(
-        color: const Color(0xFF2D3FE7).withValues(alpha: 0.1),
+        color: context.tokens.accentSolid.withValues(alpha: 0.1),
         borderRadius: BorderRadius.circular(12),
         border: Border.all(
-          color: const Color(0xFF2D3FE7).withValues(alpha: 0.2),
+          color: context.tokens.accentSolid.withValues(alpha: 0.2),
         ),
       ),
       child: Column(
@@ -904,7 +881,7 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                   children: [
                     Icon(
                       Icons.info_outline,
-                      color: const Color(0xFF4C63F7),
+                      color: context.tokens.accentSolid,
                       size: 20,
                     ),
                     const SizedBox(width: 12),
@@ -915,13 +892,12 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                           fontSize: 16,
                           fontWeight: FontWeight.w600,
                           color: Color(0xFF4C63F7),
-                          fontFamily: 'Manrope',
-                        ),
+                                                  ),
                       ),
                     ),
                     Icon(
                       _isInfoExpanded ? Icons.expand_less : Icons.expand_more,
-                      color: const Color(0xFF4C63F7),
+                      color: context.tokens.accentSolid,
                       size: 24,
                     ),
                   ],
@@ -937,8 +913,8 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  const Divider(
-                    color: Color(0xFF2D3FE7),
+                  Divider(
+                    color: context.tokens.accentSolid,
                     thickness: 1,
                     height: 1,
                   ),
@@ -947,9 +923,8 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                     AppLocalizations.of(context)!.receive_info_text,
                     style: TextStyle(
                       fontSize: 14,
-                      color: Colors.white.withValues(alpha: 0.8),
-                      fontFamily: 'Manrope',
-                      height: 1.4,
+                      color: context.tokens.textPrimary.withValues(alpha: 0.8),
+                                            height: 1.4,
                     ),
                   ),
                 ],
@@ -966,9 +941,9 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
       child: OutlinedButton.icon(
         onPressed: _showRequestAmountModal,
         style: OutlinedButton.styleFrom(
-          foregroundColor: Colors.white,
+          foregroundColor: context.tokens.accentForeground,
           side: BorderSide(
-            color: Colors.white.withValues(alpha: 0.3),
+            color: context.tokens.textTertiary,
             width: 1.5,
           ),
           padding: const EdgeInsets.symmetric(vertical: 16),
@@ -982,8 +957,7 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
           style: TextStyle(
             fontSize: 16,
             fontWeight: FontWeight.w600,
-            fontFamily: 'Manrope',
-          ),
+                      ),
         ),
       ),
     );
@@ -1004,18 +978,17 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
             SnackBar(
               content: Row(
                 children: [
-                  Icon(Icons.refresh, color: Colors.white, size: 20),
+                  Icon(Icons.refresh, color: context.tokens.textPrimary, size: 20),
                   SizedBox(width: 12),
                   Text(
                     AppLocalizations.of(context)!.lightning_address_title,
                     style: TextStyle(
-                      fontFamily: 'Manrope',
-                      fontWeight: FontWeight.w500,
+                                            fontWeight: FontWeight.w500,
                     ),
                   ),
                 ],
               ),
-              backgroundColor: const Color(0xFF4C63F7),
+              backgroundColor: context.tokens.accentSolid,
               behavior: SnackBarBehavior.floating,
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(12),
@@ -1025,9 +998,9 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
           );
         },
         style: OutlinedButton.styleFrom(
-          foregroundColor: Colors.white,
+          foregroundColor: context.tokens.accentForeground,
           side: BorderSide(
-            color: Colors.white.withValues(alpha: 0.3),
+            color: context.tokens.textTertiary,
             width: 1.5,
           ),
           padding: const EdgeInsets.symmetric(vertical: 16),
@@ -1041,8 +1014,7 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
           style: TextStyle(
             fontSize: 16,
             fontWeight: FontWeight.w600,
-            fontFamily: 'Manrope',
-          ),
+                      ),
         ),
       ),
     );
@@ -1087,7 +1059,7 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                     width: 40,
                     height: 4,
                     decoration: BoxDecoration(
-                      color: Colors.white.withValues(alpha: 0.3),
+                      color: context.tokens.textTertiary,
                       borderRadius: BorderRadius.circular(2),
                     ),
                   ),
@@ -1107,18 +1079,17 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                           child: Text(
                             AppLocalizations.of(context)!.amount_sats_label,
                             style: TextStyle(
-                              color: Colors.white,
+                              color: context.tokens.textPrimary,
                               fontSize: 20,
                               fontWeight: FontWeight.w600,
-                              fontFamily: 'Manrope',
-                            ),
+                                                          ),
                           ),
                         ),
                         IconButton(
                           onPressed: () => Navigator.pop(context),
                           icon: Icon(
                             Icons.close,
-                            color: Colors.white.withValues(alpha: 0.7),
+                            color: context.tokens.textPrimary.withValues(alpha: 0.7),
                           ),
                         ),
                       ],
@@ -1144,38 +1115,36 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                                   Text(
                                     AppLocalizations.of(context)!.amount_label,
                                     style: TextStyle(
-                                      color: Colors.white.withValues(alpha: 0.8),
+                                      color: context.tokens.textPrimary.withValues(alpha: 0.8),
                                       fontSize: 14,
                                       fontWeight: FontWeight.w500,
-                                      fontFamily: 'Manrope',
-                                    ),
+                                                                          ),
                                   ),
                                   const SizedBox(height: 8),
                                   TextFormField(
                                     controller: _amountController,
                                     keyboardType: TextInputType.number,
-                                    style: const TextStyle(
-                                      color: Colors.white,
+                                    style: TextStyle(
+                                      color: context.tokens.textPrimary,
                                       fontSize: 16,
-                                      fontFamily: 'Manrope',
-                                    ),
+                                                                          ),
                                     decoration: InputDecoration(
                                       hintText: '0',
                                       hintStyle: TextStyle(
-                                        color: Colors.white.withValues(alpha: 0.5),
+                                        color: context.tokens.textSecondary,
                                       ),
                                       filled: true,
-                                      fillColor: Colors.white.withValues(alpha: 0.05),
+                                      fillColor: context.tokens.inputFill,
                                       border: OutlineInputBorder(
                                         borderRadius: BorderRadius.circular(12),
                                         borderSide: BorderSide(
-                                          color: Colors.white.withValues(alpha: 0.1),
+                                          color: context.tokens.outline,
                                         ),
                                       ),
                                       enabledBorder: OutlineInputBorder(
                                         borderRadius: BorderRadius.circular(12),
                                         borderSide: BorderSide(
-                                          color: Colors.white.withValues(alpha: 0.1),
+                                          color: context.tokens.outline,
                                         ),
                                       ),
                                       focusedBorder: OutlineInputBorder(
@@ -1203,18 +1172,17 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                                 Text(
                                   AppLocalizations.of(context)!.currency_label,
                                   style: TextStyle(
-                                    color: Colors.white.withValues(alpha: 0.8),
+                                    color: context.tokens.textPrimary.withValues(alpha: 0.8),
                                     fontSize: 14,
                                     fontWeight: FontWeight.w500,
-                                    fontFamily: 'Manrope',
-                                  ),
+                                                                      ),
                                 ),
                                 const SizedBox(height: 8),
                                 SizedBox(
                                   width: 80,
                                   height: 52,
                                   child: Material(
-                                    color: Colors.white.withValues(alpha: 0.05),
+                                    color: context.tokens.inputFill,
                                     borderRadius: BorderRadius.circular(12),
                                     child: InkWell(
                                       borderRadius: BorderRadius.circular(12),
@@ -1229,18 +1197,17 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                                         decoration: BoxDecoration(
                                           borderRadius: BorderRadius.circular(12),
                                           border: Border.all(
-                                            color: Colors.white.withValues(alpha: 0.1),
+                                            color: context.tokens.outline,
                                           ),
                                         ),
                                         child: Center(
                                           child: Text(
                                             _selectedCurrency,
-                                            style: const TextStyle(
-                                              color: Colors.white,
+                                            style: TextStyle(
+                                              color: context.tokens.textPrimary,
                                               fontSize: 14,
                                               fontWeight: FontWeight.w600,
-                                              fontFamily: 'Manrope',
-                                            ),
+                                                                                          ),
                                           ),
                                         ),
                                       ),
@@ -1261,37 +1228,35 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                             Text(
                               AppLocalizations.of(context)!.optional_description_label,
                               style: TextStyle(
-                                color: Colors.white.withValues(alpha: 0.8),
+                                color: context.tokens.textPrimary.withValues(alpha: 0.8),
                                 fontSize: 14,
                                 fontWeight: FontWeight.w500,
-                                fontFamily: 'Manrope',
-                              ),
+                                                              ),
                             ),
                             const SizedBox(height: 8),
                             TextFormField(
                               controller: _noteController,
-                              style: const TextStyle(
-                                color: Colors.white,
+                              style: TextStyle(
+                                color: context.tokens.textPrimary,
                                 fontSize: 16,
-                                fontFamily: 'Manrope',
-                              ),
+                                                              ),
                               decoration: InputDecoration(
                                 hintText: AppLocalizations.of(context)!.payment_description_example,
                                 hintStyle: TextStyle(
-                                  color: Colors.white.withValues(alpha: 0.5),
+                                  color: context.tokens.textSecondary,
                                 ),
                                 filled: true,
-                                fillColor: Colors.white.withValues(alpha: 0.05),
+                                fillColor: context.tokens.inputFill,
                                 border: OutlineInputBorder(
                                   borderRadius: BorderRadius.circular(12),
                                   borderSide: BorderSide(
-                                    color: Colors.white.withValues(alpha: 0.1),
+                                    color: context.tokens.outline,
                                   ),
                                 ),
                                 enabledBorder: OutlineInputBorder(
                                   borderRadius: BorderRadius.circular(12),
                                   borderSide: BorderSide(
-                                    color: Colors.white.withValues(alpha: 0.1),
+                                    color: context.tokens.outline,
                                   ),
                                 ),
                                 focusedBorder: OutlineInputBorder(
@@ -1321,9 +1286,9 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                                 child: OutlinedButton(
                                   onPressed: () => Navigator.pop(context),
                                   style: OutlinedButton.styleFrom(
-                                    foregroundColor: Colors.white,
+                                    foregroundColor: context.tokens.accentForeground,
                                     side: BorderSide(
-                                      color: Colors.white.withValues(alpha: 0.3),
+                                      color: context.tokens.textTertiary,
                                     ),
                                     padding: const EdgeInsets.symmetric(vertical: 16),
                                     shape: RoundedRectangleBorder(
@@ -1335,8 +1300,7 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                                     style: TextStyle(
                                       fontSize: 16,
                                       fontWeight: FontWeight.w600,
-                                      fontFamily: 'Manrope',
-                                    ),
+                                                                          ),
                                   ),
                                 ),
                               ),
@@ -1345,8 +1309,8 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                                 child: ElevatedButton(
                                   onPressed: () => _confirmRequestAmount(),
                                   style: ElevatedButton.styleFrom(
-                                    backgroundColor: const Color(0xFF2D3FE7),
-                                    foregroundColor: Colors.white,
+                                    backgroundColor: context.tokens.accentSolid,
+                                    foregroundColor: context.tokens.accentForeground,
                                     padding: const EdgeInsets.symmetric(vertical: 16),
                                     shape: RoundedRectangleBorder(
                                       borderRadius: BorderRadius.circular(12),
@@ -1358,8 +1322,7 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                                     style: TextStyle(
                                       fontSize: 16,
                                       fontWeight: FontWeight.w600,
-                                      fontFamily: 'Manrope',
-                                    ),
+                                                                          ),
                                   ),
                                 ),
                               ),
@@ -1477,7 +1440,7 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
         SnackBar(
           content: Row(
             children: [
-              const Icon(Icons.check_circle, color: Colors.white, size: 20),
+              Icon(Icons.check_circle, color: context.tokens.textPrimary, size: 20),
               const SizedBox(width: 12),
               Expanded(
                 child: Column(
@@ -1487,8 +1450,7 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                     Text(
                       conversionMessage.isNotEmpty ? conversionMessage : 'Factura: ${invoice.formattedAmount}',
                       style: const TextStyle(
-                        fontFamily: 'Manrope',
-                        fontWeight: FontWeight.w500,
+                                                fontWeight: FontWeight.w500,
                       ),
                       overflow: TextOverflow.ellipsis,
                     ),
@@ -1497,7 +1459,7 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
               ),
             ],
           ),
-          backgroundColor: Colors.green,
+          backgroundColor: context.tokens.statusHealthy,
           behavior: SnackBarBehavior.floating,
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(12),
@@ -1527,14 +1489,13 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
       SnackBar(
         content: Row(
           children: [
-            const Icon(Icons.error, color: Colors.white, size: 20),
+            Icon(Icons.error, color: context.tokens.textPrimary, size: 20),
             const SizedBox(width: 12),
             Expanded(
               child: Text(
                 message,
                 style: const TextStyle(
-                  fontFamily: 'Manrope',
-                  fontWeight: FontWeight.w500,
+                                    fontWeight: FontWeight.w500,
                 ),
                 overflow: TextOverflow.ellipsis,
                 maxLines: 2,
@@ -1542,7 +1503,7 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
             ),
           ],
         ),
-        backgroundColor: Colors.red,
+        backgroundColor: context.tokens.statusUnhealthy,
         behavior: SnackBarBehavior.floating,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(12),
@@ -1557,18 +1518,17 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
       SnackBar(
         content: Row(
           children: [
-            const Icon(Icons.info, color: Colors.white, size: 20),
+            Icon(Icons.info, color: context.tokens.textPrimary, size: 20),
             const SizedBox(width: 12),
             Text(
               message,
               style: const TextStyle(
-                fontFamily: 'Manrope',
-                fontWeight: FontWeight.w500,
+                                fontWeight: FontWeight.w500,
               ),
             ),
           ],
         ),
-        backgroundColor: const Color(0xFF4C63F7),
+        backgroundColor: context.tokens.accentSolid,
         behavior: SnackBarBehavior.floating,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(12),
@@ -1598,18 +1558,17 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
         SnackBar(
           content: Row(
             children: [
-              const Icon(Icons.check_circle, color: Colors.white, size: 20),
+              Icon(Icons.check_circle, color: context.tokens.textPrimary, size: 20),
               const SizedBox(width: 12),
               Text(
                 successMessage,
                 style: const TextStyle(
-                  fontFamily: 'Manrope',
-                  fontWeight: FontWeight.w500,
+                                    fontWeight: FontWeight.w500,
                 ),
               ),
             ],
           ),
-          backgroundColor: const Color(0xFF2D3FE7),
+          backgroundColor: context.tokens.accentSolid,
           behavior: SnackBarBehavior.floating,
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(12),
@@ -1660,18 +1619,17 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                   SnackBar(
                     content: Row(
                       children: [
-                        const Icon(Icons.check_circle, color: Colors.white, size: 20),
+                        Icon(Icons.check_circle, color: context.tokens.textPrimary, size: 20),
                         const SizedBox(width: 12),
                         Text(
                           '${AppLocalizations.of(context)!.received_label}! ${invoice.formattedAmount}',
                           style: const TextStyle(
-                            fontFamily: 'Manrope',
-                            fontWeight: FontWeight.w500,
+                                                        fontWeight: FontWeight.w500,
                           ),
                         ),
                       ],
                     ),
-                    backgroundColor: Colors.green,
+                    backgroundColor: context.tokens.statusHealthy,
                     behavior: SnackBarBehavior.floating,
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(12),
@@ -1702,9 +1660,9 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
       child: OutlinedButton.icon(
         onPressed: () => _copyLNURL(defaultAddress),
         style: OutlinedButton.styleFrom(
-          foregroundColor: Colors.white,
+          foregroundColor: context.tokens.accentForeground,
           side: BorderSide(
-            color: Colors.white.withValues(alpha: 0.3),
+            color: context.tokens.textTertiary,
             width: 1.5,
           ),
           padding: const EdgeInsets.symmetric(vertical: 16),
@@ -1718,8 +1676,7 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
           style: const TextStyle(
             fontSize: 16,
             fontWeight: FontWeight.w600,
-            fontFamily: 'Manrope',
-          ),
+                      ),
         ),
       ),
     );
@@ -1735,18 +1692,17 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
           SnackBar(
             content: Row(
               children: [
-                const Icon(Icons.check_circle, color: Colors.white, size: 20),
+                Icon(Icons.check_circle, color: context.tokens.textPrimary, size: 20),
                 const SizedBox(width: 12),
                 const Text(
                   'LNURL copiado',
                   style: TextStyle(
-                    fontFamily: 'Manrope',
-                    fontWeight: FontWeight.w500,
+                                        fontWeight: FontWeight.w500,
                   ),
                 ),
               ],
             ),
-            backgroundColor: const Color(0xFF2D3FE7),
+            backgroundColor: context.tokens.accentSolid,
             behavior: SnackBarBehavior.floating,
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(12),
@@ -1761,18 +1717,17 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
           SnackBar(
             content: Row(
               children: [
-                const Icon(Icons.error, color: Colors.white, size: 20),
+                Icon(Icons.error, color: context.tokens.textPrimary, size: 20),
                 const SizedBox(width: 12),
                 const Text(
                   'LNURL no disponible',
                   style: TextStyle(
-                    fontFamily: 'Manrope',
-                    fontWeight: FontWeight.w500,
+                                        fontWeight: FontWeight.w500,
                   ),
                 ),
               ],
             ),
-            backgroundColor: Colors.red,
+            backgroundColor: context.tokens.statusUnhealthy,
             behavior: SnackBarBehavior.floating,
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(12),
@@ -1791,18 +1746,17 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
         SnackBar(
           content: Row(
             children: [
-              const Icon(Icons.check_circle, color: Colors.white, size: 20),
+              Icon(Icons.check_circle, color: context.tokens.textPrimary, size: 20),
               const SizedBox(width: 12),
               Text(
                 AppLocalizations.of(context)!.address_copied_message,
                 style: const TextStyle(
-                  fontFamily: 'Manrope',
-                  fontWeight: FontWeight.w500,
+                                    fontWeight: FontWeight.w500,
                 ),
               ),
             ],
           ),
-          backgroundColor: const Color(0xFF2D3FE7),
+          backgroundColor: context.tokens.accentSolid,
           behavior: SnackBarBehavior.floating,
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(12),

--- a/lib/screens/auth_checker.dart
+++ b/lib/screens/auth_checker.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../providers/auth_provider.dart';
+import '../theme/app_tokens.dart';
 import '2start_screen.dart';
 import '6home_screen.dart';
 
@@ -73,18 +74,11 @@ class _AuthCheckerState extends State<AuthChecker> {
 
   @override
   Widget build(BuildContext context) {
+    final t = context.tokens;
     return Scaffold(
       body: Container(
-        decoration: const BoxDecoration(
-          gradient: LinearGradient(
-            colors: [
-              Color(0xFF0F1419),
-              Color(0xFF1A1D47),
-              Color(0xFF2D3FE7),
-            ],
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-          ),
+        decoration: BoxDecoration(
+          gradient: t.backgroundGradient,
         ),
         child: Center(
           child: Column(
@@ -95,7 +89,7 @@ class _AuthCheckerState extends State<AuthChecker> {
                 decoration: BoxDecoration(
                   boxShadow: [
                     BoxShadow(
-                      color: const Color(0xFF2D3FE7).withValues(alpha: 0.3),
+                      color: t.accentSolid.withValues(alpha: 0.3),
                       blurRadius: 20,
                       spreadRadius: 5,
                     ),
@@ -108,17 +102,17 @@ class _AuthCheckerState extends State<AuthChecker> {
                 ),
               ),
               const SizedBox(height: 32),
-              
+
               // App name
               Text(
                 'LaChispa',
                 style: TextStyle(
                   fontSize: 32,
                   fontWeight: FontWeight.w700,
-                  color: Colors.white,
+                  color: t.textPrimary,
                   shadows: [
                     Shadow(
-                      color: const Color(0xFF2D3FE7).withValues(alpha: 0.8),
+                      color: t.accentSolid.withValues(alpha: 0.8),
                       blurRadius: 10,
                       offset: const Offset(0, 2),
                     ),
@@ -126,15 +120,15 @@ class _AuthCheckerState extends State<AuthChecker> {
                 ),
               ),
               const SizedBox(height: 16),
-              
+
               // Loading indicator
               if (_isInitializing) ...[
-                const SizedBox(
+                SizedBox(
                   height: 24,
                   width: 24,
                   child: CircularProgressIndicator(
                     strokeWidth: 2,
-                    valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                    valueColor: AlwaysStoppedAnimation<Color>(t.textPrimary),
                   ),
                 ),
                 const SizedBox(height: 16),
@@ -142,7 +136,7 @@ class _AuthCheckerState extends State<AuthChecker> {
                   'Checking session...',
                   style: TextStyle(
                     fontSize: 16,
-                    color: Colors.white.withValues(alpha: 0.7),
+                    color: t.textPrimary.withValues(alpha: 0.7),
                   ),
                 ),
               ],

--- a/lib/screens/voucher_scan_screen.dart
+++ b/lib/screens/voucher_scan_screen.dart
@@ -251,14 +251,7 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
             width: 200,
             height: 200,
             decoration: BoxDecoration(
-              gradient: LinearGradient(
-                colors: [
-                  context.tokens.accentSolid,
-                  context.tokens.accentSolid,
-                ],
-                begin: Alignment.topLeft,
-                end: Alignment.bottomRight,
-              ),
+              gradient: context.tokens.accentGradient,
               borderRadius: BorderRadius.circular(100),
               boxShadow: [
                 BoxShadow(

--- a/lib/screens/voucher_scan_screen.dart
+++ b/lib/screens/voucher_scan_screen.dart
@@ -7,6 +7,7 @@ import '../providers/wallet_provider.dart';
 import '../services/invoice_service.dart';
 import '../models/wallet_info.dart';
 import '../l10n/generated/app_localizations.dart';
+import '../theme/app_tokens.dart';
 import '../widgets/universal_screen_wrapper.dart';
 import '../widgets/qr_scanner_widget.dart';
 
@@ -89,18 +90,7 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       body: Container(
-        decoration: const BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-            colors: [
-              Color(0xFF0F1419),
-              Color(0xFF1A1D47),
-              Color(0xFF2D3FE7),
-            ],
-            stops: [0.0, 0.5, 1.0],
-          ),
-        ),
+        decoration: BoxDecoration(gradient: context.tokens.backgroundGradient),
         child: SafeArea(
           child: withBottomPadding(
             context,
@@ -161,10 +151,10 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
                 width: 40,
                 height: 40,
                 decoration: BoxDecoration(
-                  color: Colors.white.withValues(alpha: 0.08),
+                  color: context.tokens.surface,
                   borderRadius: BorderRadius.circular(12),
                   border: Border.all(
-                    color: Colors.white.withValues(alpha: 0.1),
+                    color: context.tokens.outline,
                     width: 1,
                   ),
                   boxShadow: [
@@ -176,9 +166,9 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
                   ],
                 ),
                 child: IconButton(
-                  icon: const Icon(
+                  icon: Icon(
                     Icons.arrow_back,
-                    color: Colors.white,
+                    color: context.tokens.textPrimary,
                     size: 20,
                   ),
                   onPressed: () {
@@ -198,10 +188,9 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
           Text(
             AppLocalizations.of(context)!.voucher_scan_title,
             style: TextStyle(
-              fontFamily: 'Manrope',
-              fontSize: isMobile ? 32 : 40,
+                            fontSize: isMobile ? 32 : 40,
               fontWeight: FontWeight.w700,
-              color: Colors.white,
+              color: context.tokens.textPrimary,
               height: 1.1,
             ),
             textAlign: TextAlign.center,
@@ -215,38 +204,36 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
     return Container(
       padding: const EdgeInsets.all(20),
       decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.08),
+        color: context.tokens.surface,
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
-          color: Colors.white.withValues(alpha: 0.1),
+          color: context.tokens.outline,
         ),
       ),
       child: Column(
         children: [
           Icon(
             Icons.qr_code_2,
-            color: const Color(0xFF4C63F7),
+            color: context.tokens.accentSolid,
             size: 48,
           ),
           const SizedBox(height: 16),
           Text(
             AppLocalizations.of(context)!.voucher_scan_instructions,
             style: TextStyle(
-              color: Colors.white,
+              color: context.tokens.textPrimary,
               fontSize: 16,
               fontWeight: FontWeight.w500,
-              fontFamily: 'Manrope',
-            ),
+                          ),
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 8),
           Text(
             AppLocalizations.of(context)!.voucher_scan_subtitle,
             style: TextStyle(
-              color: Colors.white.withValues(alpha: 0.7),
+              color: context.tokens.textPrimary.withValues(alpha: 0.7),
               fontSize: 14,
-              fontFamily: 'Manrope',
-            ),
+                          ),
             textAlign: TextAlign.center,
           ),
         ],
@@ -266,8 +253,8 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
             decoration: BoxDecoration(
               gradient: LinearGradient(
                 colors: [
-                  const Color(0xFF2D3FE7),
-                  const Color(0xFF4C63F7),
+                  context.tokens.accentSolid,
+                  context.tokens.accentSolid,
                 ],
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
@@ -275,7 +262,7 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
               borderRadius: BorderRadius.circular(100),
               boxShadow: [
                 BoxShadow(
-                  color: const Color(0xFF2D3FE7).withValues(alpha: 0.3),
+                  color: context.tokens.accentSolid.withValues(alpha: 0.3),
                   blurRadius: 20,
                   offset: const Offset(0, 8),
                 ),
@@ -290,7 +277,7 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
                   decoration: BoxDecoration(
                     borderRadius: BorderRadius.circular(100),
                     border: Border.all(
-                      color: Colors.white.withValues(alpha: 0.2),
+                      color: context.tokens.outlineStrong,
                       width: 2,
                     ),
                   ),
@@ -299,11 +286,11 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
                         ? Column(
                             mainAxisSize: MainAxisSize.min,
                             children: [
-                              const SizedBox(
+                              SizedBox(
                                 width: 40,
                                 height: 40,
                                 child: CircularProgressIndicator(
-                                  color: Colors.white,
+                                  color: context.tokens.textPrimary,
                                   strokeWidth: 3,
                                 ),
                               ),
@@ -311,10 +298,9 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
                               Text(
                                 AppLocalizations.of(context)!.voucher_processing,
                                 style: TextStyle(
-                                  color: Colors.white,
+                                  color: context.tokens.textPrimary,
                                   fontSize: 14,
-                                  fontFamily: 'Manrope',
-                                  fontWeight: FontWeight.w500,
+                                                                    fontWeight: FontWeight.w500,
                                 ),
                               ),
                             ],
@@ -324,17 +310,16 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
                             children: [
                               Icon(
                                 Icons.qr_code_scanner,
-                                color: Colors.white,
+                                color: context.tokens.textPrimary,
                                 size: 48,
                               ),
                               const SizedBox(height: 12),
                               Text(
                                 AppLocalizations.of(context)!.voucher_scan_button,
                                 style: TextStyle(
-                                  color: Colors.white,
+                                  color: context.tokens.textPrimary,
                                   fontSize: 18,
-                                  fontFamily: 'Manrope',
-                                  fontWeight: FontWeight.w600,
+                                                                    fontWeight: FontWeight.w600,
                                 ),
                               ),
                             ],
@@ -351,10 +336,9 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
           Text(
             AppLocalizations.of(context)!.voucher_tap_to_scan,
             style: TextStyle(
-              color: Colors.white.withValues(alpha: 0.7),
+              color: context.tokens.textPrimary.withValues(alpha: 0.7),
               fontSize: 16,
-              fontFamily: 'Manrope',
-            ),
+                          ),
           ),
         ],
       ),
@@ -370,9 +354,9 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
           child: OutlinedButton.icon(
             onPressed: _showManualInputDialog,
             style: OutlinedButton.styleFrom(
-              foregroundColor: Colors.white,
+              foregroundColor: context.tokens.accentForeground,
               side: BorderSide(
-                color: Colors.white.withValues(alpha: 0.3),
+                color: context.tokens.textTertiary,
                 width: 1.5,
               ),
               padding: const EdgeInsets.symmetric(vertical: 16),
@@ -386,8 +370,7 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
               style: TextStyle(
                 fontSize: 16,
                 fontWeight: FontWeight.w600,
-                fontFamily: 'Manrope',
-              ),
+                              ),
             ),
           ),
         ),
@@ -524,16 +507,15 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
-        backgroundColor: const Color(0xFF1A1D47),
+        backgroundColor: context.tokens.dialogBackground,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(16),
         ),
         title: Text(
           AppLocalizations.of(context)!.voucher_manual_input,
           style: TextStyle(
-            color: Colors.white,
-            fontFamily: 'Manrope',
-            fontWeight: FontWeight.w600,
+            color: context.tokens.textPrimary,
+                        fontWeight: FontWeight.w600,
           ),
         ),
         content: Column(
@@ -542,34 +524,32 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
             Text(
               AppLocalizations.of(context)!.voucher_manual_input_hint,
               style: TextStyle(
-                color: Colors.white.withValues(alpha: 0.8),
-                fontFamily: 'Manrope',
-              ),
+                color: context.tokens.textPrimary.withValues(alpha: 0.8),
+                              ),
             ),
             const SizedBox(height: 16),
             TextFormField(
               controller: controller,
-              style: const TextStyle(
-                color: Colors.white,
-                fontFamily: 'Manrope',
-              ),
+              style: TextStyle(
+                color: context.tokens.textPrimary,
+                              ),
               decoration: InputDecoration(
                 hintText: AppLocalizations.of(context)!.voucher_manual_input_placeholder,
                 hintStyle: TextStyle(
-                  color: Colors.white.withValues(alpha: 0.5),
+                  color: context.tokens.textSecondary,
                 ),
                 filled: true,
-                fillColor: Colors.white.withValues(alpha: 0.05),
+                fillColor: context.tokens.inputFill,
                 border: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
                   borderSide: BorderSide(
-                    color: Colors.white.withValues(alpha: 0.1),
+                    color: context.tokens.outline,
                   ),
                 ),
                 enabledBorder: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
                   borderSide: BorderSide(
-                    color: Colors.white.withValues(alpha: 0.1),
+                    color: context.tokens.outline,
                   ),
                 ),
                 focusedBorder: OutlineInputBorder(
@@ -589,9 +569,8 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
             child: Text(
               AppLocalizations.of(context)!.cancel_button,
               style: TextStyle(
-                color: Colors.white.withValues(alpha: 0.7),
-                fontFamily: 'Manrope',
-              ),
+                color: context.tokens.textPrimary.withValues(alpha: 0.7),
+                              ),
             ),
           ),
           ElevatedButton(
@@ -603,7 +582,7 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
               }
             },
             style: ElevatedButton.styleFrom(
-              backgroundColor: const Color(0xFF4C63F7),
+              backgroundColor: context.tokens.accentSolid,
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(8),
               ),
@@ -611,9 +590,8 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
             child: Text(
               AppLocalizations.of(context)!.process_button,
               style: TextStyle(
-                color: Colors.white,
-                fontFamily: 'Manrope',
-                fontWeight: FontWeight.w600,
+                color: context.tokens.textPrimary,
+                                fontWeight: FontWeight.w600,
               ),
             ),
           ),
@@ -626,20 +604,19 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
-        backgroundColor: const Color(0xFF1A1D47),
+        backgroundColor: context.tokens.dialogBackground,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(16),
         ),
         title: Row(
           children: [
-            Icon(Icons.error, color: Colors.red, size: 24),
+            Icon(Icons.error, color: context.tokens.statusUnhealthy, size: 24),
             const SizedBox(width: 12),
             Text(
               title,
               style: TextStyle(
-                color: Colors.white,
-                fontFamily: 'Manrope',
-                fontWeight: FontWeight.w600,
+                color: context.tokens.textPrimary,
+                                fontWeight: FontWeight.w600,
               ),
             ),
           ],
@@ -647,15 +624,14 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
         content: Text(
           message,
           style: TextStyle(
-            color: Colors.white.withValues(alpha: 0.8),
-            fontFamily: 'Manrope',
-          ),
+            color: context.tokens.textPrimary.withValues(alpha: 0.8),
+                      ),
         ),
         actions: [
           ElevatedButton(
             onPressed: () => Navigator.pop(context),
             style: ElevatedButton.styleFrom(
-              backgroundColor: const Color(0xFF4C63F7),
+              backgroundColor: context.tokens.accentSolid,
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(8),
               ),
@@ -663,9 +639,8 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
             child: Text(
               'OK',
               style: TextStyle(
-                color: Colors.white,
-                fontFamily: 'Manrope',
-                fontWeight: FontWeight.w600,
+                color: context.tokens.textPrimary,
+                                fontWeight: FontWeight.w600,
               ),
             ),
           ),
@@ -689,21 +664,20 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
       context: context,
       barrierDismissible: false,
       builder: (context) => AlertDialog(
-        backgroundColor: const Color(0xFF1A1D47),
+        backgroundColor: context.tokens.dialogBackground,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(16),
         ),
         title: Row(
           children: [
-            Icon(Icons.card_giftcard, color: const Color(0xFF4C63F7), size: 24),
+            Icon(Icons.card_giftcard, color: context.tokens.accentSolid, size: 24),
             const SizedBox(width: 12),
             Expanded(
               child: Text(
                 AppLocalizations.of(context)!.voucher_detected_title,
                 style: TextStyle(
-                  color: Colors.white,
-                  fontFamily: 'Manrope',
-                  fontWeight: FontWeight.w600,
+                  color: context.tokens.textPrimary,
+                                    fontWeight: FontWeight.w600,
                   fontSize: 18,
                 ),
               ),
@@ -719,23 +693,22 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
               Container(
                 padding: const EdgeInsets.all(12),
                 decoration: BoxDecoration(
-                  color: Colors.white.withValues(alpha: 0.05),
+                  color: context.tokens.inputFill,
                   borderRadius: BorderRadius.circular(8),
                   border: Border.all(
-                    color: Colors.white.withValues(alpha: 0.1),
+                    color: context.tokens.outline,
                   ),
                 ),
                 child: Row(
                   children: [
-                    Icon(Icons.description, color: Colors.white.withValues(alpha: 0.7), size: 16),
+                    Icon(Icons.description, color: context.tokens.textPrimary.withValues(alpha: 0.7), size: 16),
                     const SizedBox(width: 8),
                     Expanded(
                       child: Text(
                         description,
                         style: TextStyle(
-                          color: Colors.white.withValues(alpha: 0.9),
-                          fontFamily: 'Manrope',
-                          fontSize: 14,
+                          color: context.tokens.textPrimary.withValues(alpha: 0.9),
+                                                    fontSize: 14,
                         ),
                       ),
                     ),
@@ -749,10 +722,10 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
               Container(
                 padding: const EdgeInsets.all(12),
                 decoration: BoxDecoration(
-                  color: const Color(0xFF4C63F7).withValues(alpha: 0.1),
+                  color: context.tokens.accentSolid.withValues(alpha: 0.1),
                   borderRadius: BorderRadius.circular(8),
                   border: Border.all(
-                    color: const Color(0xFF4C63F7).withValues(alpha: 0.2),
+                    color: context.tokens.accentSolid.withValues(alpha: 0.2),
                   ),
                 ),
                 child: Column(
@@ -760,14 +733,13 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
                   children: [
                     Row(
                       children: [
-                        Icon(Icons.monetization_on, color: const Color(0xFF4C63F7), size: 20),
+                        Icon(Icons.monetization_on, color: context.tokens.accentSolid, size: 20),
                         const SizedBox(width: 8),
                         Text(
                           isFixedAmount ? AppLocalizations.of(context)!.voucher_fixed_amount : AppLocalizations.of(context)!.voucher_amount_range,
                           style: TextStyle(
-                            color: Colors.white,
-                            fontFamily: 'Manrope',
-                            fontWeight: FontWeight.w600,
+                            color: context.tokens.textPrimary,
+                                                        fontWeight: FontWeight.w600,
                             fontSize: 14,
                           ),
                         ),
@@ -779,9 +751,8 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
                           ? '$maxSats sats'
                           : 'De $minSats a $maxSats sats',
                       style: TextStyle(
-                        color: const Color(0xFF4C63F7),
-                        fontFamily: 'Manrope',
-                        fontWeight: FontWeight.w700,
+                        color: context.tokens.accentSolid,
+                                                fontWeight: FontWeight.w700,
                         fontSize: 18,
                       ),
                     ),
@@ -795,42 +766,40 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
                 Text(
                   AppLocalizations.of(context)!.voucher_amount_to_claim,
                   style: TextStyle(
-                    color: Colors.white.withValues(alpha: 0.8),
+                    color: context.tokens.textPrimary.withValues(alpha: 0.8),
                     fontSize: 14,
                     fontWeight: FontWeight.w500,
-                    fontFamily: 'Manrope',
-                  ),
+                                      ),
                 ),
                 const SizedBox(height: 8),
                 TextFormField(
                   controller: amountController,
                   keyboardType: TextInputType.number,
-                  style: const TextStyle(
-                    color: Colors.white,
+                  style: TextStyle(
+                    color: context.tokens.textPrimary,
                     fontSize: 16,
-                    fontFamily: 'Manrope',
-                  ),
+                                      ),
                   decoration: InputDecoration(
                     hintText: 'Ej: ${maxSats}',
                     hintStyle: TextStyle(
-                      color: Colors.white.withValues(alpha: 0.5),
+                      color: context.tokens.textSecondary,
                     ),
                     suffixText: 'sats',
                     suffixStyle: TextStyle(
-                      color: Colors.white.withValues(alpha: 0.7),
+                      color: context.tokens.textPrimary.withValues(alpha: 0.7),
                     ),
                     filled: true,
-                    fillColor: Colors.white.withValues(alpha: 0.05),
+                    fillColor: context.tokens.inputFill,
                     border: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(12),
                       borderSide: BorderSide(
-                        color: Colors.white.withValues(alpha: 0.1),
+                        color: context.tokens.outline,
                       ),
                     ),
                     enabledBorder: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(12),
                       borderSide: BorderSide(
-                        color: Colors.white.withValues(alpha: 0.1),
+                        color: context.tokens.outline,
                       ),
                     ),
                     focusedBorder: OutlineInputBorder(
@@ -849,10 +818,9 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
                 Text(
                   AppLocalizations.of(context)!.voucher_min_max_hint(minSats, maxSats),
                   style: TextStyle(
-                    color: Colors.white.withValues(alpha: 0.6),
+                    color: context.tokens.textSecondary,
                     fontSize: 12,
-                    fontFamily: 'Manrope',
-                  ),
+                                      ),
                 ),
               ],
             ],
@@ -870,9 +838,8 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
             child: Text(
               AppLocalizations.of(context)!.cancel_button,
               style: TextStyle(
-                color: Colors.white.withValues(alpha: 0.7),
-                fontFamily: 'Manrope',
-              ),
+                color: context.tokens.textPrimary.withValues(alpha: 0.7),
+                              ),
             ),
           ),
           ElevatedButton(
@@ -885,7 +852,7 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
                 ScaffoldMessenger.of(context).showSnackBar(
                   SnackBar(
                     content: Text(AppLocalizations.of(context)!.voucher_amount_invalid(minSats, maxSats)),
-                    backgroundColor: Colors.red,
+                    backgroundColor: context.tokens.statusUnhealthy,
                   ),
                 );
                 return;
@@ -895,7 +862,7 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
               _claimVoucher(voucherInfo, amount);
             },
             style: ElevatedButton.styleFrom(
-              backgroundColor: const Color(0xFF4C63F7),
+              backgroundColor: context.tokens.accentSolid,
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(8),
               ),
@@ -903,9 +870,8 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
             child: Text(
               AppLocalizations.of(context)!.voucher_claim_button,
               style: TextStyle(
-                color: Colors.white,
-                fontFamily: 'Manrope',
-                fontWeight: FontWeight.w600,
+                color: context.tokens.textPrimary,
+                                fontWeight: FontWeight.w600,
               ),
             ),
           ),
@@ -970,20 +936,19 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
-        backgroundColor: const Color(0xFF1A1D47),
+        backgroundColor: context.tokens.dialogBackground,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(16),
         ),
         title: Row(
           children: [
-            Icon(Icons.check_circle, color: Colors.green, size: 24),
+            Icon(Icons.check_circle, color: context.tokens.statusHealthy, size: 24),
             const SizedBox(width: 12),
             Text(
               AppLocalizations.of(context)!.voucher_claimed_title,
               style: TextStyle(
-                color: Colors.white,
-                fontFamily: 'Manrope',
-                fontWeight: FontWeight.w600,
+                color: context.tokens.textPrimary,
+                                fontWeight: FontWeight.w600,
               ),
             ),
           ],
@@ -994,10 +959,10 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
             Container(
               padding: const EdgeInsets.all(16),
               decoration: BoxDecoration(
-                color: Colors.green.withValues(alpha: 0.1),
+                color: context.tokens.statusHealthy.withValues(alpha: 0.1),
                 borderRadius: BorderRadius.circular(12),
                 border: Border.all(
-                  color: Colors.green.withValues(alpha: 0.2),
+                  color: context.tokens.statusHealthy.withValues(alpha: 0.2),
                 ),
               ),
               child: Column(
@@ -1005,20 +970,18 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
                   Text(
                     '$amount sats',
                     style: TextStyle(
-                      color: Colors.green,
+                      color: context.tokens.statusHealthy,
                       fontSize: 24,
                       fontWeight: FontWeight.w700,
-                      fontFamily: 'Manrope',
-                    ),
+                                          ),
                   ),
                   const SizedBox(height: 4),
                   Text(
                     description,
                     style: TextStyle(
-                      color: Colors.white.withValues(alpha: 0.8),
+                      color: context.tokens.textPrimary.withValues(alpha: 0.8),
                       fontSize: 14,
-                      fontFamily: 'Manrope',
-                    ),
+                                          ),
                     textAlign: TextAlign.center,
                   ),
                 ],
@@ -1028,9 +991,8 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
             Text(
               AppLocalizations.of(context)!.voucher_claimed_subtitle,
               style: TextStyle(
-                color: Colors.white.withValues(alpha: 0.8),
-                fontFamily: 'Manrope',
-              ),
+                color: context.tokens.textPrimary.withValues(alpha: 0.8),
+                              ),
               textAlign: TextAlign.center,
             ),
           ],
@@ -1042,7 +1004,7 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
               Navigator.pop(context); // Go back to receive screen
             },
             style: ElevatedButton.styleFrom(
-              backgroundColor: Colors.green,
+              backgroundColor: context.tokens.statusHealthy,
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(8),
               ),
@@ -1050,9 +1012,8 @@ class _VoucherScanScreenState extends State<VoucherScanScreen> {
             child: Text(
               'Continuar',
               style: TextStyle(
-                color: Colors.white,
-                fontFamily: 'Manrope',
-                fontWeight: FontWeight.w600,
+                color: context.tokens.textPrimary,
+                                fontWeight: FontWeight.w600,
               ),
             ),
           ),

--- a/lib/theme/app_tokens.dart
+++ b/lib/theme/app_tokens.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 class AppTokens extends ThemeExtension<AppTokens> {
   const AppTokens({
     required this.backgroundGradient,
+    required this.scaffoldBase,
     required this.surface,
     required this.outline,
     required this.outlineStrong,
@@ -19,12 +20,14 @@ class AppTokens extends ThemeExtension<AppTokens> {
     required this.statusUnhealthy,
     required this.statusChecking,
     required this.statusWarning,
+    required this.statusWarningSoft,
     required this.ctaShadow,
     required this.dialogBackground,
     required this.inputFill,
   });
 
   final Gradient backgroundGradient;
+  final Color scaffoldBase;
   final Color surface;
   final Color outline;
   final Color outlineStrong;
@@ -40,6 +43,7 @@ class AppTokens extends ThemeExtension<AppTokens> {
   final Color statusUnhealthy;
   final Color statusChecking;
   final Color statusWarning;
+  final Color statusWarningSoft;
   final Color ctaShadow;
   final Color dialogBackground;
   final Color inputFill;
@@ -47,6 +51,7 @@ class AppTokens extends ThemeExtension<AppTokens> {
   @override
   AppTokens copyWith({
     Gradient? backgroundGradient,
+    Color? scaffoldBase,
     Color? surface,
     Color? outline,
     Color? outlineStrong,
@@ -62,12 +67,14 @@ class AppTokens extends ThemeExtension<AppTokens> {
     Color? statusUnhealthy,
     Color? statusChecking,
     Color? statusWarning,
+    Color? statusWarningSoft,
     Color? ctaShadow,
     Color? dialogBackground,
     Color? inputFill,
   }) {
     return AppTokens(
       backgroundGradient: backgroundGradient ?? this.backgroundGradient,
+      scaffoldBase: scaffoldBase ?? this.scaffoldBase,
       surface: surface ?? this.surface,
       outline: outline ?? this.outline,
       outlineStrong: outlineStrong ?? this.outlineStrong,
@@ -83,6 +90,7 @@ class AppTokens extends ThemeExtension<AppTokens> {
       statusUnhealthy: statusUnhealthy ?? this.statusUnhealthy,
       statusChecking: statusChecking ?? this.statusChecking,
       statusWarning: statusWarning ?? this.statusWarning,
+      statusWarningSoft: statusWarningSoft ?? this.statusWarningSoft,
       ctaShadow: ctaShadow ?? this.ctaShadow,
       dialogBackground: dialogBackground ?? this.dialogBackground,
       inputFill: inputFill ?? this.inputFill,
@@ -95,6 +103,7 @@ class AppTokens extends ThemeExtension<AppTokens> {
     return AppTokens(
       backgroundGradient:
           t < 0.5 ? backgroundGradient : other.backgroundGradient,
+      scaffoldBase: Color.lerp(scaffoldBase, other.scaffoldBase, t)!,
       surface: Color.lerp(surface, other.surface, t)!,
       outline: Color.lerp(outline, other.outline, t)!,
       outlineStrong: Color.lerp(outlineStrong, other.outlineStrong, t)!,
@@ -112,6 +121,8 @@ class AppTokens extends ThemeExtension<AppTokens> {
           Color.lerp(statusUnhealthy, other.statusUnhealthy, t)!,
       statusChecking: Color.lerp(statusChecking, other.statusChecking, t)!,
       statusWarning: Color.lerp(statusWarning, other.statusWarning, t)!,
+      statusWarningSoft:
+          Color.lerp(statusWarningSoft, other.statusWarningSoft, t)!,
       ctaShadow: Color.lerp(ctaShadow, other.ctaShadow, t)!,
       dialogBackground:
           Color.lerp(dialogBackground, other.dialogBackground, t)!,

--- a/lib/theme/app_tokens.dart
+++ b/lib/theme/app_tokens.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+
+@immutable
+class AppTokens extends ThemeExtension<AppTokens> {
+  const AppTokens({
+    required this.backgroundGradient,
+    required this.surface,
+    required this.outline,
+    required this.outlineStrong,
+    required this.textPrimary,
+    required this.textSecondary,
+    required this.textTertiary,
+    required this.textAccent,
+    required this.accentGradient,
+    required this.accentSolid,
+    required this.accentBright,
+    required this.accentForeground,
+    required this.statusHealthy,
+    required this.statusUnhealthy,
+    required this.statusChecking,
+    required this.statusWarning,
+    required this.ctaShadow,
+    required this.dialogBackground,
+    required this.inputFill,
+  });
+
+  final Gradient backgroundGradient;
+  final Color surface;
+  final Color outline;
+  final Color outlineStrong;
+  final Color textPrimary;
+  final Color textSecondary;
+  final Color textTertiary;
+  final Color textAccent;
+  final Gradient accentGradient;
+  final Color accentSolid;
+  final Color accentBright;
+  final Color accentForeground;
+  final Color statusHealthy;
+  final Color statusUnhealthy;
+  final Color statusChecking;
+  final Color statusWarning;
+  final Color ctaShadow;
+  final Color dialogBackground;
+  final Color inputFill;
+
+  @override
+  AppTokens copyWith({
+    Gradient? backgroundGradient,
+    Color? surface,
+    Color? outline,
+    Color? outlineStrong,
+    Color? textPrimary,
+    Color? textSecondary,
+    Color? textTertiary,
+    Color? textAccent,
+    Gradient? accentGradient,
+    Color? accentSolid,
+    Color? accentBright,
+    Color? accentForeground,
+    Color? statusHealthy,
+    Color? statusUnhealthy,
+    Color? statusChecking,
+    Color? statusWarning,
+    Color? ctaShadow,
+    Color? dialogBackground,
+    Color? inputFill,
+  }) {
+    return AppTokens(
+      backgroundGradient: backgroundGradient ?? this.backgroundGradient,
+      surface: surface ?? this.surface,
+      outline: outline ?? this.outline,
+      outlineStrong: outlineStrong ?? this.outlineStrong,
+      textPrimary: textPrimary ?? this.textPrimary,
+      textSecondary: textSecondary ?? this.textSecondary,
+      textTertiary: textTertiary ?? this.textTertiary,
+      textAccent: textAccent ?? this.textAccent,
+      accentGradient: accentGradient ?? this.accentGradient,
+      accentSolid: accentSolid ?? this.accentSolid,
+      accentBright: accentBright ?? this.accentBright,
+      accentForeground: accentForeground ?? this.accentForeground,
+      statusHealthy: statusHealthy ?? this.statusHealthy,
+      statusUnhealthy: statusUnhealthy ?? this.statusUnhealthy,
+      statusChecking: statusChecking ?? this.statusChecking,
+      statusWarning: statusWarning ?? this.statusWarning,
+      ctaShadow: ctaShadow ?? this.ctaShadow,
+      dialogBackground: dialogBackground ?? this.dialogBackground,
+      inputFill: inputFill ?? this.inputFill,
+    );
+  }
+
+  @override
+  AppTokens lerp(covariant ThemeExtension<AppTokens>? other, double t) {
+    if (other is! AppTokens) return this;
+    return AppTokens(
+      backgroundGradient:
+          t < 0.5 ? backgroundGradient : other.backgroundGradient,
+      surface: Color.lerp(surface, other.surface, t)!,
+      outline: Color.lerp(outline, other.outline, t)!,
+      outlineStrong: Color.lerp(outlineStrong, other.outlineStrong, t)!,
+      textPrimary: Color.lerp(textPrimary, other.textPrimary, t)!,
+      textSecondary: Color.lerp(textSecondary, other.textSecondary, t)!,
+      textTertiary: Color.lerp(textTertiary, other.textTertiary, t)!,
+      textAccent: Color.lerp(textAccent, other.textAccent, t)!,
+      accentGradient: t < 0.5 ? accentGradient : other.accentGradient,
+      accentSolid: Color.lerp(accentSolid, other.accentSolid, t)!,
+      accentBright: Color.lerp(accentBright, other.accentBright, t)!,
+      accentForeground:
+          Color.lerp(accentForeground, other.accentForeground, t)!,
+      statusHealthy: Color.lerp(statusHealthy, other.statusHealthy, t)!,
+      statusUnhealthy:
+          Color.lerp(statusUnhealthy, other.statusUnhealthy, t)!,
+      statusChecking: Color.lerp(statusChecking, other.statusChecking, t)!,
+      statusWarning: Color.lerp(statusWarning, other.statusWarning, t)!,
+      ctaShadow: Color.lerp(ctaShadow, other.ctaShadow, t)!,
+      dialogBackground:
+          Color.lerp(dialogBackground, other.dialogBackground, t)!,
+      inputFill: Color.lerp(inputFill, other.inputFill, t)!,
+    );
+  }
+}
+
+extension AppTokensContext on BuildContext {
+  AppTokens get tokens => Theme.of(this).extension<AppTokens>()!;
+}

--- a/lib/theme/themes.dart
+++ b/lib/theme/themes.dart
@@ -12,6 +12,7 @@ const AppTokens chispaTokens = AppTokens(
     ],
     stops: [0.0, 0.5, 1.0],
   ),
+  scaffoldBase: Color(0xFF0F1419),    // matches backgroundGradient first stop
   surface: Color(0x0DFFFFFF),         // white @ 0.05
   outline: Color(0x1AFFFFFF),         // white @ 0.10
   outlineStrong: Color(0x2EFFFFFF),   // white @ 0.18
@@ -31,6 +32,7 @@ const AppTokens chispaTokens = AppTokens(
   statusUnhealthy: Color(0xFFEF4444),
   statusChecking: Color(0x40FFFFFF),  // white @ 0.25
   statusWarning: Color(0xFFFFA726),   // orange warning indicator
+  statusWarningSoft: Color(0xFFFFCC80),  // Colors.orange.shade200 — muted warning for secondary content
   ctaShadow: Color(0x59000000),       // black @ 0.35
   dialogBackground: Color(0xFF1A1D47),
   inputFill: Color(0x0DFFFFFF),       // white @ 0.05
@@ -41,7 +43,7 @@ ThemeData chispaTheme() {
     useMaterial3: true,
     fontFamily: 'Manrope',
     brightness: Brightness.dark,
-    scaffoldBackgroundColor: const Color(0xFF0F1419),
+    scaffoldBackgroundColor: chispaTokens.scaffoldBase,
     colorScheme: const ColorScheme.dark(
       primary: Color(0xFF4C63F7),
       onPrimary: Colors.white,

--- a/lib/theme/themes.dart
+++ b/lib/theme/themes.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'app_tokens.dart';
+
+const AppTokens chispaTokens = AppTokens(
+  backgroundGradient: LinearGradient(
+    begin: Alignment.topLeft,
+    end: Alignment.bottomRight,
+    colors: [
+      Color(0xFF0F1419),
+      Color(0xFF1A1D47),
+      Color(0xFF2D3FE7),
+    ],
+    stops: [0.0, 0.5, 1.0],
+  ),
+  surface: Color(0x0DFFFFFF),         // white @ 0.05
+  outline: Color(0x1AFFFFFF),         // white @ 0.10
+  outlineStrong: Color(0x2EFFFFFF),   // white @ 0.18
+  textPrimary: Colors.white,
+  textSecondary: Color(0x8CFFFFFF),   // white @ 0.55
+  textTertiary: Color(0x73FFFFFF),    // white @ 0.45
+  textAccent: Color(0xFF6B7FFF),
+  accentGradient: LinearGradient(
+    begin: Alignment.centerLeft,
+    end: Alignment.centerRight,
+    colors: [Color(0xFF2D3FE7), Color(0xFF4C63F7)],
+  ),
+  accentSolid: Color(0xFF4C63F7),
+  accentBright: Color(0xFF5B73FF),
+  accentForeground: Colors.white,
+  statusHealthy: Color(0xFF4ADE80),
+  statusUnhealthy: Color(0xFFEF4444),
+  statusChecking: Color(0x40FFFFFF),  // white @ 0.25
+  statusWarning: Color(0xFFFFA726),   // orange warning indicator
+  ctaShadow: Color(0x59000000),       // black @ 0.35
+  dialogBackground: Color(0xFF1A1D47),
+  inputFill: Color(0x0DFFFFFF),       // white @ 0.05
+);
+
+ThemeData chispaTheme() {
+  return ThemeData(
+    useMaterial3: true,
+    fontFamily: 'Manrope',
+    brightness: Brightness.dark,
+    scaffoldBackgroundColor: const Color(0xFF0F1419),
+    colorScheme: const ColorScheme.dark(
+      primary: Color(0xFF4C63F7),
+      onPrimary: Colors.white,
+      secondary: Color(0xFF6B7FFF),
+      onSecondary: Colors.white,
+      surface: Color(0xFF1A1D47),
+      onSurface: Colors.white,
+      error: Color(0xFFEF4444),
+      onError: Colors.white,
+    ),
+    extensions: const [chispaTokens],
+  );
+}

--- a/lib/widgets/qr_scanner_widget.dart
+++ b/lib/widgets/qr_scanner_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
+import '../theme/app_tokens.dart';
 
 class _QrScannerOverlayShape extends ShapeBorder {
   final Color borderColor;
@@ -178,6 +179,7 @@ class _QRScannerWidgetState extends State<QRScannerWidget> {
 
   @override
   Widget build(BuildContext context) {
+    final t = context.tokens;
     return Scaffold(
       body: Stack(
         children: [
@@ -192,7 +194,7 @@ class _QRScannerWidgetState extends State<QRScannerWidget> {
               Container(
                 decoration: ShapeDecoration(
                   shape: _QrScannerOverlayShape(
-                    borderColor: const Color(0xFF2D3FE7),
+                    borderColor: t.accentSolid,
                     borderRadius: 16,
                     borderLength: 30,
                     borderWidth: 4,
@@ -202,11 +204,12 @@ class _QRScannerWidgetState extends State<QRScannerWidget> {
               ),
             ],
           ),
-          
+
           // Header with gradient background
           Container(
             height: 120,
             decoration: BoxDecoration(
+              // Dark scrim is intrinsic to the camera-overlay UX
               gradient: LinearGradient(
                 begin: Alignment.topCenter,
                 end: Alignment.bottomCenter,
@@ -221,22 +224,22 @@ class _QRScannerWidgetState extends State<QRScannerWidget> {
                 padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
                 child: Row(
                   children: [
-                    // Back button
+                    // Back button (semi-transparent over camera)
                     Container(
                       width: 40,
                       height: 40,
                       decoration: BoxDecoration(
-                        color: Colors.white.withValues(alpha: 0.2),
+                        color: t.textPrimary.withValues(alpha: 0.2),
                         borderRadius: BorderRadius.circular(12),
                         border: Border.all(
-                          color: Colors.white.withValues(alpha: 0.3),
+                          color: t.textPrimary.withValues(alpha: 0.3),
                           width: 1,
                         ),
                       ),
                       child: IconButton(
-                        icon: const Icon(
+                        icon: Icon(
                           Icons.arrow_back,
-                          color: Colors.white,
+                          color: t.textPrimary,
                           size: 20,
                         ),
                         onPressed: () {
@@ -245,17 +248,16 @@ class _QRScannerWidgetState extends State<QRScannerWidget> {
                         padding: EdgeInsets.zero,
                       ),
                     ),
-                    
+
                     const SizedBox(width: 16),
-                    
+
                     // Title
-                    const Text(
+                    Text(
                       'Escanear QR',
                       style: TextStyle(
-                        fontFamily: 'Manrope',
                         fontSize: 20,
                         fontWeight: FontWeight.w600,
-                        color: Colors.white,
+                        color: t.textPrimary,
                       ),
                     ),
                   ],
@@ -263,7 +265,7 @@ class _QRScannerWidgetState extends State<QRScannerWidget> {
               ),
             ),
           ),
-          
+
           // Footer with instructions
           Positioned(
             bottom: 0,
@@ -272,6 +274,7 @@ class _QRScannerWidgetState extends State<QRScannerWidget> {
             child: Container(
               padding: const EdgeInsets.fromLTRB(24, 24, 24, 40),
               decoration: BoxDecoration(
+                // Dark scrim is intrinsic to the camera-overlay UX
                 gradient: LinearGradient(
                   begin: Alignment.topCenter,
                   end: Alignment.bottomCenter,
@@ -288,28 +291,27 @@ class _QRScannerWidgetState extends State<QRScannerWidget> {
                   Container(
                     padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
                     decoration: BoxDecoration(
-                      color: Colors.white.withValues(alpha: 0.15),
+                      color: t.textPrimary.withValues(alpha: 0.15),
                       borderRadius: BorderRadius.circular(12),
                       border: Border.all(
-                        color: Colors.white.withValues(alpha: 0.2),
+                        color: t.textPrimary.withValues(alpha: 0.2),
                         width: 1,
                       ),
                     ),
-                    child: const Text(
+                    child: Text(
                       'Point the camera at the QR code\nto scan the invoice or address',
                       style: TextStyle(
-                        fontFamily: 'Manrope',
                         fontSize: 14,
                         fontWeight: FontWeight.w400,
-                        color: Colors.white,
+                        color: t.textPrimary,
                         height: 1.4,
                       ),
                       textAlign: TextAlign.center,
                     ),
                   ),
-                  
+
                   const SizedBox(height: 16),
-                  
+
                   // Camera controls
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceEvenly,
@@ -319,17 +321,17 @@ class _QRScannerWidgetState extends State<QRScannerWidget> {
                         width: 56,
                         height: 56,
                         decoration: BoxDecoration(
-                          color: Colors.white.withValues(alpha: 0.15),
+                          color: t.textPrimary.withValues(alpha: 0.15),
                           borderRadius: BorderRadius.circular(16),
                           border: Border.all(
-                            color: Colors.white.withValues(alpha: 0.2),
+                            color: t.textPrimary.withValues(alpha: 0.2),
                             width: 1,
                           ),
                         ),
                         child: IconButton(
-                          icon: const Icon(
+                          icon: Icon(
                             Icons.flash_on,
-                            color: Colors.white,
+                            color: t.textPrimary,
                             size: 24,
                           ),
                           onPressed: () async {
@@ -337,23 +339,23 @@ class _QRScannerWidgetState extends State<QRScannerWidget> {
                           },
                         ),
                       ),
-                      
+
                       // Switch camera button
                       Container(
                         width: 56,
                         height: 56,
                         decoration: BoxDecoration(
-                          color: Colors.white.withValues(alpha: 0.15),
+                          color: t.textPrimary.withValues(alpha: 0.15),
                           borderRadius: BorderRadius.circular(16),
                           border: Border.all(
-                            color: Colors.white.withValues(alpha: 0.2),
+                            color: t.textPrimary.withValues(alpha: 0.2),
                             width: 1,
                           ),
                         ),
                         child: IconButton(
-                          icon: const Icon(
+                          icon: Icon(
                             Icons.flip_camera_ios,
-                            color: Colors.white,
+                            color: t.textPrimary,
                             size: 24,
                           ),
                           onPressed: () async {


### PR DESCRIPTION
Complete the theme extraction started in the previous commit. Every screen and widget now reads colors from context.tokens instead of hardcoded literals, so swapping themes later (light / dark / chispa modes) propagates app-wide in one place.

- Extend AppTokens with 4 semantic tokens needed by the rest of the app: dialogBackground, inputFill, statusWarning, accentBright. Added to AppTokens (field + constructor + copyWith + lerp) and to chispaTokens in themes.dart.                                                                                                                        
- Migrate 19 files (all screens + qr_scanner_widget): every literal Color() and Colors.white.withValues(...) replaced with the closest semantic token; redundant fontFamily: 'Manrope' dropped from TextStyles since ThemeData.fontFamily propagates.
- Left literal on purpose (with comments): QR code pixels (Colors.white/Colors.black are intrinsic to QR rendering), particle                                                                                 
  painter colors in CustomPainter classes (no BuildContext available), the amber-gold star in the LN address default indicator, the uniquely-darker language bottom sheet gradient, and the 2-stop send-flow gradient that intentionally differs from backgroundGradient.
- flutter analyze reports 0 new errors; pre-existing print / file_name / unnecessary_non_null_assertion warnings unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized design tokens and theme applied app-wide for consistent colors, gradients, surfaces, and accents.
  * Snackbars, dialogs, buttons, icons, and loading indicators now use themed status and accent colors for consistent success/warning/error visuals.
  * Many screens updated to derive text, background, and control colors from the theme; local font overrides removed to rely on global typography.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->