### PR TITLE
themes: add light and dark themes with selector in settings

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -174,7 +174,15 @@
   "language_selector_title": "Sprache",
   "language_selector_description": "Anwendungssprache ändern",
   "select_language": "Sprache auswählen",
-  
+
+  "theme_selector_title": "Design",
+  "theme_selector_description": "Erscheinungsbild der Anwendung ändern",
+  "select_theme": "Design auswählen",
+  "theme_lachispa": "LaChispa",
+  "theme_light": "Hell",
+  "theme_dark": "Dunkel",
+
+
   "no_wallet_error": "Keine primäre Wallet verfügbar",
   "invalid_session_error": "Keine aktive Sitzung",
   "send_error_prefix": "Fehler beim Verarbeiten des Sendens: ",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -243,7 +243,15 @@
   "language_selector_title": "Language",
   "language_selector_description": "Change application language",
   "select_language": "Select language",
-  
+
+  "theme_selector_title": "Theme",
+  "theme_selector_description": "Change application appearance",
+  "select_theme": "Select theme",
+  "theme_lachispa": "LaChispa",
+  "theme_light": "Light",
+  "theme_dark": "Dark",
+
+
   "no_wallet_error": "No primary wallet available",
   "invalid_session_error": "No active session",
   "send_error_prefix": "Error processing send: ",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -228,7 +228,15 @@
   "language_selector_title": "Idioma",
   "language_selector_description": "Cambiar idioma de la aplicación",
   "select_language": "Seleccionar idioma",
-  
+
+  "theme_selector_title": "Tema",
+  "theme_selector_description": "Cambiar apariencia de la aplicación",
+  "select_theme": "Seleccionar tema",
+  "theme_lachispa": "LaChispa",
+  "theme_light": "Claro",
+  "theme_dark": "Oscuro",
+
+
   "no_wallet_error": "Sin billetera principal disponible",
   "invalid_session_error": "Sin sesión activa",
   "send_error_prefix": "Error procesando el envío: ",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -174,7 +174,15 @@
   "language_selector_title": "Langue",
   "language_selector_description": "Changer la langue de l'application",
   "select_language": "Sélectionner la langue",
-  
+
+  "theme_selector_title": "Thème",
+  "theme_selector_description": "Changer l'apparence de l'application",
+  "select_theme": "Sélectionner le thème",
+  "theme_lachispa": "LaChispa",
+  "theme_light": "Clair",
+  "theme_dark": "Sombre",
+
+
   "no_wallet_error": "Aucun portefeuille principal disponible",
   "invalid_session_error": "Aucune session active",
   "send_error_prefix": "Erreur lors du traitement de l'envoi : ",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -174,7 +174,15 @@
   "language_selector_title": "Lingua",
   "language_selector_description": "Cambia lingua dell'applicazione",
   "select_language": "Seleziona lingua",
-  
+
+  "theme_selector_title": "Tema",
+  "theme_selector_description": "Cambia aspetto dell'applicazione",
+  "select_theme": "Seleziona tema",
+  "theme_lachispa": "LaChispa",
+  "theme_light": "Chiaro",
+  "theme_dark": "Scuro",
+
+
   "no_wallet_error": "Nessun portafoglio principale disponibile",
   "invalid_session_error": "Nessuna sessione attiva",
   "send_error_prefix": "Errore nell'elaborazione dell'invio: ",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -174,7 +174,15 @@
   "language_selector_title": "Idioma",
   "language_selector_description": "Alterar idioma da aplicação",
   "select_language": "Selecionar idioma",
-  
+
+  "theme_selector_title": "Tema",
+  "theme_selector_description": "Alterar aparência da aplicação",
+  "select_theme": "Selecionar tema",
+  "theme_lachispa": "LaChispa",
+  "theme_light": "Claro",
+  "theme_dark": "Escuro",
+
+
   "no_wallet_error": "Sem carteira principal disponível",
   "invalid_session_error": "Sem sessão ativa",
   "send_error_prefix": "Erro ao processar envio: ",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -174,7 +174,15 @@
   "language_selector_title": "Язык",
   "language_selector_description": "Изменить язык приложения",
   "select_language": "Выбрать язык",
-  
+
+  "theme_selector_title": "Тема",
+  "theme_selector_description": "Изменить оформление приложения",
+  "select_theme": "Выбрать тему",
+  "theme_lachispa": "LaChispa",
+  "theme_light": "Светлая",
+  "theme_dark": "Тёмная",
+
+
   "no_wallet_error": "Нет доступного основного кошелька",
   "invalid_session_error": "Нет активной сессии",
   "send_error_prefix": "Ошибка обработки отправки: ",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1296,6 +1296,42 @@ abstract class AppLocalizations {
   /// **'Seleccionar idioma'**
   String get select_language;
 
+  /// No description provided for @theme_selector_title.
+  ///
+  /// In es, this message translates to:
+  /// **'Tema'**
+  String get theme_selector_title;
+
+  /// No description provided for @theme_selector_description.
+  ///
+  /// In es, this message translates to:
+  /// **'Cambiar apariencia de la aplicación'**
+  String get theme_selector_description;
+
+  /// No description provided for @select_theme.
+  ///
+  /// In es, this message translates to:
+  /// **'Seleccionar tema'**
+  String get select_theme;
+
+  /// No description provided for @theme_lachispa.
+  ///
+  /// In es, this message translates to:
+  /// **'LaChispa'**
+  String get theme_lachispa;
+
+  /// No description provided for @theme_light.
+  ///
+  /// In es, this message translates to:
+  /// **'Claro'**
+  String get theme_light;
+
+  /// No description provided for @theme_dark.
+  ///
+  /// In es, this message translates to:
+  /// **'Oscuro'**
+  String get theme_dark;
+
   /// No description provided for @no_wallet_error.
   ///
   /// In es, this message translates to:

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -656,6 +656,25 @@ class AppLocalizationsDe extends AppLocalizations {
   String get select_language => 'Sprache auswählen';
 
   @override
+  String get theme_selector_title => 'Design';
+
+  @override
+  String get theme_selector_description =>
+      'Erscheinungsbild der Anwendung ändern';
+
+  @override
+  String get select_theme => 'Design auswählen';
+
+  @override
+  String get theme_lachispa => 'LaChispa';
+
+  @override
+  String get theme_light => 'Hell';
+
+  @override
+  String get theme_dark => 'Dunkel';
+
+  @override
   String get no_wallet_error => 'Keine primäre Wallet verfügbar';
 
   @override

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -641,6 +641,24 @@ class AppLocalizationsEn extends AppLocalizations {
   String get select_language => 'Select language';
 
   @override
+  String get theme_selector_title => 'Theme';
+
+  @override
+  String get theme_selector_description => 'Change application appearance';
+
+  @override
+  String get select_theme => 'Select theme';
+
+  @override
+  String get theme_lachispa => 'LaChispa';
+
+  @override
+  String get theme_light => 'Light';
+
+  @override
+  String get theme_dark => 'Dark';
+
+  @override
   String get no_wallet_error => 'No primary wallet available';
 
   @override

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -646,6 +646,25 @@ class AppLocalizationsEs extends AppLocalizations {
   String get select_language => 'Seleccionar idioma';
 
   @override
+  String get theme_selector_title => 'Tema';
+
+  @override
+  String get theme_selector_description =>
+      'Cambiar apariencia de la aplicación';
+
+  @override
+  String get select_theme => 'Seleccionar tema';
+
+  @override
+  String get theme_lachispa => 'LaChispa';
+
+  @override
+  String get theme_light => 'Claro';
+
+  @override
+  String get theme_dark => 'Oscuro';
+
+  @override
   String get no_wallet_error => 'Sin billetera principal disponible';
 
   @override

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -659,6 +659,25 @@ class AppLocalizationsFr extends AppLocalizations {
   String get select_language => 'Sélectionner la langue';
 
   @override
+  String get theme_selector_title => 'Thème';
+
+  @override
+  String get theme_selector_description =>
+      'Changer l\'apparence de l\'application';
+
+  @override
+  String get select_theme => 'Sélectionner le thème';
+
+  @override
+  String get theme_lachispa => 'LaChispa';
+
+  @override
+  String get theme_light => 'Clair';
+
+  @override
+  String get theme_dark => 'Sombre';
+
+  @override
   String get no_wallet_error => 'Aucun portefeuille principal disponible';
 
   @override

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -659,6 +659,24 @@ class AppLocalizationsIt extends AppLocalizations {
   String get select_language => 'Seleziona lingua';
 
   @override
+  String get theme_selector_title => 'Tema';
+
+  @override
+  String get theme_selector_description => 'Cambia aspetto dell\'applicazione';
+
+  @override
+  String get select_theme => 'Seleziona tema';
+
+  @override
+  String get theme_lachispa => 'LaChispa';
+
+  @override
+  String get theme_light => 'Chiaro';
+
+  @override
+  String get theme_dark => 'Scuro';
+
+  @override
   String get no_wallet_error => 'Nessun portafoglio principale disponibile';
 
   @override

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -646,6 +646,24 @@ class AppLocalizationsPt extends AppLocalizations {
   String get select_language => 'Selecionar idioma';
 
   @override
+  String get theme_selector_title => 'Tema';
+
+  @override
+  String get theme_selector_description => 'Alterar aparência da aplicação';
+
+  @override
+  String get select_theme => 'Selecionar tema';
+
+  @override
+  String get theme_lachispa => 'LaChispa';
+
+  @override
+  String get theme_light => 'Claro';
+
+  @override
+  String get theme_dark => 'Escuro';
+
+  @override
   String get no_wallet_error => 'Sem carteira principal disponível';
 
   @override

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -642,6 +642,24 @@ class AppLocalizationsRu extends AppLocalizations {
   String get select_language => 'Выбрать язык';
 
   @override
+  String get theme_selector_title => 'Тема';
+
+  @override
+  String get theme_selector_description => 'Изменить оформление приложения';
+
+  @override
+  String get select_theme => 'Выбрать тему';
+
+  @override
+  String get theme_lachispa => 'LaChispa';
+
+  @override
+  String get theme_light => 'Светлая';
+
+  @override
+  String get theme_dark => 'Тёмная';
+
+  @override
   String get no_wallet_error => 'Нет доступного основного кошелька';
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'providers/auth_provider.dart';
 import 'providers/wallet_provider.dart';
 import 'providers/ln_address_provider.dart';
 import 'providers/language_provider.dart';
+import 'providers/theme_provider.dart';
 import 'providers/currency_settings_provider.dart';
 import 'services/wallet_service.dart';
 import 'services/ln_address_service.dart';
@@ -14,7 +15,6 @@ import 'services/deep_link_service.dart';
 import 'screens/auth_checker.dart';
 import 'screens/10send_screen.dart';
 import 'l10n/generated/app_localizations.dart';
-import 'theme/themes.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -126,6 +126,7 @@ class _LaChispaAppState extends State<LaChispaApp> {
     return MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (_) => LanguageProvider()),
+        ChangeNotifierProvider(create: (_) => ThemeProvider()),
         ChangeNotifierProvider(create: (_) => ServerProvider()),
         ChangeNotifierProvider(create: (_) => AuthProviderFactory.create()),
         
@@ -186,12 +187,12 @@ class _LaChispaAppState extends State<LaChispaApp> {
             _setupWalletLNAddressConnection(context);
           });
           
-          return Consumer<LanguageProvider>(
-            builder: (context, languageProvider, child) {
+          return Consumer2<LanguageProvider, ThemeProvider>(
+            builder: (context, languageProvider, themeProvider, child) {
               return MaterialApp(
                 navigatorKey: _navigatorKey,
                 title: 'LaChispa',
-                theme: chispaTheme(),
+                theme: themeProvider.themeData,
                 locale: languageProvider.currentLocale,
                 localizationsDelegates: const [
                   AppLocalizations.delegate,

--- a/lib/providers/theme_provider.dart
+++ b/lib/providers/theme_provider.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../theme/themes.dart';
+
+enum AppTheme { lachispa, light, dark }
+
+class ThemeProvider extends ChangeNotifier {
+  static const String _themeKey = 'selected_theme';
+
+  AppTheme _current = AppTheme.lachispa;
+  AppTheme get current => _current;
+
+  ThemeData get themeData {
+    switch (_current) {
+      case AppTheme.lachispa:
+        return chispaTheme();
+      case AppTheme.light:
+        return lightTheme();
+      case AppTheme.dark:
+        return darkTheme();
+    }
+  }
+
+  ThemeProvider() {
+    _loadSavedTheme();
+  }
+
+  Future<void> _loadSavedTheme() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final saved = prefs.getString(_themeKey);
+      if (saved == null) return;
+
+      final match = AppTheme.values.firstWhere(
+        (t) => t.name == saved,
+        orElse: () => AppTheme.lachispa,
+      );
+      if (match != _current) {
+        _current = match;
+        notifyListeners();
+      }
+    } catch (e) {
+      print('[ThemeProvider] Error cargando tema guardado: $e');
+    }
+  }
+
+  Future<void> changeTheme(AppTheme theme) async {
+    if (_current == theme) return;
+    _current = theme;
+    notifyListeners();
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_themeKey, theme.name);
+    } catch (e) {
+      print('[ThemeProvider] Error guardando preferencia de tema: $e');
+    }
+  }
+}

--- a/lib/screens/17settings_screen.dart
+++ b/lib/screens/17settings_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../providers/language_provider.dart';
 import '../providers/currency_settings_provider.dart';
+import '../providers/theme_provider.dart';
 import '../l10n/generated/app_localizations.dart';
 import '../theme/app_tokens.dart';
 import '7ln_address_screen.dart';
@@ -91,6 +92,22 @@ class _SettingsScreenState extends State<SettingsScreen> {
                               builder: (context) => const LanguageSelectionScreen(),
                             ),
                           ),
+                        );
+                      },
+                    ),
+
+                    const SizedBox(height: 12),
+
+                    // Theme Settings
+                    Consumer<ThemeProvider>(
+                      builder: (context, themeProvider, child) {
+                        return _buildSettingsItem(
+                          t: t,
+                          icon: _themeIcon(themeProvider.current),
+                          iconColor: t.accentSolid,
+                          title: AppLocalizations.of(context)!.theme_selector_title,
+                          subtitle: _themeLabel(context, themeProvider.current),
+                          onTap: () => _showThemeSelector(themeProvider),
                         );
                       },
                     ),
@@ -208,6 +225,122 @@ class _SettingsScreenState extends State<SettingsScreen> {
               color: t.textSecondary,
             ),
           ],
+        ),
+      ),
+    );
+  }
+
+  IconData _themeIcon(AppTheme theme) {
+    switch (theme) {
+      case AppTheme.lachispa:
+        return Icons.bolt;
+      case AppTheme.light:
+        return Icons.light_mode;
+      case AppTheme.dark:
+        return Icons.dark_mode;
+    }
+  }
+
+  String _themeLabel(BuildContext context, AppTheme theme) {
+    final l = AppLocalizations.of(context)!;
+    switch (theme) {
+      case AppTheme.lachispa:
+        return l.theme_lachispa;
+      case AppTheme.light:
+        return l.theme_light;
+      case AppTheme.dark:
+        return l.theme_dark;
+    }
+  }
+
+  void _showThemeSelector(ThemeProvider themeProvider) {
+    final t = context.tokens;
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: Colors.transparent,
+      builder: (modalContext) => Consumer<ThemeProvider>(
+        builder: (context, provider, _) => Container(
+          decoration: BoxDecoration(
+            color: t.dialogBackground,
+            borderRadius: const BorderRadius.only(
+              topLeft: Radius.circular(20),
+              topRight: Radius.circular(20),
+            ),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                margin: const EdgeInsets.only(top: 8),
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: t.textPrimary.withValues(alpha: 0.3),
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(20),
+                child: Text(
+                  AppLocalizations.of(context)!.select_theme,
+                  style: TextStyle(
+                    fontSize: 20,
+                    fontWeight: FontWeight.bold,
+                    color: t.textPrimary,
+                  ),
+                ),
+              ),
+              ...AppTheme.values.map((option) {
+                final isSelected = provider.current == option;
+                return Material(
+                  color: Colors.transparent,
+                  child: InkWell(
+                    onTap: () async {
+                      await provider.changeTheme(option);
+                      if (mounted) Navigator.pop(context);
+                    },
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 20,
+                        vertical: 16,
+                      ),
+                      child: Row(
+                        children: [
+                          Icon(
+                            _themeIcon(option),
+                            color: isSelected ? t.accentSolid : t.textPrimary,
+                            size: 24,
+                          ),
+                          const SizedBox(width: 16),
+                          Expanded(
+                            child: Text(
+                              _themeLabel(context, option),
+                              style: TextStyle(
+                                fontSize: 18,
+                                fontWeight: isSelected
+                                    ? FontWeight.w600
+                                    : FontWeight.w400,
+                                color: isSelected
+                                    ? t.accentSolid
+                                    : t.textPrimary,
+                              ),
+                            ),
+                          ),
+                          if (isSelected)
+                            Icon(
+                              Icons.check_circle,
+                              color: t.accentSolid,
+                              size: 24,
+                            ),
+                        ],
+                      ),
+                    ),
+                  ),
+                );
+              }),
+              const SizedBox(height: 20),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/screens/6home_screen.dart
+++ b/lib/screens/6home_screen.dart
@@ -1422,7 +1422,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                         subtitle: Text(
                           wallet.balanceFormatted,
                           style: TextStyle(
-                            color: isSelected ? context.tokens.accentBright : context.tokens.textPrimary.withValues(alpha: 0.7),
+                            color: isSelected ? context.tokens.textAccent : context.tokens.textPrimary.withValues(alpha: 0.7),
                             fontSize: 14,
                             fontWeight: FontWeight.w500,
                           ),
@@ -1555,7 +1555,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
             onPressed: () => Navigator.pop(context),
             child: Text(
               AppLocalizations.of(context)!.cancel_button,
-              style: TextStyle(color: context.tokens.accentBright),
+              style: TextStyle(color: context.tokens.textAccent),
             ),
           ),
         ],
@@ -1603,7 +1603,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                   style: TextStyle(
                                         fontSize: 16,
                     fontWeight: FontWeight.w500, // Weight for secondary buttons
-                    color: _isInHistory ? context.tokens.accentBright : context.tokens.textPrimary,
+                    color: _isInHistory ? context.tokens.textAccent : context.tokens.textPrimary,
                   ),
                 ),
               ],
@@ -1709,7 +1709,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                                     walletProvider.primaryWallet!.balanceFormatted,
                                     style: TextStyle(
                                       fontSize: 12,
-                                      color: context.tokens.accentBright,
+                                      color: context.tokens.textAccent,
                                       fontWeight: FontWeight.w600,
                                     ),
                                   ),
@@ -1983,7 +1983,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                   Text(
                     AppInfoService.getVersionDisplay(languageProvider.currentLocale.languageCode),
                     style: TextStyle(
-                      color: context.tokens.accentBright,
+                      color: context.tokens.textAccent,
                       fontSize: 12,
                       fontWeight: FontWeight.w500,
                     ),
@@ -1998,7 +1998,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
             onPressed: () => Navigator.pop(context),
             child: Text(
               AppLocalizations.of(context)!.cancel_button,
-              style: TextStyle(color: context.tokens.accentBright),
+              style: TextStyle(color: context.tokens.textAccent),
             ),
           ),
         ],

--- a/lib/screens/6home_screen.dart
+++ b/lib/screens/6home_screen.dart
@@ -1220,6 +1220,11 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                       blurRadius: _sendButtonPressed ? 8 : 12,
                       offset: Offset(0, _sendButtonPressed ? 3 : 6),
                     ),
+                    BoxShadow(
+                      color: context.tokens.ctaShadow,
+                      blurRadius: _sendButtonPressed ? 6 : 10,
+                      offset: Offset(0, _sendButtonPressed ? 2 : 4),
+                    ),
                   ],
                 ),
                 child: GestureDetector(
@@ -1241,13 +1246,13 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                           style: TextStyle(
                                                         fontSize: 16,
                             fontWeight: FontWeight.w600,
-                            color: context.tokens.textPrimary,
+                            color: context.tokens.accentForeground,
                           ),
                         ),
                         SizedBox(width: 8),
                         Icon(
                           Icons.north_east,
-                          color: context.tokens.textPrimary,
+                          color: context.tokens.accentForeground,
                           size: 20,
                         ),
                       ],
@@ -1265,23 +1270,21 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
                 transform: Matrix4.identity()
                   ..scale(_receiveButtonPressed ? 0.95 : 1.0),
                 decoration: BoxDecoration(
-                  color: context.tokens.textPrimary.withValues(
-                    alpha: _receiveButtonPressed ? 0.12 : 0.08,
-                  ),
+                  color: _receiveButtonPressed
+                      ? context.tokens.outline
+                      : context.tokens.surface,
                   borderRadius: BorderRadius.circular(16),
                   border: Border.all(
-                    color: context.tokens.textPrimary.withValues(
-                      alpha: _receiveButtonPressed ? 0.2 : 0.1,
-                    ),
+                    color: context.tokens.outlineStrong,
                     width: 1,
                   ),
-                  boxShadow: _receiveButtonPressed ? [
+                  boxShadow: [
                     BoxShadow(
-                      color: context.tokens.outline,
-                      blurRadius: 8,
-                      offset: const Offset(0, 3),
+                      color: context.tokens.ctaShadow,
+                      blurRadius: _receiveButtonPressed ? 6 : 10,
+                      offset: Offset(0, _receiveButtonPressed ? 2 : 4),
                     ),
-                  ] : [],
+                  ],
                 ),
                 child: GestureDetector(
                   onTapDown: (_) => setState(() => _receiveButtonPressed = true),
@@ -1327,16 +1330,9 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Ti
     return Consumer<WalletProvider>(
       builder: (context, walletProvider, child) {
         return Container(
-          decoration: const BoxDecoration(
-            gradient: LinearGradient(
-              colors: [
-                Color(0xFF0F1419),
-                Color(0xFF1A1D47),
-              ],
-              begin: Alignment.topCenter,
-              end: Alignment.bottomCenter,
-            ),
-            borderRadius: BorderRadius.only(
+          decoration: BoxDecoration(
+            color: context.tokens.dialogBackground,
+            borderRadius: const BorderRadius.only(
               topLeft: Radius.circular(20),
               topRight: Radius.circular(20),
             ),

--- a/lib/screens/8settings_screen.dart
+++ b/lib/screens/8settings_screen.dart
@@ -605,16 +605,7 @@ class _SettingsScreenState extends State<SettingsScreen>
       builder: (modalContext) => Consumer<LanguageProvider>(
         builder: (context, langProvider, child) => Container(
         decoration: BoxDecoration(
-          // Modal-specific darker gradient kept literal — unique to this sheet
-          gradient: const LinearGradient(
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-            colors: [
-              Color(0xFF1A1A2E),
-              Color(0xFF16213E),
-              Color(0xFF0F0F23),
-            ],
-          ),
+          color: t.dialogBackground,
           borderRadius: const BorderRadius.only(
             topLeft: Radius.circular(20),
             topRight: Radius.circular(20),

--- a/lib/theme/themes.dart
+++ b/lib/theme/themes.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
 import 'app_tokens.dart';
 
+// =====================================================================
+// LaChispa (Original) — cypherpunk · electric blue · sparks
+// =====================================================================
+
 const AppTokens chispaTokens = AppTokens(
   backgroundGradient: LinearGradient(
     begin: Alignment.topLeft,
@@ -55,5 +59,121 @@ ThemeData chispaTheme() {
       onError: Colors.white,
     ),
     extensions: const [chispaTokens],
+  );
+}
+
+// =====================================================================
+// Light — quiet trust · minimal fintech · calm
+// =====================================================================
+
+const AppTokens lightTokens = AppTokens(
+  // Flat background — same color repeated keeps the API surface stable while
+  // visually rendering as a solid fill on screens that paint t.backgroundGradient.
+  backgroundGradient: LinearGradient(
+    begin: Alignment.topLeft,
+    end: Alignment.bottomRight,
+    colors: [Color(0xFFF7F7F5), Color(0xFFF7F7F5)],
+  ),
+  scaffoldBase: Color(0xFFF7F7F5),
+  surface: Color(0xFFFFFFFF),
+  outline: Color(0xFFE5E5E0),
+  outlineStrong: Color(0xFFD1D1CC),
+  textPrimary: Color(0xFF0D0D0D),
+  textSecondary: Color(0xFF6B6B6B),
+  textTertiary: Color(0xFF9A9A9A),
+  textAccent: Color(0xFF3B4FE0),
+  // Light theme renders accents as flat solids — same color repeated so the
+  // shared accentGradient API still works without showing a gradient.
+  accentGradient: LinearGradient(
+    begin: Alignment.centerLeft,
+    end: Alignment.centerRight,
+    colors: [Color(0xFF4C63F7), Color(0xFF4C63F7)],
+  ),
+  accentSolid: Color(0xFF4C63F7),
+  accentBright: Color(0xFF6B7FFF),
+  accentForeground: Color(0xFFFFFFFF),
+  statusHealthy: Color(0xFF10B981),
+  statusUnhealthy: Color(0xFFDC2626),
+  statusChecking: Color(0x330D0D0D),     // ink @ 0.20
+  statusWarning: Color(0xFFD97706),
+  statusWarningSoft: Color(0xFFFED7AA),
+  ctaShadow: Color(0x140D0D0D),          // ink @ 0.08
+  dialogBackground: Color(0xFFFFFFFF),
+  inputFill: Color(0xFFFFFFFF),
+);
+
+ThemeData lightTheme() {
+  return ThemeData(
+    useMaterial3: true,
+    fontFamily: 'Manrope',
+    brightness: Brightness.light,
+    scaffoldBackgroundColor: lightTokens.scaffoldBase,
+    colorScheme: const ColorScheme.light(
+      primary: Color(0xFF4C63F7),
+      onPrimary: Colors.white,
+      secondary: Color(0xFF3B4FE0),
+      onSecondary: Colors.white,
+      surface: Color(0xFFFFFFFF),
+      onSurface: Color(0xFF0D0D0D),
+      error: Color(0xFFDC2626),
+      onError: Colors.white,
+    ),
+    extensions: const [lightTokens],
+  );
+}
+
+// =====================================================================
+// Dark — sovereign tool · terminal-elegant · flat layers
+// =====================================================================
+
+const AppTokens darkTokens = AppTokens(
+  backgroundGradient: LinearGradient(
+    begin: Alignment.topLeft,
+    end: Alignment.bottomRight,
+    colors: [Color(0xFF0B0B0C), Color(0xFF0B0B0C)],
+  ),
+  scaffoldBase: Color(0xFF0B0B0C),
+  surface: Color(0xFF141416),
+  outline: Color(0xFF2A2A2E),
+  outlineStrong: Color(0xFF3A3A3E),
+  textPrimary: Color(0xFFF5F5F5),
+  textSecondary: Color(0xFF9A9A9A),
+  textTertiary: Color(0xFF6B6B6E),
+  textAccent: Color(0xFF7E92FF),
+  accentGradient: LinearGradient(
+    begin: Alignment.centerLeft,
+    end: Alignment.centerRight,
+    colors: [Color(0xFF2D3FE7), Color(0xFF5B73FF)],
+  ),
+  accentSolid: Color(0xFF4C63F7),
+  accentBright: Color(0xFF7E92FF),
+  accentForeground: Color(0xFFFFFFFF),
+  statusHealthy: Color(0xFF3BD671),
+  statusUnhealthy: Color(0xFFFF5C5C),
+  statusChecking: Color(0x33FFFFFF),     // white @ 0.20
+  statusWarning: Color(0xFFFFB454),
+  statusWarningSoft: Color(0xFF7A5A2E),
+  ctaShadow: Color(0x99000000),          // black @ 0.60
+  dialogBackground: Color(0xFF1C1C1F),
+  inputFill: Color(0xFF1C1C1F),
+);
+
+ThemeData darkTheme() {
+  return ThemeData(
+    useMaterial3: true,
+    fontFamily: 'Manrope',
+    brightness: Brightness.dark,
+    scaffoldBackgroundColor: darkTokens.scaffoldBase,
+    colorScheme: const ColorScheme.dark(
+      primary: Color(0xFF4C63F7),
+      onPrimary: Colors.white,
+      secondary: Color(0xFF7E92FF),
+      onSecondary: Colors.white,
+      surface: Color(0xFF141416),
+      onSurface: Color(0xFFF5F5F5),
+      error: Color(0xFFFF5C5C),
+      onError: Colors.white,
+    ),
+    extensions: const [darkTokens],
   );
 }

--- a/style.md
+++ b/style.md
@@ -1,241 +1,333 @@
-# Style Guide - LaChispa
+# Style Guide — LaChispa
 
-## Color Palette
+LaChispa ships a **token-driven** design system with **three themes**:
 
-### Main Colors
-- **Main Background**: Linear diagonal gradient (topLeft → bottomRight)
-  - `Color(0xFF0F1419)` - Deep dark blue
-  - `Color(0xFF1A1D47)` - Medium blue
-  - `Color(0xFF2D3FE7)` - Vibrant blue
-  - Stops: `[0.0, 0.5, 1.0]`
+| Theme    | Identity                                | State        |
+| -------- | --------------------------------------- | ------------ |
+| LaChispa | Cypherpunk · electric blue · sparks     | Implemented  |
+| Light    | Quiet trust · minimal fintech           | Spec only    |
+| Dark     | Sovereign tool · terminal-elegant       | Spec only    |
 
-### Accent Colors
-- **Primary Blue**: `Color(0xFF2D3FE7)` 
-- **Secondary Blue**: `Color(0xFF4C63F7)`
-- **Bright Blue**: `Color(0xFF5B73FF)` (used in particles)
+`accentSolid` (`#4C63F7`, the **Chispa blue**) is shared across all three themes
+to preserve brand identity. Themes vary in backgrounds, surfaces, text, and the
+behavior of the Spark/glass system — never in the primary accent.
 
-### Text Colors
-- **Primary Text**: `Colors.white`
-- **Secondary Text**: `Colors.white` with 0.9 opacity
-- **Tertiary Text**: `Colors.white` with 0.6-0.8 opacity
-- **Placeholder**: `Colors.white` with 0.4 opacity
+Tokens live in `lib/theme/app_tokens.dart` (the `AppTokens` extension) and are
+applied to a theme through `lib/theme/themes.dart`. This document is the
+human-readable spec; the code is the source of truth.
+
+---
 
 ## Typography
 
-### Main Font
-- **Family**: `Inter`
-- **Main Titles**: 
-  - Size: 48px
-  - Weight: FontWeight.bold
-  - Color: Colors.white
-- **Subtitles**: 
-  - Size: 18px
-  - Weight: FontWeight.w500
-  - Color: Colors.white with 0.9 opacity
-- **Body Text**: 
-  - Size: 16px
-  - Weight: FontWeight.w500
-  - Color: Colors.white with 0.9 opacity
-- **Button Text**: 
-  - Size: 16px
-  - Weight: FontWeight.w600
-  - Color: Colors.white
+**Font family:** `Manrope` (variable, bundled at `assets/fonts/Manrope-Variable.ttf`).
+The same family is used across all three themes.
 
-## UI Components
+| Role          | Size | Weight        | Notes                                  |
+| ------------- | ---- | ------------- | -------------------------------------- |
+| Display title | 48px | Bold (700)    | Hero balances, splash                  |
+| Section title | 24px | SemiBold (600)| Screen headers                         |
+| Subtitle      | 18px | Medium (500)  | Sub-headers, list group titles         |
+| Body          | 16px | Medium (500)  | Default copy                           |
+| Body small    | 14px | Regular (400) | Secondary copy, captions               |
+| Numeric       | —    | Medium (500)  | Balances; prefer tabular figures       |
+| Button        | 16px | SemiBold (600)| All CTAs                               |
 
-### Glassmorphism Cards
-- **Background**: `Colors.white` with 0.08 opacity
-- **Border**: `Colors.white` with 0.1 opacity, 1px width
-- **Border Radius**: 16px
-- **Shadow**: `Colors.black` with 0.1 opacity, blur 10px, offset (0, 4)
+Numeric balances should use Manrope Medium with `FontFeature.tabularFigures()`
+so digits don't wobble during animation. Bitcoin convention: leading zeros and
+non-significant digits render at `textTertiary`; significant digits at
+`textPrimary`.
 
-### Primary Buttons
-- **Background**: Linear gradient (centerLeft → centerRight)
-  - `Color(0xFF2D3FE7)` → `Color(0xFF4C63F7)`
-- **Border Radius**: 16px
-- **Height**: 56px
-- **Shadow**: `Color(0xFF2D3FE7)` with 0.3 opacity, blur 12px, offset (0, 6)
-- **Text**: Colors.white, Inter, 16px, FontWeight.w600
+---
 
-### Secondary Buttons (Glass)
-- **Background**: `Colors.white` with 0.08 opacity
-- **Border**: `Colors.white` with 0.1 opacity, 1px width
-- **Border Radius**: 16px
-- **Height**: 56px
-- **Shadow**: `Colors.black` with 0.1 opacity, blur 10px, offset (0, 4)
-- **Text**: Colors.white, Inter, 16px, FontWeight.w500
+## Token Reference
 
-### Text Fields
-- **Background**: `Colors.white` with 0.08 opacity
-- **Border**: `Colors.white` with 0.1 opacity, 1px width
-- **Border Radius**: 16px
-- **Padding**: 24px horizontal, 22px vertical
-- **Icons**: `Colors.white` with 0.6 opacity, size 20px
-- **Text**: Colors.white, 16px
-- **Placeholder**: `Colors.white` with 0.4 opacity
+The 21 tokens defined in `AppTokens`. Use these names — never hard-code colors.
 
-### Navigation Buttons
-- **Background**: `Colors.white` with 0.08 opacity
-- **Border**: `Colors.white` with 0.1 opacity, 1px width
-- **Border Radius**: 12px
-- **Size**: 48x48px
-- **Icon**: Colors.white, size 24px
+| Token                | LaChispa (current)           | Light (spec)             | Dark (spec)              |
+| -------------------- | ---------------------------- | ------------------------ | ------------------------ |
+| `scaffoldBase`       | `#0F1419`                    | `#F7F7F5`                | `#0B0B0C`                |
+| `backgroundGradient` | `#0F1419 → #1A1D47 → #2D3FE7` (diagonal) | solid `#F7F7F5` (no gradient) | solid `#0B0B0C` (no gradient) |
+| `surface`            | `#FFFFFF` @ 5% (glass)       | `#FFFFFF`                | `#141416`                |
+| `dialogBackground`   | `#1A1D47`                    | `#FFFFFF`                | `#1C1C1F`                |
+| `inputFill`          | `#FFFFFF` @ 5%               | `#FFFFFF`                | `#1C1C1F`                |
+| `outline`            | `#FFFFFF` @ 10%              | `#E5E5E0`                | `#2A2A2E`                |
+| `outlineStrong`      | `#FFFFFF` @ 18%              | `#D1D1CC`                | `#3A3A3E`                |
+| `textPrimary`        | `#FFFFFF`                    | `#0D0D0D`                | `#F5F5F5`                |
+| `textSecondary`      | `#FFFFFF` @ 55%              | `#6B6B6B`                | `#9A9A9A`                |
+| `textTertiary`       | `#FFFFFF` @ 45%              | `#9A9A9A`                | `#6B6B6E`                |
+| `textAccent`         | `#6B7FFF`                    | `#3B4FE0`                | `#7E92FF`                |
+| `accentSolid`        | `#4C63F7`                    | `#4C63F7`                | `#4C63F7`                |
+| `accentBright`       | `#5B73FF`                    | `#6B7FFF`                | `#7E92FF`                |
+| `accentForeground`   | `#FFFFFF`                    | `#FFFFFF`                | `#FFFFFF`                |
+| `accentGradient`     | `#2D3FE7 → #4C63F7`          | `#3B4FE0 → #4C63F7`      | `#2D3FE7 → #5B73FF`      |
+| `statusHealthy`      | `#4ADE80`                    | `#10B981`                | `#3BD671`                |
+| `statusUnhealthy`    | `#EF4444`                    | `#DC2626`                | `#FF5C5C`                |
+| `statusWarning`      | `#FFA726`                    | `#D97706`                | `#FFB454`                |
+| `statusWarningSoft`  | `#FFCC80`                    | `#FED7AA`                | `#7A5A2E`                |
+| `statusChecking`     | `#FFFFFF` @ 25%              | `#0D0D0D` @ 20%          | `#FFFFFF` @ 20%          |
+| `ctaShadow`          | `#000000` @ 35%              | `#0D0D0D` @ 8%           | `#000000` @ 60%          |
 
-## Spark Effect
+Status colors are tuned per theme so that contrast against `surface` stays
+≥ 4.5:1 for text and ≥ 3:1 for non-text UI. Hue stays semantically constant
+(green=ok, red=fail, orange=warn).
 
-### Technical Specifications
-- **Frequency**: Every 3 seconds exactly
-- **Quantity per cycle**: 2-4 sparks per screen
-- **Particles per spark**: 10-30 particles
-- **Position**: Random across entire screen
-- **Lifespan**: 100 frames with degradation
+---
 
-### Particle Properties
-- **Size**: 1-4px (random)
-- **Speed**: Organic radial distribution (2-6 intensity)
-- **Deceleration**: 0.99 per frame
-- **Opacity**: EaseOutQuart curve for smooth fade
-- **Colors**:
-  - Outer glow: `Color(0xFF5B73FF)` with 0.4 opacity
-  - Inner glow: `Color(0xFF4C63F7)` with 0.8 opacity
-  - Central particle: `Color(0xFF5B73FF)` with 0.9 opacity
+## Themes
 
-### Rendering Layers
-1. **Outer glow**: 2x radius, blur 2.0
-2. **Inner glow**: 1.5x radius, blur 2.0
-3. **Solid particle**: 1x radius, no blur
+### LaChispa (Original) — “electric · cypherpunk · sovereign”
 
-### Implementation
-- **AnimationController**: 16ms (60 FPS)
-- **Timer**: 3-second intervals
-- **CustomPainter**: SparkPainter with automatic updates
-- **Optimization**: Automatic removal of dead particles
+**Identity:** energy, underground, unmistakable. The visual fingerprint of
+the brand. Glassmorphism over a deep gradient, ambient sparks, blue glow.
+
+- Background is the 3-stop diagonal gradient `#0F1419 → #1A1D47 → #2D3FE7`.
+- Surfaces are **glass**: `Colors.white.withValues(alpha: 0.08)` over the
+  gradient, with a 1px white-@-10% border and a black-@-10% drop shadow.
+- The **Spark particle system** is on (see § Spark System).
+- CTAs use `accentGradient` with a Chispa-blue glow shadow.
+- Border radius: **16px** everywhere (12px on small icon buttons).
+
+### Light — “quiet trust”
+
+**Identity:** clean, calm, unmistakably *not a bank*. Minimalism that doesn't
+intimidate. White space does the heavy lifting.
+
+- Background is **flat** `#F7F7F5` — no gradient.
+- Surfaces are **opaque** `#FFFFFF` with a 1px `outline` border. No glass.
+- Shadows: barely visible (`ctaShadow` @ 8%), only on elevated CTAs.
+- Spark system is **disabled** in Light. (White-on-white sparks are noise,
+  not signal.) Reintroduce only as a brief one-shot during success states.
+- CTAs are solid `accentSolid` with white text. No glow.
+- Border radius: **16px** (consistent with LaChispa).
+
+### Dark — “sovereign tool”
+
+**Identity:** serious instrument, terminal-elegant. Not a generic dark mode —
+a deliberate flat-layered system with high typographic contrast.
+
+- Background is **flat** `#0B0B0C` — no gradient. Layering is achieved with
+  surface elevation (`surface` < `dialogBackground` < CTA), not shadows.
+- Surfaces are opaque (`#141416`, `#1C1C1F`) with a visible 1px `outline`
+  (`#2A2A2E`).
+- Spark system is **muted**: half the spawn rate of LaChispa, 50% opacity,
+  reuses `accentBright`. Off by default; opt-in via settings.
+- CTAs use `accentSolid` with a soft `accentBright` outer glow on press.
+- Border radius: **16px**.
+
+---
+
+## Components
+
+All components use the **same structure** across themes. Only token values
+change. Never branch on theme name in widget code — read tokens.
+
+### Balance widget
+
+- Display: numeric Manrope Medium, 48px (mobile) / 64px (tablet+).
+- Color: `textPrimary` for significant digits, `textTertiary` for leading
+  zeros and the unit suffix (`sats` / `BTC`).
+- Surface: glass card on LaChispa; opaque card on Light/Dark.
+- Animation: digit changes use a 220ms cross-fade (no slot-machine roll —
+  too noisy for monetary data).
+
+### Send / Receive
+
+- Primary action: full-width 56px button using `accentGradient` (LaChispa) or
+  `accentSolid` (Light, Dark). 16px radius. Shadow per theme.
+- Secondary action: outlined or glass-style button using `outline` and
+  `surface`. Same height, same radius, lighter weight.
+- QR display: always rendered with a **white frame** for scanner reliability.
+  In LaChispa and Dark, the frame includes a 12px white inset around the QR.
+  In Light, the frame is the surface itself.
+
+### Transaction history
+
+- Row: 64px tall, `surface` background, 1px `outline` divider between rows.
+- Status indicator (left edge, 4px wide):
+  - confirmed → `statusHealthy`
+  - pending   → `statusChecking` with a subtle pulse
+  - failed    → `statusUnhealthy`
+- Amount: right-aligned, `textPrimary` for incoming (with `+` prefix in
+  `statusHealthy`) and `textPrimary` for outgoing (no special color).
+- Timestamp: `textTertiary`, body small.
+
+### Text fields
+
+- Background: `inputFill`.
+- Border: 1px `outline`, becomes `accentSolid` on focus.
+- Border radius: 16px.
+- Padding: 24px horizontal, 22px vertical.
+- Icons: `textTertiary`, 20px.
+- Placeholder: `textTertiary`.
+
+### Dialogs
+
+- Background: `dialogBackground`.
+- Border radius: 16px.
+- 1px `outline` border in Dark and Light; no border in LaChispa (the surface
+  contrast is sufficient).
+
+---
+
+## UI States
+
+| State    | Effect                                                                  |
+| -------- | ----------------------------------------------------------------------- |
+| Default  | Token defaults                                                          |
+| Hover    | Surface +5% lightness; outline → `outlineStrong`                        |
+| Pressed  | Surface −8% lightness (Light) / +8% lightness (LaChispa, Dark)          |
+| Focus    | Outline → `accentSolid`, 1.5px                                          |
+| Disabled | Opacity 0.4, no shadow, no glow                                         |
+| Loading  | `statusChecking` indeterminate progress; CTA label hidden               |
+| Error    | `statusUnhealthy` 1px outline + helper text in `statusUnhealthy`        |
+| Success  | `statusHealthy` outline pulse 220ms, then return to default             |
+
+Hover applies on web/desktop only. On mobile, ripple uses
+`accentSolid` @ 12% on Light and `accentBright` @ 14% on LaChispa/Dark.
+
+---
+
+## Spark System
+
+The Spark particle system is part of LaChispa's identity. Specs:
+
+- **Cycle:** every 3 seconds. 2–4 sparks per cycle. 10–30 particles per spark.
+- **Position:** uniform random across the screen.
+- **Lifespan:** 100 frames, with `Curves.easeOutQuart` opacity decay.
+- **Particle:** 1–4px radius, organic radial dispersion (intensity 2–6),
+  deceleration 0.99/frame.
+- **Layers:** outer glow (2× radius, blur 2.0) + inner glow (1.5×, blur 2.0)
+  + solid core (1×).
+- **Colors (LaChispa):** outer `#5B73FF` @ 40%, inner `#4C63F7` @ 80%,
+  core `#5B73FF` @ 90%.
+- **Implementation:** `AnimationController` at 16ms (60fps), 3s spawn timer,
+  `SparkPainter` with auto-removal of dead particles.
+
+### Per-theme behavior
+
+| Theme    | Default state | Spawn rate | Opacity |
+| -------- | ------------- | ---------- | ------- |
+| LaChispa | On            | 100%       | 100%    |
+| Dark     | Off (opt-in)  | 50%        | 50%     |
+| Light    | Off           | n/a        | n/a     |
+
+In Light, sparks are reserved for **discrete success moments** (e.g., a payment
+confirmation): a single one-shot burst near the action point, ~400ms total,
+using `accentSolid` instead of `accentBright`.
+
+---
 
 ## Animations
 
-### Entrance Animations (Staggered)
-- **Total Duration**: 1600-2000ms
-- **Curve**: Curves.easeOutCubic
-- **Staggered Intervals**:
-  - Header: 0.0-0.4 (immediate)
-  - Content: 0.3-0.7 (overlapping)
-  - Footer: 0.6-1.0 (final)
-- **Offset**: 30-50px from bottom
-- **Opacity**: 0.0 → 1.0
+### Entrance (staggered)
 
-### Glow Animations
-- **Duration**: 2000ms
-- **Repeat**: reverse: true (ping-pong)
-- **Curve**: Curves.easeInOut
-- **Range**: 0.3 → 1.0
-- **Application**: Title shadows
+- Total duration: **1600–2000ms**.
+- Curve: `Curves.easeOutCubic`.
+- Stagger:
+  - Header: `0.0–0.4` (immediate)
+  - Content: `0.3–0.7` (overlapping)
+  - Footer: `0.6–1.0` (final)
+- Offset: 30–50px from bottom.
+- Opacity: 0 → 1.
 
-## Spacing and Layout
+### Glow (LaChispa, Dark)
 
-### Standard Spacing
-- **Horizontal padding**: 24px
-- **Element spacing**: 16-24px
-- **Large spacing**: 32-48px
-- **Bottom margin**: 32px
+- Duration: 2000ms, ping-pong (`reverse: true`).
+- Curve: `Curves.easeInOut`.
+- Range: 0.3 → 1.0.
+- Application: title shadows, primary CTA glow on press.
 
-### Responsive Design
-- **Mobile breakpoint**: < 600px
-- **Mobile layout**: Vertical column
-- **Tablet layout**: Horizontal row for buttons
-- **Flex**: Spacer(flex: 2) for vertical centering
+### Microinteractions
 
-## Reusable Components
+| Action               | LaChispa                          | Dark                          | Light                       |
+| -------------------- | --------------------------------- | ----------------------------- | --------------------------- |
+| Receive sats         | Spark burst (orange-tinted) + balance pulse | Soft glow pulse on balance card | Single spark burst at amount |
+| Send confirmed       | Quick fade-out → checkmark        | Same as LaChispa              | Checkmark + 220ms scale-in  |
+| Balance changes      | Cross-fade 220ms                  | Cross-fade 220ms              | Cross-fade 220ms            |
+| QR appears           | Scan-line sweep 600ms             | Scan-line sweep 600ms         | Fade-in 300ms               |
+| Copy address         | Inline “Copied” snackbar 1.5s     | Same                          | Same                        |
+| Tap CTA              | Glow flash 180ms                  | Glow flash 180ms              | Subtle scale 0.98 → 1.0     |
 
-### Particle System
-- **Class**: `Particle` with physical properties
-- **Generator**: `_createRandomSpark()` with random distribution
-- **Painter**: `SparkPainter` with optimized rendering
-- **Timer**: `_setupSparkTimer()` for regular cycles
+Respect `MediaQuery.disableAnimations`. When animations are disabled, all
+microinteractions become instantaneous state changes — never silent failures.
 
-### Glassmorphism Pattern
-- Consistently applied to:
-  - Feature cards
-  - Secondary buttons
-  - Input fields
-  - Navigation elements
+---
 
-## Design Patterns
+## Spacing & Layout
 
-### Visual Consistency
-- **Same background gradient** across all screens
-- **Same particle system** as animated background
-- **Same proportions** for similar elements
-- **Same typography** Inter for all text
+- Horizontal padding: **24px**.
+- Element spacing: 16–24px.
+- Section spacing: 32–48px.
+- Bottom safe-area padding: ≥ 32px.
+- Grid: 8px multiples for all spacing.
 
-### Visual Hierarchy
-- **Main titles**: Larger size, bold weight
-- **Subtitles**: Medium size, medium weight
-- **Body text**: Base size, normal weight
-- **Secondary text**: Reduced opacity for less prominence
+### Responsive
 
-### Interactivity
-- **Hover states**: Implicit in ElevatedButton
-- **Loading states**: White CircularProgressIndicator
-- **Visual feedback**: Navigation with transition animations
-- **Accessibility**: White contrast on dark background
+- Mobile (`< 600px`): vertical column, full-width CTAs.
+- Tablet/desktop (`≥ 600px`): horizontal row for paired CTAs; balance card
+  centered with `Spacer(flex: 2)` above and below.
 
-## Technical Implementation
+---
 
-### Animation Structure
-```dart
-late AnimationController _staggerController;
-late AnimationController _sparkController;
-late Animation<double> _titleAnimation;
-// ... more animations
-```
+## Accessibility
 
-### Gradient Configuration
-```dart
-decoration: BoxDecoration(
-  gradient: LinearGradient(
-    begin: Alignment.topLeft,
-    end: Alignment.bottomRight,
-    colors: [
-      Color(0xFF0F1419),
-      Color(0xFF1A1D47),
-      Color(0xFF2D3FE7),
-    ],
-    stops: [0.0, 0.5, 1.0],
-  ),
-)
-```
+- **Contrast:** body text ≥ 4.5:1 against its surface; large text and UI
+  elements ≥ 3:1. Run a contrast check whenever a token value changes.
+- **Tap targets:** ≥ 44×44 logical pixels.
+- **Motion:** all animations have an instantaneous fallback under
+  `MediaQuery.disableAnimations`. Spark system is fully suppressed.
+- **Color is never the only signal:** transaction status uses both color and
+  iconography; errors use color, icon, and helper text.
+- **Localization:** string lengths can grow ~30% in Spanish. CTAs and labels
+  must reflow without truncation.
 
-### Glassmorphism Configuration
-```dart
-decoration: BoxDecoration(
-  color: Colors.white.withValues(alpha: 0.08),
-  borderRadius: BorderRadius.circular(16),
-  border: Border.all(
-    color: Colors.white.withValues(alpha: 0.1),
-    width: 1,
-  ),
-  boxShadow: [
-    BoxShadow(
-      color: Colors.black.withValues(alpha: 0.1),
-      blurRadius: 10,
-      offset: Offset(0, 4),
-    ),
-  ],
-)
-```
+---
 
 ## Implementation Notes
 
+### Reading tokens
+
+```dart
+final tokens = context.tokens;          // AppTokensContext extension
+final color  = tokens.accentSolid;
+```
+
+Never read raw `Color` constants in widget code — go through `context.tokens`.
+
+### Defining a new theme
+
+1. Add an `AppTokens` constant in `lib/theme/themes.dart` (e.g.
+   `lightTokens`, `darkTokens`).
+2. Add a `ThemeData` builder that wires the token set to a
+   `ColorScheme` (`Brightness.light` for Light, `Brightness.dark` for Dark
+   and LaChispa).
+3. Register both via `extensions: [<tokens>]` on the `ThemeData`.
+4. Switch them at the `MaterialApp` level via a `ThemeProvider`
+   (`ChangeNotifier` + `SharedPreferences`), following the same pattern as
+   `LanguageProvider`.
+
 ### Compatibility
-- **Flutter 3.x**: Uses `withValues(alpha: x)` instead of `withOpacity(x)`
-- **60 FPS**: AnimationController with 16ms for smoothness
-- **Performance**: Automatic particle removal to prevent memory leaks
-- **Responsiveness**: LayoutBuilder for adaptation to different sizes
 
-### Quality Standards
-- **Smooth animations**: EaseOutCubic curves for naturalness
-- **Consistent colors**: Limited and coherent palette
-- **Clear typography**: Inter for optimal readability
-- **Proportional spacing**: 8px multiples for consistent grid
+- Flutter 3.x: use `withValues(alpha: x)`, not `withOpacity(x)`.
+- 60fps target: `AnimationController(duration: Duration(milliseconds: 16))`
+  for particle ticks.
+- Particle cleanup is mandatory — leaks compound on long sessions.
 
-This style should be maintained consistently across all future screens and components of the Chispa application.
+### Hardcoded color audit
+
+These files still hard-code colors and must migrate to tokens before the
+multi-theme rollout:
+
+- `lib/screens/8settings_screen.dart:613-615` (internal gradient)
+- `lib/screens/3server_settings_screen.dart:578-579` (direct refs)
+- `lib/screens/9receive_screen.dart:1046` (`#1A1D47` → `dialogBackground`)
+
+---
+
+## Rollout Strategy
+
+When introducing Light or Dark, apply the new tokens to **one screen first**
+(home / balance is the canonical pilot), validate visually against this spec,
+then propagate. Don't ship a half-themed app — every screen reads tokens, so
+the only thing gating a clean switch is the three hard-coded files above.


### PR DESCRIPTION
- Add lightTokens/darkTokens and lightTheme()/darkTheme() builders; Chispa blue (#4C63F7) anchored across all three themes
- New ThemeProvider with SharedPreferences persistence (default LaChispa)
- Theme selector in settings (LaChispa / Claro / Oscuro)
- Localize theme strings in 7 supported languages
- Migrate hardcoded gradients in wallet selector and language modal to dialogBackground token                                              
- Tune light theme send/receive buttons: flat accent, ctaShadow, outlineStrong border for visible affordance on white background
- Update style.md with full 3-theme spec, token mapping table, per-theme spark behavior, and accessibility targets  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Theme selection added to Settings (LaChispa, Light, Dark)
  * Theme choice persists across sessions

* **Style**
  * Updated button, modal, and dialog visuals for consistency across themes
  * Theme-aware dialog/background styling and token-driven color usage

* **Documentation**
  * Expanded design/style guide describing multi-theme tokens, typography, and rollout notes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->