### PR TITLE
history: show invoice QR in transaction details

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -182,6 +182,9 @@
   "theme_light": "Hell",
   "theme_dark": "Dunkel",
 
+  "copy_invoice_button": "Rechnung kopieren",
+  "invoice_copied_message": "Rechnung in die Zwischenablage kopiert",
+
 
   "no_wallet_error": "Keine primäre Wallet verfügbar",
   "invalid_session_error": "Keine aktive Sitzung",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -251,6 +251,9 @@
   "theme_light": "Light",
   "theme_dark": "Dark",
 
+  "copy_invoice_button": "Copy invoice",
+  "invoice_copied_message": "Invoice copied to clipboard",
+
 
   "no_wallet_error": "No primary wallet available",
   "invalid_session_error": "No active session",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -236,6 +236,9 @@
   "theme_light": "Claro",
   "theme_dark": "Oscuro",
 
+  "copy_invoice_button": "Copiar factura",
+  "invoice_copied_message": "Factura copiada al portapapeles",
+
 
   "no_wallet_error": "Sin billetera principal disponible",
   "invalid_session_error": "Sin sesión activa",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -182,6 +182,9 @@
   "theme_light": "Clair",
   "theme_dark": "Sombre",
 
+  "copy_invoice_button": "Copier la facture",
+  "invoice_copied_message": "Facture copiée dans le presse-papiers",
+
 
   "no_wallet_error": "Aucun portefeuille principal disponible",
   "invalid_session_error": "Aucune session active",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -182,6 +182,9 @@
   "theme_light": "Chiaro",
   "theme_dark": "Scuro",
 
+  "copy_invoice_button": "Copia fattura",
+  "invoice_copied_message": "Fattura copiata negli appunti",
+
 
   "no_wallet_error": "Nessun portafoglio principale disponibile",
   "invalid_session_error": "Nessuna sessione attiva",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -182,6 +182,9 @@
   "theme_light": "Claro",
   "theme_dark": "Escuro",
 
+  "copy_invoice_button": "Copiar fatura",
+  "invoice_copied_message": "Fatura copiada para a área de transferência",
+
 
   "no_wallet_error": "Sem carteira principal disponível",
   "invalid_session_error": "Sem sessão ativa",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -182,6 +182,9 @@
   "theme_light": "Светлая",
   "theme_dark": "Тёмная",
 
+  "copy_invoice_button": "Копировать счёт",
+  "invoice_copied_message": "Счёт скопирован в буфер обмена",
+
 
   "no_wallet_error": "Нет доступного основного кошелька",
   "invalid_session_error": "Нет активной сессии",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1332,6 +1332,18 @@ abstract class AppLocalizations {
   /// **'Oscuro'**
   String get theme_dark;
 
+  /// No description provided for @copy_invoice_button.
+  ///
+  /// In es, this message translates to:
+  /// **'Copiar factura'**
+  String get copy_invoice_button;
+
+  /// No description provided for @invoice_copied_message.
+  ///
+  /// In es, this message translates to:
+  /// **'Factura copiada al portapapeles'**
+  String get invoice_copied_message;
+
   /// No description provided for @no_wallet_error.
   ///
   /// In es, this message translates to:

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -675,6 +675,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get theme_dark => 'Dunkel';
 
   @override
+  String get copy_invoice_button => 'Rechnung kopieren';
+
+  @override
+  String get invoice_copied_message => 'Rechnung in die Zwischenablage kopiert';
+
+  @override
   String get no_wallet_error => 'Keine primäre Wallet verfügbar';
 
   @override

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -659,6 +659,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get theme_dark => 'Dark';
 
   @override
+  String get copy_invoice_button => 'Copy invoice';
+
+  @override
+  String get invoice_copied_message => 'Invoice copied to clipboard';
+
+  @override
   String get no_wallet_error => 'No primary wallet available';
 
   @override

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -665,6 +665,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get theme_dark => 'Oscuro';
 
   @override
+  String get copy_invoice_button => 'Copiar factura';
+
+  @override
+  String get invoice_copied_message => 'Factura copiada al portapapeles';
+
+  @override
   String get no_wallet_error => 'Sin billetera principal disponible';
 
   @override

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -678,6 +678,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get theme_dark => 'Sombre';
 
   @override
+  String get copy_invoice_button => 'Copier la facture';
+
+  @override
+  String get invoice_copied_message => 'Facture copiée dans le presse-papiers';
+
+  @override
   String get no_wallet_error => 'Aucun portefeuille principal disponible';
 
   @override

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -677,6 +677,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get theme_dark => 'Scuro';
 
   @override
+  String get copy_invoice_button => 'Copia fattura';
+
+  @override
+  String get invoice_copied_message => 'Fattura copiata negli appunti';
+
+  @override
   String get no_wallet_error => 'Nessun portafoglio principale disponibile';
 
   @override

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -664,6 +664,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get theme_dark => 'Escuro';
 
   @override
+  String get copy_invoice_button => 'Copiar fatura';
+
+  @override
+  String get invoice_copied_message =>
+      'Fatura copiada para a área de transferência';
+
+  @override
   String get no_wallet_error => 'Sem carteira principal disponível';
 
   @override

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -660,6 +660,12 @@ class AppLocalizationsRu extends AppLocalizations {
   String get theme_dark => 'Тёмная';
 
   @override
+  String get copy_invoice_button => 'Копировать счёт';
+
+  @override
+  String get invoice_copied_message => 'Счёт скопирован в буфер обмена';
+
+  @override
   String get no_wallet_error => 'Нет доступного основного кошелька';
 
   @override

--- a/lib/screens/7history_screen.dart
+++ b/lib/screens/7history_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
+import 'package:qr_flutter/qr_flutter.dart';
 import 'dart:async';
 import 'dart:math' as math;
 import '../providers/auth_provider.dart';
@@ -831,6 +833,11 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
 
             const SizedBox(height: 24),
 
+            if (transaction.invoice != null && transaction.invoice!.isNotEmpty) ...[
+              _buildInvoiceQRSection(transaction, t),
+              const SizedBox(height: 24),
+            ],
+
             _buildDetailRow(t, 'Date', transaction.formattedDate),
             _buildDetailRow(t, 'Description', transaction.memo.isEmpty ? AppLocalizations.of(context)!.no_description_text : transaction.memo),
             if (transaction.originalFiatAmount != null && transaction.originalFiatCurrency != null) ...[
@@ -846,32 +853,85 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
             if (transaction.paymentHash != null)
               _buildDetailRow(t, 'Hash', transaction.paymentHash!, copyable: true),
             if (transaction.fee != null)
-              _buildDetailRow(t, 'Fee', '${transaction.fee} msat'),
+              _buildDetailRow(t, 'Fee', '${(transaction.fee! / 1000).toStringAsFixed(3)} sats'),
             _buildDetailRow(t, AppLocalizations.of(context)!.invoice_status_label, _getTransactionStatus(transaction)),
-
-            const SizedBox(height: 16),
-
-            // Close button
-            SizedBox(
-              width: double.infinity,
-              child: ElevatedButton(
-                onPressed: () => Navigator.pop(context),
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: t.accentSolid,
-                  foregroundColor: t.accentForeground,
-                  padding: const EdgeInsets.symmetric(vertical: 16),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                ),
-                child: Text(AppLocalizations.of(context)!.cancel_button),
-              ),
-            ),
                 ],
               ),
             ),
           ),
         ),
+      ),
+    );
+  }
+
+  Widget _buildInvoiceQRSection(TransactionInfo transaction, AppTokens t) {
+    final invoice = transaction.invoice!;
+    final l = AppLocalizations.of(context)!;
+    return Column(
+      children: [
+        Center(
+          child: Container(
+            padding: const EdgeInsets.all(8),
+            decoration: BoxDecoration(
+              color: t.textPrimary,
+              borderRadius: BorderRadius.circular(6),
+              border: Border.all(color: t.outlineStrong),
+            ),
+            child: QrImageView(
+              data: invoice,
+              version: QrVersions.auto,
+              size: 300.0,
+              backgroundColor: Colors.white,
+              errorCorrectionLevel: QrErrorCorrectLevel.H,
+              eyeStyle: const QrEyeStyle(
+                eyeShape: QrEyeShape.square,
+                color: Colors.black,
+              ),
+              dataModuleStyle: const QrDataModuleStyle(
+                dataModuleShape: QrDataModuleShape.square,
+                color: Colors.black,
+              ),
+              embeddedImage: const AssetImage('Logo/chispalogoredondo.png'),
+              embeddedImageStyle: const QrEmbeddedImageStyle(
+                size: Size(60, 60),
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: 12),
+        SizedBox(
+          width: double.infinity,
+          child: OutlinedButton.icon(
+            onPressed: () => _copyInvoice(invoice),
+            icon: Icon(Icons.copy, size: 18, color: t.textPrimary),
+            label: Text(
+              l.copy_invoice_button,
+              style: TextStyle(
+                color: t.textPrimary,
+                fontSize: 14,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+            style: OutlinedButton.styleFrom(
+              side: BorderSide(color: t.outlineStrong, width: 1),
+              padding: const EdgeInsets.symmetric(vertical: 12),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _copyInvoice(String invoice) async {
+    await Clipboard.setData(ClipboardData(text: invoice));
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(AppLocalizations.of(context)!.invoice_copied_message),
+        duration: const Duration(seconds: 2),
       ),
     );
   }

--- a/lib/screens/7history_screen.dart
+++ b/lib/screens/7history_screen.dart
@@ -880,7 +880,9 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
             child: QrImageView(
               data: invoice,
               version: QrVersions.auto,
-              size: 300.0,
+              // Cap at 300 on wide screens; shrink to fit narrow phones (sheet
+              // padding 24*2 + container padding 8*2 = 64 logical pixels reserved).
+              size: math.min(300.0, MediaQuery.of(context).size.width - 64),
               backgroundColor: Colors.white,
               errorCorrectionLevel: QrErrorCorrectLevel.H,
               eyeStyle: const QrEyeStyle(


### PR DESCRIPTION
- Render bolt11 QR (300px) with embedded logo in the transaction detail bottom sheet for both incoming and outgoing payments
- Add "Copy invoice" button below the QR with clipboard snackbar
- Format fee in sats with 3 decimals (e.g. 46.620 sats) instead of msat  
- Drop redundant Close button sheet dismisses by drag/tap-outside
- Localize copy_invoice_button and invoice_copied_message in 7 languages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added invoice copy-to-clipboard functionality with localized confirmation messages.
  * Transaction details now display invoice QR codes with integrated copy action.
  * Extended localization to German, English, Spanish, French, Italian, Portuguese, and Russian.

* **Improvements**
  * Updated fee display from milliseconds to sats format for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->