### PR TITLE
fix(android): persist auth session across app restarts

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,9 @@
     <application
         android:label="LaChispa"
         android:name="${applicationName}"
-        android:icon="@mipmap/launcher_icon">
+        android:icon="@mipmap/launcher_icon"
+        android:allowBackup="false"
+        android:fullBackupContent="false">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -14,9 +14,11 @@ class AuthService {
   final Dio _dio;
   final FlutterSecureStorage _storage;
   
-  AuthService() 
+  AuthService()
     : _dio = Dio(),
-      _storage = const FlutterSecureStorage() {
+      _storage = const FlutterSecureStorage(
+          aOptions: AndroidOptions(encryptedSharedPreferences: true),
+        ) {
     _configureDio();
   }
 

--- a/lib/services/user_credentials_service.dart
+++ b/lib/services/user_credentials_service.dart
@@ -9,7 +9,9 @@ import '../models/saved_user.dart';
 class UserCredentialsService {
   static const String _masterKeyName = 'master_encryption_key';
   static const String _savedUsersKey = 'saved_users_list';
-  static const _secureStorage = FlutterSecureStorage();
+  static const _secureStorage = FlutterSecureStorage(
+    aOptions: AndroidOptions(encryptedSharedPreferences: true),
+  );
   
   // Helper for safe substring
   String _safeSubstring(String? str, int start, int? end, {String suffix = '...'}) {


### PR DESCRIPTION
flutter_secure_storage on Android defaulted to legacy Keystore-based encryption that intermittently corrupts data when the OS kills the process or restores from auto-backup. Switch to encryptedSharedPreferences and disable Android Auto Backup to prevent the JWT from being lost between app close and reopen.
Refs #44  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automatic device backups to enhance data privacy and security
  * Enhanced encryption for stored authentication data on Android devices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->