### PR TITLE
feat(receive): redesign screen + real NFC Boltcard charging

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.NFC" />
+    <uses-feature android:name="android.hardware.nfc" android:required="false" />
+
     <application
         android:label="LaChispa"
         android:name="${applicationName}"

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -371,6 +371,7 @@
   "nfc_charging_message": "Wird belastet...",
   "nfc_invalid_tag_message": "Ungültiges Tag oder keine Boltcard",
   "nfc_charge_error_prefix": "NFC-Fehler beim Einziehen: ",
+  "nfc_charge_unknown_error": "Unbekannter Fehler beim Einziehen",
   "share_ready_message": "Bereit zum Teilen",
   "lnurl_copied_message": "LNURL in die Zwischenablage kopiert"
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -363,5 +363,14 @@
 
   "clear_invoice_button": "Rechnung löschen",
   "invoice_cleared_message": "Rechnung gelöscht",
-  "invoice_monitoring_timeout_message": "Überwachung gestoppt. Erstellen Sie eine neue Rechnung."
+  "invoice_monitoring_timeout_message": "Überwachung gestoppt. Erstellen Sie eine neue Rechnung.",
+  "nfc_action_label": "NFC",
+  "nfc_unavailable_message": "NFC auf diesem Gerät nicht verfügbar",
+  "nfc_scanning_title": "Mit NFC einziehen",
+  "nfc_scanning_message": "Halten Sie die Boltcard an das Telefon",
+  "nfc_charging_message": "Wird belastet...",
+  "nfc_invalid_tag_message": "Ungültiges Tag oder keine Boltcard",
+  "nfc_charge_error_prefix": "NFC-Fehler beim Einziehen: ",
+  "share_ready_message": "Bereit zum Teilen",
+  "lnurl_copied_message": "LNURL in die Zwischenablage kopiert"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -386,6 +386,7 @@
   "nfc_charging_message": "Charging...",
   "nfc_invalid_tag_message": "Invalid tag or not a Boltcard",
   "nfc_charge_error_prefix": "NFC charge error: ",
+  "nfc_charge_unknown_error": "Unknown error during charge",
   "share_ready_message": "Ready to share",
   "lnurl_copied_message": "LNURL copied to clipboard"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -378,5 +378,14 @@
 
   "clear_invoice_button": "Clear invoice",
   "invoice_cleared_message": "Invoice cleared",
-  "invoice_monitoring_timeout_message": "Monitoring stopped. Generate a new invoice."
+  "invoice_monitoring_timeout_message": "Monitoring stopped. Generate a new invoice.",
+  "nfc_action_label": "NFC",
+  "nfc_unavailable_message": "NFC not available on this device",
+  "nfc_scanning_title": "Charge with NFC",
+  "nfc_scanning_message": "Tap the Boltcard against the phone",
+  "nfc_charging_message": "Charging...",
+  "nfc_invalid_tag_message": "Invalid tag or not a Boltcard",
+  "nfc_charge_error_prefix": "NFC charge error: ",
+  "share_ready_message": "Ready to share",
+  "lnurl_copied_message": "LNURL copied to clipboard"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -371,6 +371,7 @@
   "nfc_charging_message": "Cobrando...",
   "nfc_invalid_tag_message": "Tag inválido o no es una Boltcard",
   "nfc_charge_error_prefix": "Error en cobro NFC: ",
+  "nfc_charge_unknown_error": "Error desconocido al cobrar",
   "share_ready_message": "Listo para compartir",
   "lnurl_copied_message": "LNURL copiado al portapapeles"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -363,5 +363,14 @@
 
   "clear_invoice_button": "Limpiar factura",
   "invoice_cleared_message": "Factura limpiada",
-  "invoice_monitoring_timeout_message": "Monitoreo detenido. Genera una nueva factura."
+  "invoice_monitoring_timeout_message": "Monitoreo detenido. Genera una nueva factura.",
+  "nfc_action_label": "NFC",
+  "nfc_unavailable_message": "NFC no disponible en este dispositivo",
+  "nfc_scanning_title": "Cobrar con NFC",
+  "nfc_scanning_message": "Acerca la Boltcard al teléfono",
+  "nfc_charging_message": "Cobrando...",
+  "nfc_invalid_tag_message": "Tag inválido o no es una Boltcard",
+  "nfc_charge_error_prefix": "Error en cobro NFC: ",
+  "share_ready_message": "Listo para compartir",
+  "lnurl_copied_message": "LNURL copiado al portapapeles"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -371,6 +371,7 @@
   "nfc_charging_message": "Encaissement en cours...",
   "nfc_invalid_tag_message": "Tag invalide ou pas de Boltcard",
   "nfc_charge_error_prefix": "Erreur d'encaissement NFC : ",
+  "nfc_charge_unknown_error": "Erreur inconnue lors de l'encaissement",
   "share_ready_message": "Prêt à partager",
   "lnurl_copied_message": "LNURL copié dans le presse-papiers"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -363,5 +363,14 @@
 
   "clear_invoice_button": "Effacer la facture",
   "invoice_cleared_message": "Facture effacée",
-  "invoice_monitoring_timeout_message": "Surveillance arrêtée. Générez une nouvelle facture."
+  "invoice_monitoring_timeout_message": "Surveillance arrêtée. Générez une nouvelle facture.",
+  "nfc_action_label": "NFC",
+  "nfc_unavailable_message": "NFC non disponible sur cet appareil",
+  "nfc_scanning_title": "Encaisser avec NFC",
+  "nfc_scanning_message": "Approchez la Boltcard du téléphone",
+  "nfc_charging_message": "Encaissement en cours...",
+  "nfc_invalid_tag_message": "Tag invalide ou pas de Boltcard",
+  "nfc_charge_error_prefix": "Erreur d'encaissement NFC : ",
+  "share_ready_message": "Prêt à partager",
+  "lnurl_copied_message": "LNURL copié dans le presse-papiers"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -363,5 +363,14 @@
 
   "clear_invoice_button": "Cancella fattura",
   "invoice_cleared_message": "Fattura cancellata",
-  "invoice_monitoring_timeout_message": "Monitoraggio interrotto. Genera una nuova fattura."
+  "invoice_monitoring_timeout_message": "Monitoraggio interrotto. Genera una nuova fattura.",
+  "nfc_action_label": "NFC",
+  "nfc_unavailable_message": "NFC non disponibile su questo dispositivo",
+  "nfc_scanning_title": "Incassa con NFC",
+  "nfc_scanning_message": "Avvicina la Boltcard al telefono",
+  "nfc_charging_message": "Incasso in corso...",
+  "nfc_invalid_tag_message": "Tag non valido o non è una Boltcard",
+  "nfc_charge_error_prefix": "Errore incasso NFC: ",
+  "share_ready_message": "Pronto da condividere",
+  "lnurl_copied_message": "LNURL copiato negli appunti"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -371,6 +371,7 @@
   "nfc_charging_message": "Incasso in corso...",
   "nfc_invalid_tag_message": "Tag non valido o non è una Boltcard",
   "nfc_charge_error_prefix": "Errore incasso NFC: ",
+  "nfc_charge_unknown_error": "Errore sconosciuto durante l'incasso",
   "share_ready_message": "Pronto da condividere",
   "lnurl_copied_message": "LNURL copiato negli appunti"
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -371,6 +371,7 @@
   "nfc_charging_message": "Cobrando...",
   "nfc_invalid_tag_message": "Tag inválido ou não é uma Boltcard",
   "nfc_charge_error_prefix": "Erro ao cobrar com NFC: ",
+  "nfc_charge_unknown_error": "Erro desconhecido ao cobrar",
   "share_ready_message": "Pronto para compartilhar",
   "lnurl_copied_message": "LNURL copiado para a área de transferência"
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -363,5 +363,14 @@
 
   "clear_invoice_button": "Limpar fatura",
   "invoice_cleared_message": "Fatura limpa",
-  "invoice_monitoring_timeout_message": "Monitoramento parado. Gera uma nova fatura."
+  "invoice_monitoring_timeout_message": "Monitoramento parado. Gera uma nova fatura.",
+  "nfc_action_label": "NFC",
+  "nfc_unavailable_message": "NFC não disponível neste dispositivo",
+  "nfc_scanning_title": "Cobrar com NFC",
+  "nfc_scanning_message": "Aproxime a Boltcard do telefone",
+  "nfc_charging_message": "Cobrando...",
+  "nfc_invalid_tag_message": "Tag inválido ou não é uma Boltcard",
+  "nfc_charge_error_prefix": "Erro ao cobrar com NFC: ",
+  "share_ready_message": "Pronto para compartilhar",
+  "lnurl_copied_message": "LNURL copiado para a área de transferência"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -371,6 +371,7 @@
   "nfc_charging_message": "Списание...",
   "nfc_invalid_tag_message": "Неверный тег или это не Boltcard",
   "nfc_charge_error_prefix": "Ошибка приёма по NFC: ",
+  "nfc_charge_unknown_error": "Неизвестная ошибка при списании",
   "share_ready_message": "Готово к отправке",
   "lnurl_copied_message": "LNURL скопирован в буфер обмена"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -363,5 +363,14 @@
 
   "clear_invoice_button": "Очистить счёт",
   "invoice_cleared_message": "Счёт очищен",
-  "invoice_monitoring_timeout_message": "Мониторинг остановлен. Создайте новый счёт."
+  "invoice_monitoring_timeout_message": "Мониторинг остановлен. Создайте новый счёт.",
+  "nfc_action_label": "NFC",
+  "nfc_unavailable_message": "NFC недоступен на этом устройстве",
+  "nfc_scanning_title": "Приём через NFC",
+  "nfc_scanning_message": "Поднесите Boltcard к телефону",
+  "nfc_charging_message": "Списание...",
+  "nfc_invalid_tag_message": "Неверный тег или это не Boltcard",
+  "nfc_charge_error_prefix": "Ошибка приёма по NFC: ",
+  "share_ready_message": "Готово к отправке",
+  "lnurl_copied_message": "LNURL скопирован в буфер обмена"
 }

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1884,6 +1884,12 @@ abstract class AppLocalizations {
   /// **'Error en cobro NFC: '**
   String get nfc_charge_error_prefix;
 
+  /// No description provided for @nfc_charge_unknown_error.
+  ///
+  /// In es, this message translates to:
+  /// **'Error desconocido al cobrar'**
+  String get nfc_charge_unknown_error;
+
   /// No description provided for @share_ready_message.
   ///
   /// In es, this message translates to:

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1841,6 +1841,60 @@ abstract class AppLocalizations {
   /// In es, this message translates to:
   /// **'Monitoreo detenido. Genera una nueva factura.'**
   String get invoice_monitoring_timeout_message;
+
+  /// No description provided for @nfc_action_label.
+  ///
+  /// In es, this message translates to:
+  /// **'NFC'**
+  String get nfc_action_label;
+
+  /// No description provided for @nfc_unavailable_message.
+  ///
+  /// In es, this message translates to:
+  /// **'NFC no disponible en este dispositivo'**
+  String get nfc_unavailable_message;
+
+  /// No description provided for @nfc_scanning_title.
+  ///
+  /// In es, this message translates to:
+  /// **'Cobrar con NFC'**
+  String get nfc_scanning_title;
+
+  /// No description provided for @nfc_scanning_message.
+  ///
+  /// In es, this message translates to:
+  /// **'Acerca la Boltcard al teléfono'**
+  String get nfc_scanning_message;
+
+  /// No description provided for @nfc_charging_message.
+  ///
+  /// In es, this message translates to:
+  /// **'Cobrando...'**
+  String get nfc_charging_message;
+
+  /// No description provided for @nfc_invalid_tag_message.
+  ///
+  /// In es, this message translates to:
+  /// **'Tag inválido o no es una Boltcard'**
+  String get nfc_invalid_tag_message;
+
+  /// No description provided for @nfc_charge_error_prefix.
+  ///
+  /// In es, this message translates to:
+  /// **'Error en cobro NFC: '**
+  String get nfc_charge_error_prefix;
+
+  /// No description provided for @share_ready_message.
+  ///
+  /// In es, this message translates to:
+  /// **'Listo para compartir'**
+  String get share_ready_message;
+
+  /// No description provided for @lnurl_copied_message.
+  ///
+  /// In es, this message translates to:
+  /// **'LNURL copiado al portapapeles'**
+  String get lnurl_copied_message;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -968,4 +968,31 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get invoice_monitoring_timeout_message =>
       'Überwachung gestoppt. Erstellen Sie eine neue Rechnung.';
+
+  @override
+  String get nfc_action_label => 'NFC';
+
+  @override
+  String get nfc_unavailable_message => 'NFC auf diesem Gerät nicht verfügbar';
+
+  @override
+  String get nfc_scanning_title => 'Mit NFC einziehen';
+
+  @override
+  String get nfc_scanning_message => 'Halten Sie die Boltcard an das Telefon';
+
+  @override
+  String get nfc_charging_message => 'Wird belastet...';
+
+  @override
+  String get nfc_invalid_tag_message => 'Ungültiges Tag oder keine Boltcard';
+
+  @override
+  String get nfc_charge_error_prefix => 'NFC-Fehler beim Einziehen: ';
+
+  @override
+  String get share_ready_message => 'Bereit zum Teilen';
+
+  @override
+  String get lnurl_copied_message => 'LNURL in die Zwischenablage kopiert';
 }

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -991,6 +991,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get nfc_charge_error_prefix => 'NFC-Fehler beim Einziehen: ';
 
   @override
+  String get nfc_charge_unknown_error => 'Unbekannter Fehler beim Einziehen';
+
+  @override
   String get share_ready_message => 'Bereit zum Teilen';
 
   @override

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -944,4 +944,31 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get invoice_monitoring_timeout_message =>
       'Monitoring stopped. Generate a new invoice.';
+
+  @override
+  String get nfc_action_label => 'NFC';
+
+  @override
+  String get nfc_unavailable_message => 'NFC not available on this device';
+
+  @override
+  String get nfc_scanning_title => 'Charge with NFC';
+
+  @override
+  String get nfc_scanning_message => 'Tap the Boltcard against the phone';
+
+  @override
+  String get nfc_charging_message => 'Charging...';
+
+  @override
+  String get nfc_invalid_tag_message => 'Invalid tag or not a Boltcard';
+
+  @override
+  String get nfc_charge_error_prefix => 'NFC charge error: ';
+
+  @override
+  String get share_ready_message => 'Ready to share';
+
+  @override
+  String get lnurl_copied_message => 'LNURL copied to clipboard';
 }

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -967,6 +967,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get nfc_charge_error_prefix => 'NFC charge error: ';
 
   @override
+  String get nfc_charge_unknown_error => 'Unknown error during charge';
+
+  @override
   String get share_ready_message => 'Ready to share';
 
   @override

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -957,4 +957,31 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get invoice_monitoring_timeout_message =>
       'Monitoreo detenido. Genera una nueva factura.';
+
+  @override
+  String get nfc_action_label => 'NFC';
+
+  @override
+  String get nfc_unavailable_message => 'NFC no disponible en este dispositivo';
+
+  @override
+  String get nfc_scanning_title => 'Cobrar con NFC';
+
+  @override
+  String get nfc_scanning_message => 'Acerca la Boltcard al teléfono';
+
+  @override
+  String get nfc_charging_message => 'Cobrando...';
+
+  @override
+  String get nfc_invalid_tag_message => 'Tag inválido o no es una Boltcard';
+
+  @override
+  String get nfc_charge_error_prefix => 'Error en cobro NFC: ';
+
+  @override
+  String get share_ready_message => 'Listo para compartir';
+
+  @override
+  String get lnurl_copied_message => 'LNURL copiado al portapapeles';
 }

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -980,6 +980,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get nfc_charge_error_prefix => 'Error en cobro NFC: ';
 
   @override
+  String get nfc_charge_unknown_error => 'Error desconocido al cobrar';
+
+  @override
   String get share_ready_message => 'Listo para compartir';
 
   @override

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -974,4 +974,31 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get invoice_monitoring_timeout_message =>
       'Surveillance arrêtée. Générez une nouvelle facture.';
+
+  @override
+  String get nfc_action_label => 'NFC';
+
+  @override
+  String get nfc_unavailable_message => 'NFC non disponible sur cet appareil';
+
+  @override
+  String get nfc_scanning_title => 'Encaisser avec NFC';
+
+  @override
+  String get nfc_scanning_message => 'Approchez la Boltcard du téléphone';
+
+  @override
+  String get nfc_charging_message => 'Encaissement en cours...';
+
+  @override
+  String get nfc_invalid_tag_message => 'Tag invalide ou pas de Boltcard';
+
+  @override
+  String get nfc_charge_error_prefix => 'Erreur d\'encaissement NFC : ';
+
+  @override
+  String get share_ready_message => 'Prêt à partager';
+
+  @override
+  String get lnurl_copied_message => 'LNURL copié dans le presse-papiers';
 }

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -997,6 +997,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get nfc_charge_error_prefix => 'Erreur d\'encaissement NFC : ';
 
   @override
+  String get nfc_charge_unknown_error =>
+      'Erreur inconnue lors de l\'encaissement';
+
+  @override
   String get share_ready_message => 'Prêt à partager';
 
   @override

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -969,4 +969,32 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get invoice_monitoring_timeout_message =>
       'Monitoraggio interrotto. Genera una nuova fattura.';
+
+  @override
+  String get nfc_action_label => 'NFC';
+
+  @override
+  String get nfc_unavailable_message =>
+      'NFC non disponibile su questo dispositivo';
+
+  @override
+  String get nfc_scanning_title => 'Incassa con NFC';
+
+  @override
+  String get nfc_scanning_message => 'Avvicina la Boltcard al telefono';
+
+  @override
+  String get nfc_charging_message => 'Incasso in corso...';
+
+  @override
+  String get nfc_invalid_tag_message => 'Tag non valido o non è una Boltcard';
+
+  @override
+  String get nfc_charge_error_prefix => 'Errore incasso NFC: ';
+
+  @override
+  String get share_ready_message => 'Pronto da condividere';
+
+  @override
+  String get lnurl_copied_message => 'LNURL copiato negli appunti';
 }

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -993,6 +993,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get nfc_charge_error_prefix => 'Errore incasso NFC: ';
 
   @override
+  String get nfc_charge_unknown_error =>
+      'Errore sconosciuto durante l\'incasso';
+
+  @override
   String get share_ready_message => 'Pronto da condividere';
 
   @override

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -979,6 +979,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get nfc_charge_error_prefix => 'Erro ao cobrar com NFC: ';
 
   @override
+  String get nfc_charge_unknown_error => 'Erro desconhecido ao cobrar';
+
+  @override
   String get share_ready_message => 'Pronto para compartilhar';
 
   @override

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -956,4 +956,32 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get invoice_monitoring_timeout_message =>
       'Monitoramento parado. Gera uma nova fatura.';
+
+  @override
+  String get nfc_action_label => 'NFC';
+
+  @override
+  String get nfc_unavailable_message => 'NFC não disponível neste dispositivo';
+
+  @override
+  String get nfc_scanning_title => 'Cobrar com NFC';
+
+  @override
+  String get nfc_scanning_message => 'Aproxime a Boltcard do telefone';
+
+  @override
+  String get nfc_charging_message => 'Cobrando...';
+
+  @override
+  String get nfc_invalid_tag_message => 'Tag inválido ou não é uma Boltcard';
+
+  @override
+  String get nfc_charge_error_prefix => 'Erro ao cobrar com NFC: ';
+
+  @override
+  String get share_ready_message => 'Pronto para compartilhar';
+
+  @override
+  String get lnurl_copied_message =>
+      'LNURL copiado para a área de transferência';
 }

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -971,6 +971,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get nfc_charge_error_prefix => 'Ошибка приёма по NFC: ';
 
   @override
+  String get nfc_charge_unknown_error => 'Неизвестная ошибка при списании';
+
+  @override
   String get share_ready_message => 'Готово к отправке';
 
   @override

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -948,4 +948,31 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get invoice_monitoring_timeout_message =>
       'Мониторинг остановлен. Создайте новый счёт.';
+
+  @override
+  String get nfc_action_label => 'NFC';
+
+  @override
+  String get nfc_unavailable_message => 'NFC недоступен на этом устройстве';
+
+  @override
+  String get nfc_scanning_title => 'Приём через NFC';
+
+  @override
+  String get nfc_scanning_message => 'Поднесите Boltcard к телефону';
+
+  @override
+  String get nfc_charging_message => 'Списание...';
+
+  @override
+  String get nfc_invalid_tag_message => 'Неверный тег или это не Boltcard';
+
+  @override
+  String get nfc_charge_error_prefix => 'Ошибка приёма по NFC: ';
+
+  @override
+  String get share_ready_message => 'Готово к отправке';
+
+  @override
+  String get lnurl_copied_message => 'LNURL скопирован в буфер обмена';
 }

--- a/lib/screens/9receive_screen.dart
+++ b/lib/screens/9receive_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:qr_flutter/qr_flutter.dart';
+import 'package:share_plus/share_plus.dart';
 import 'dart:async';
 import '../providers/auth_provider.dart';
 import '../providers/wallet_provider.dart';
@@ -11,11 +12,11 @@ import '../models/ln_address.dart';
 import '../services/invoice_service.dart';
 import '../services/yadio_service.dart';
 import '../services/transaction_detector.dart';
+import '../services/nfc_charge_service.dart';
 import '../models/lightning_invoice.dart';
 import '../models/wallet_info.dart';
 import '../l10n/generated/app_localizations.dart';
 import '../theme/app_tokens.dart';
-import '../widgets/universal_screen_wrapper.dart';
 import '7ln_address_screen.dart';
 import 'voucher_scan_screen.dart';
 
@@ -27,32 +28,22 @@ class ReceiveScreen extends StatefulWidget {
 }
 
 class _ReceiveScreenState extends State<ReceiveScreen> {
-  // Cache for generated LNURL
-  String? _cachedLightningAddress;
-  String? _cachedLNURL;
-  Future<String?>? _lnurlFuture;
-  
-  // State for information panel
-  bool _isInfoExpanded = false;
-  
-  // State for request amount modal
   final _amountController = TextEditingController();
   final _noteController = TextEditingController();
   String _selectedCurrency = 'sats';
   List<String> _currencies = ['sats'];
-  
-  // State for generated invoice
+
   LightningInvoice? _generatedInvoice;
   final InvoiceService _invoiceService = InvoiceService();
   final YadioService _yadioService = YadioService();
   final TransactionDetector _transactionDetector = TransactionDetector();
   bool _isGeneratingInvoice = false;
-  
-  // Timer to verify invoice payment
-  Timer? _invoicePaymentTimer;
 
-  // Timer that stops invoice monitoring after a long idle window
+  Timer? _invoicePaymentTimer;
   Timer? _invoicePaymentTimeoutTimer;
+
+  bool _nfcAvailable = false;
+  bool _nfcChecked = false;
 
   @override
   void initState() {
@@ -60,99 +51,66 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _initializeLightningAddress();
       _initializeCurrencies();
+      _checkNfcAvailability();
     });
   }
-  
+
+  Future<void> _checkNfcAvailability() async {
+    final available = await NfcChargeService.isAvailable();
+    if (!mounted) return;
+    setState(() {
+      _nfcAvailable = available;
+      _nfcChecked = true;
+    });
+  }
+
   void _initializeCurrencies() async {
     final currencyProvider = context.read<CurrencySettingsProvider>();
     final authProvider = context.read<AuthProvider>();
-    
-    print('[RECEIVE_SCREEN] Initializing currencies...');
-    print('[RECEIVE_SCREEN] Server URL: ${authProvider.currentServer}');
-    
-    // Ensure provider has server URL configured
+
     if (authProvider.currentServer != null) {
       await currencyProvider.updateServerUrl(authProvider.currentServer);
-      
-      // Force load exchange rates to ensure they're available
       await currencyProvider.loadExchangeRates(forceRefresh: true);
-      
-      print('[RECEIVE_SCREEN] Available currencies: ${currencyProvider.availableCurrencies}');
-      print('[RECEIVE_SCREEN] Exchange rates loaded: ${currencyProvider.availableCurrencies.isNotEmpty}');
     }
-    
+
     final displaySequence = currencyProvider.displaySequence;
-    
+
     if (mounted) {
       setState(() {
         _currencies = displaySequence.isNotEmpty ? displaySequence : ['sats'];
-        // Ensure selected currency is valid
         if (!_currencies.contains(_selectedCurrency)) {
           _selectedCurrency = _currencies.first;
         }
       });
     }
-    
-    print('[RECEIVE_SCREEN] Final currencies: $_currencies');
-    print('[RECEIVE_SCREEN] Selected currency: $_selectedCurrency');
   }
-  
-  /// Convert fiat amount to sats using inverse conversion (same method as amount_screen)
+
   Future<int> _getAmountInSats(double amount, String currency) async {
-    print('[RECEIVE_SCREEN] Converting $amount $currency to sats');
-    
     if (currency == 'sats') {
       return amount.round();
     }
-    
-    // Use INVERSE conversion from the working convertSatsToFiat method
-    // This ensures we use exactly the same rates as home_screen
+
     try {
       final currencyProvider = context.read<CurrencySettingsProvider>();
-      
-      print('[RECEIVE_SCREEN] Using inverse conversion method for consistency');
-      
-      // Step 1: Get rate by converting 1 BTC (100M sats) to fiat
-      const oneBtcInSats = 100000000; // 1 BTC = 100M sats
+      const oneBtcInSats = 100000000;
       final oneBtcInFiat = await currencyProvider.convertSatsToFiat(oneBtcInSats, currency);
-      
-      print('[RECEIVE_SCREEN] Rate check: $oneBtcInSats sats = $oneBtcInFiat $currency');
-      
-      // Step 2: Parse the result to get numeric rate
-      final fiatString = oneBtcInFiat.replaceAll(RegExp(r'[^\d.]'), ''); // Remove non-numeric chars
+
+      final fiatString = oneBtcInFiat.replaceAll(RegExp(r'[^\d.]'), '');
       final oneBtcRate = double.tryParse(fiatString);
-      
+
       if (oneBtcRate == null || oneBtcRate <= 0) {
         throw Exception('Invalid rate obtained: $oneBtcInFiat');
       }
-      
-      print('[RECEIVE_SCREEN] Parsed rate: 1 BTC = $oneBtcRate $currency');
-      
-      // Step 3: Calculate sats using inverse proportion
-      // If 1 BTC = oneBtcRate fiat, then amount fiat = ? sats
-      // sats = (amount / oneBtcRate) * 100000000
+
       final btcAmount = amount / oneBtcRate;
-      final satsAmount = (btcAmount * 100000000).round();
-      
-      print('[RECEIVE_SCREEN] Conversion successful: $amount $currency = $satsAmount sats');
-      print('[RECEIVE_SCREEN] Math: ($amount / $oneBtcRate) * 100000000 = $satsAmount');
-      
-      return satsAmount;
-      
+      return (btcAmount * 100000000).round();
     } catch (e) {
-      print('[RECEIVE_SCREEN] Error with inverse conversion: $e');
-      
-      // Fallback to YadioService as last resort
       try {
-        print('[RECEIVE_SCREEN] Trying YadioService fallback');
-        final sats = await _yadioService.convertToSats(
+        return await _yadioService.convertToSats(
           amount: amount,
           currency: currency,
         );
-        print('[RECEIVE_SCREEN] YadioService conversion: $amount $currency = $sats sats');
-        return sats;
       } catch (fallbackError) {
-        print('[RECEIVE_SCREEN] All conversion methods failed: $fallbackError');
         throw Exception('Error de conversión: $fallbackError');
       }
     }
@@ -170,18 +128,15 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
   }
 
   void _initializeLightningAddress() {
-    final authProvider = context.read<AuthProvider>();
     final walletProvider = context.read<WalletProvider>();
     final lnAddressProvider = context.read<LNAddressProvider>();
 
-    // Configure authentication
     if (walletProvider.primaryWallet != null) {
       final wallet = walletProvider.primaryWallet!;
       lnAddressProvider.setAuthHeaders(wallet.inKey, wallet.adminKey);
       lnAddressProvider.setCurrentWallet(wallet.id);
     }
 
-    // Only load addresses if they are not already loaded
     if (lnAddressProvider.currentWalletAddresses.isEmpty && !lnAddressProvider.isLoading) {
       lnAddressProvider.loadAllAddresses();
     }
@@ -194,36 +149,24 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
       body: Container(
         decoration: BoxDecoration(gradient: context.tokens.backgroundGradient),
         child: SafeArea(
-          child: withBottomPadding(
-            context,
-            Column(
-              children: [
-                // Header with navigation
-                _buildHeader(),
-                
-                // Main content
-                Expanded(
-                  child: Consumer3<LNAddressProvider, WalletProvider, AuthProvider>(
-                    builder: (context, lnAddressProvider, walletProvider, authProvider, child) {
-                      final isMobile = MediaQuery.of(context).size.width < 768;
-                      return SingleChildScrollView(
-                        padding: EdgeInsets.symmetric(
-                          horizontal: isMobile ? 24.0 : 32.0,
-                          vertical: 16.0,
-                        ),
-                        child: Column(
-                          children: [
-                            SizedBox(height: isMobile ? 8 : 12),
-                            _buildMainContent(lnAddressProvider, walletProvider),
-                          ],
-                        ),
-                      );
-                    },
+          child: Consumer3<LNAddressProvider, WalletProvider, AuthProvider>(
+            builder: (context, lnAddressProvider, walletProvider, authProvider, child) {
+              final defaultAddress = lnAddressProvider.defaultAddress;
+              final hasContent = (defaultAddress != null) || (_generatedInvoice != null);
+              final showBottomBar = hasContent &&
+                  !lnAddressProvider.isLoading &&
+                  lnAddressProvider.error == null;
+
+              return Column(
+                children: [
+                  _buildHeader(),
+                  Expanded(
+                    child: _buildContent(lnAddressProvider, walletProvider),
                   ),
-                ),
-              ],
-            ),
-            extraPadding: 24.0,
+                  if (showBottomBar) _buildBottomActionBar(defaultAddress),
+                ],
+              );
+            },
           ),
         ),
       ),
@@ -232,88 +175,30 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
 
   Widget _buildHeader() {
     final isMobile = MediaQuery.of(context).size.width < 768;
-    
-    return Container(
+
+    return Padding(
       padding: const EdgeInsets.fromLTRB(24, 16, 24, 8),
       child: Column(
         children: [
-          // Row with back button and QR button
           Row(
             children: [
-              // Back button
-              Container(
-                width: 40,
-                height: 40,
-                decoration: BoxDecoration(
-                  color: context.tokens.surface,
-                  borderRadius: BorderRadius.circular(12),
-                  border: Border.all(
-                    color: context.tokens.outline,
-                    width: 1,
-                  ),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black.withValues(alpha: 0.1),
-                      blurRadius: 8,
-                      offset: const Offset(0, 4),
-                    ),
-                  ],
-                ),
-                child: IconButton(
-                  icon: Icon(
-                    Icons.arrow_back,
-                    color: context.tokens.textPrimary,
-                    size: 20,
-                  ),
-                  onPressed: () {
-                    Navigator.pop(context);
-                  },
-                  padding: EdgeInsets.zero,
-                ),
+              _buildIconButton(
+                icon: Icons.arrow_back,
+                onPressed: () => Navigator.pop(context),
               ),
-              
               const Spacer(),
-              
-              // QR Scan button for vouchers
-              Container(
-                width: 40,
-                height: 40,
-                decoration: BoxDecoration(
-                  color: context.tokens.surface,
-                  borderRadius: BorderRadius.circular(12),
-                  border: Border.all(
-                    color: context.tokens.outline,
-                    width: 1,
-                  ),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black.withValues(alpha: 0.1),
-                      blurRadius: 8,
-                      offset: const Offset(0, 4),
-                    ),
-                  ],
-                ),
-                child: IconButton(
-                  icon: Icon(
-                    Icons.qr_code_scanner,
-                    color: context.tokens.textPrimary,
-                    size: 20,
-                  ),
-                  onPressed: _navigateToVoucherScreen,
-                  padding: EdgeInsets.zero,
-                  tooltip: 'Escanear voucher',
-                ),
+              _buildIconButton(
+                icon: Icons.qr_code_scanner,
+                onPressed: _navigateToVoucherScreen,
+                tooltip: 'Escanear voucher',
               ),
             ],
           ),
-          
           SizedBox(height: isMobile ? 0 : 4),
-          
-          // Centered title
           Text(
             AppLocalizations.of(context)!.receive_title,
             style: TextStyle(
-                            fontSize: isMobile ? 40 : 48,
+              fontSize: isMobile ? 36 : 44,
               fontWeight: FontWeight.w700,
               color: context.tokens.textPrimary,
               height: 1.1,
@@ -325,388 +210,65 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
     );
   }
 
-  Widget _buildMainContent(LNAddressProvider lnAddressProvider, WalletProvider walletProvider) {
-    final defaultAddress = lnAddressProvider.defaultAddress;
-    
+  Widget _buildIconButton({
+    required IconData icon,
+    required VoidCallback onPressed,
+    String? tooltip,
+  }) {
+    return Container(
+      width: 40,
+      height: 40,
+      decoration: BoxDecoration(
+        color: context.tokens.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: context.tokens.outline,
+          width: 1,
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.1),
+            blurRadius: 8,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: IconButton(
+        icon: Icon(icon, color: context.tokens.textPrimary, size: 20),
+        onPressed: onPressed,
+        padding: EdgeInsets.zero,
+        tooltip: tooltip,
+      ),
+    );
+  }
+
+  Widget _buildContent(LNAddressProvider lnAddressProvider, WalletProvider walletProvider) {
     if (lnAddressProvider.isLoading) {
       return _buildLoadingState();
     }
-    
+
     if (lnAddressProvider.error != null) {
       return _buildErrorState(lnAddressProvider.error!);
     }
-    
-    if (defaultAddress == null) {
-      if (_generatedInvoice != null) {
-        return _buildNoAddressInvoiceCard();
-      }
+
+    final defaultAddress = lnAddressProvider.defaultAddress;
+    if (defaultAddress == null && _generatedInvoice == null) {
       return _buildNoAddressState();
     }
 
-    // Show Lightning Address with QR
-    return _buildLightningAddressCard(defaultAddress, walletProvider);
-  }
-
-  Widget _buildLoadingState() {
-    return Container(
-      height: 400,
-      child: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const SizedBox(
-              width: 48,
-              height: 48,
-              child: CircularProgressIndicator(
-                color: Color(0xFF4C63F7),
-                strokeWidth: 3,
-              ),
-            ),
-            const SizedBox(height: 24),
-            Text(
-              AppLocalizations.of(context)!.loading_address_text,
-              style: TextStyle(
-                color: context.tokens.textPrimary.withValues(alpha: 0.8),
-                fontSize: 16,
-                              ),
-            ),
-          ],
-        ),
-      ),
+    return SingleChildScrollView(
+      padding: const EdgeInsets.fromLTRB(24, 8, 24, 16),
+      child: _buildMainCard(defaultAddress),
     );
   }
 
-  Widget _buildErrorState(String error) {
+  Widget _buildMainCard(LNAddress? defaultAddress) {
     return Container(
       padding: const EdgeInsets.all(24),
       decoration: BoxDecoration(
         color: context.tokens.surface,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(
-          color: context.tokens.outline,
-          width: 1,
-        ),
-      ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(
-            Icons.error_outline,
-            color: context.tokens.statusUnhealthy.withValues(alpha: 0.8),
-            size: 48,
-          ),
-          const SizedBox(height: 16),
-          Text(
-            AppLocalizations.of(context)!.loading_address_error_prefix,
-            style: TextStyle(
-              color: context.tokens.textPrimary,
-              fontSize: 18,
-              fontWeight: FontWeight.w600,
-                          ),
-          ),
-          const SizedBox(height: 8),
-          Text(
-            error,
-            style: TextStyle(
-              color: context.tokens.textPrimary.withValues(alpha: 0.8),
-              fontSize: 14,
-                          ),
-            textAlign: TextAlign.center,
-          ),
-          const SizedBox(height: 24),
-          SizedBox(
-            width: double.infinity,
-            child: ElevatedButton(
-              onPressed: () => context.read<LNAddressProvider>().refresh(),
-              style: ElevatedButton.styleFrom(
-                backgroundColor: context.tokens.accentSolid,
-                foregroundColor: context.tokens.accentForeground,
-                padding: const EdgeInsets.symmetric(vertical: 16),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(16),
-                ),
-                elevation: 0,
-              ),
-              child: Text(
-                AppLocalizations.of(context)!.connect_button,
-                style: TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w600,
-                                  ),
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildNoAddressState() {
-    return Container(
-      padding: const EdgeInsets.all(24),
-      decoration: BoxDecoration(
-        color: context.tokens.surface,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(
-          color: context.tokens.outline,
-          width: 1,
-        ),
-      ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(
-            Icons.alternate_email,
-            color: context.tokens.textSecondary,
-            size: 64,
-          ),
-          const SizedBox(height: 24),
-          Text(
-            AppLocalizations.of(context)!.not_available_text,
-            style: TextStyle(
-              color: context.tokens.textPrimary,
-              fontSize: 20,
-              fontWeight: FontWeight.w600,
-                          ),
-          ),
-          const SizedBox(height: 12),
-          Text(
-            AppLocalizations.of(context)!.lightning_address_description,
-            style: TextStyle(
-              color: context.tokens.textPrimary.withValues(alpha: 0.8),
-              fontSize: 16,
-                          ),
-            textAlign: TextAlign.center,
-          ),
-          const SizedBox(height: 32),
-          SizedBox(
-            width: double.infinity,
-            child: Container(
-              decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  colors: [context.tokens.accentSolid, context.tokens.accentSolid],
-                  begin: Alignment.centerLeft,
-                  end: Alignment.centerRight,
-                ),
-                borderRadius: BorderRadius.circular(16),
-                boxShadow: [
-                  BoxShadow(
-                    color: context.tokens.accentSolid.withValues(alpha: 0.3),
-                    blurRadius: 12,
-                    offset: const Offset(0, 6),
-                  ),
-                ],
-              ),
-              child: ElevatedButton.icon(
-                onPressed: _showRequestAmountModal,
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.transparent,
-                  shadowColor: Colors.transparent,
-                  padding: const EdgeInsets.symmetric(vertical: 16),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(16),
-                  ),
-                ),
-                icon: Icon(Icons.request_quote, color: context.tokens.textPrimary),
-                label: Text(
-                  AppLocalizations.of(context)!.amount_sats_label,
-                  style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.w600,
-                    color: context.tokens.textPrimary,
-                  ),
-                ),
-              ),
-            ),
-          ),
-          const SizedBox(height: 16),
-          Text(
-            AppLocalizations.of(context)!.create_lnaddress_label,
-            style: TextStyle(
-              color: context.tokens.textPrimary.withValues(alpha: 0.6),
-              fontSize: 14,
-            ),
-          ),
-          const SizedBox(height: 12),
-          SizedBox(
-            width: double.infinity,
-            child: OutlinedButton.icon(
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => const LNAddressScreen(),
-                  ),
-                );
-              },
-              style: OutlinedButton.styleFrom(
-                foregroundColor: context.tokens.accentForeground,
-                side: BorderSide(
-                  color: context.tokens.textTertiary,
-                  width: 1.5,
-                ),
-                padding: const EdgeInsets.symmetric(vertical: 16),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(16),
-                ),
-              ),
-              icon: const Icon(Icons.add, size: 20),
-              label: Text(
-                AppLocalizations.of(context)!.lightning_address_title,
-                style: const TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildNoAddressInvoiceCard() {
-    final invoice = _generatedInvoice!;
-    return Container(
-      padding: const EdgeInsets.all(24),
-      decoration: BoxDecoration(
-        color: context.tokens.surface,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(
-          color: context.tokens.outline,
-          width: 1,
-        ),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Center(child: _buildInvoiceQR(invoice)),
-          const SizedBox(height: 16),
-          Container(
-            padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
-            decoration: BoxDecoration(
-              color: context.tokens.accentSolid.withValues(alpha: 0.08),
-              borderRadius: BorderRadius.circular(12),
-              border: Border.all(
-                color: context.tokens.accentSolid.withValues(alpha: 0.2),
-              ),
-            ),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Icon(Icons.bolt, color: context.tokens.accentSolid, size: 22),
-                const SizedBox(width: 8),
-                Text(
-                  invoice.formattedAmount,
-                  style: TextStyle(
-                    color: context.tokens.textPrimary,
-                    fontSize: 18,
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-              ],
-            ),
-          ),
-          if (invoice.memo.isNotEmpty) ...[
-            const SizedBox(height: 8),
-            Text(
-              invoice.memo,
-              style: TextStyle(
-                color: context.tokens.textPrimary.withValues(alpha: 0.7),
-                fontSize: 14,
-              ),
-              textAlign: TextAlign.center,
-            ),
-          ],
-          const SizedBox(height: 16),
-          _buildCopyInvoiceButton(),
-          const SizedBox(height: 12),
-          _buildClearInvoiceButton(),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildCopyInvoiceButton() {
-    return SizedBox(
-      width: double.infinity,
-      child: Container(
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            colors: [context.tokens.accentSolid, context.tokens.accentSolid],
-            begin: Alignment.centerLeft,
-            end: Alignment.centerRight,
-          ),
-          borderRadius: BorderRadius.circular(16),
-          boxShadow: [
-            BoxShadow(
-              color: context.tokens.accentSolid.withValues(alpha: 0.3),
-              blurRadius: 12,
-              offset: const Offset(0, 6),
-            ),
-          ],
-        ),
-        child: ElevatedButton.icon(
-          onPressed: _copyInvoice,
-          style: ElevatedButton.styleFrom(
-            backgroundColor: Colors.transparent,
-            shadowColor: Colors.transparent,
-            padding: const EdgeInsets.symmetric(vertical: 16),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(16),
-            ),
-          ),
-          icon: Icon(Icons.copy, color: context.tokens.textPrimary, size: 20),
-          label: Text(
-            AppLocalizations.of(context)!.copy_button,
-            style: TextStyle(
-              fontSize: 16,
-              fontWeight: FontWeight.w600,
-              color: context.tokens.textPrimary,
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-
-  void _copyInvoice() async {
-    final invoice = _generatedInvoice;
-    if (invoice == null) return;
-    await Clipboard.setData(ClipboardData(text: invoice.paymentRequest));
-    if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Row(
-          children: [
-            Icon(Icons.check_circle, color: context.tokens.textPrimary, size: 20),
-            const SizedBox(width: 12),
-            Text(
-              AppLocalizations.of(context)!.invoice_copied_message,
-              style: const TextStyle(fontWeight: FontWeight.w500),
-            ),
-          ],
-        ),
-        backgroundColor: context.tokens.accentSolid,
-        behavior: SnackBarBehavior.floating,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-        ),
-        duration: const Duration(seconds: 2),
-      ),
-    );
-  }
-
-  Widget _buildLightningAddressCard(LNAddress defaultAddress, WalletProvider walletProvider) {
-    return Container(
-      padding: const EdgeInsets.all(24),
-      decoration: BoxDecoration(
-        color: context.tokens.surface,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(
-          color: context.tokens.outline,
-          width: 1,
-        ),
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: context.tokens.outline, width: 1),
         boxShadow: [
           BoxShadow(
             color: Colors.black.withValues(alpha: 0.1),
@@ -718,228 +280,49 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          // QR Code with LNURL
-          _buildQRSection(defaultAddress),
-          
+          Center(child: _buildQRCard(defaultAddress)),
           const SizedBox(height: 16),
-          
-          // Lightning Address and copy button together
-          _buildAddressWithCopySection(defaultAddress),
-          
-          const SizedBox(height: 16),
-          
-          // Collapsible contextual information
-          _buildCollapsibleInfoSection(),
+          if (defaultAddress != null) _buildAddressDisplay(defaultAddress),
+          if (_generatedInvoice != null) ...[
+            if (defaultAddress != null) const SizedBox(height: 12),
+            _buildAmountChip(_generatedInvoice!),
+          ],
+          const SizedBox(height: 20),
+          _buildPrimaryCta(),
         ],
       ),
     );
   }
 
-  Widget _buildWalletInfo(WalletProvider walletProvider) {
-    final wallet = walletProvider.primaryWallet;
-    if (wallet == null) return const SizedBox.shrink();
-    
+  Widget _buildQRCard(LNAddress? defaultAddress) {
     return Container(
-      padding: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(8),
       decoration: BoxDecoration(
-        color: context.tokens.inputFill,
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(
-          color: context.tokens.outline,
-        ),
+        color: context.tokens.textPrimary,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: context.tokens.outlineStrong),
       ),
-      child: Row(
-        children: [
-          Container(
-            padding: const EdgeInsets.all(8),
-            decoration: BoxDecoration(
-              color: context.tokens.accentSolid,
-              borderRadius: BorderRadius.circular(8),
-            ),
-            child: Icon(
-              Icons.account_balance_wallet,
-              color: context.tokens.textPrimary,
-              size: 20,
-            ),
-          ),
-          const SizedBox(width: 12),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  wallet.name,
-                  style: TextStyle(
-                    color: context.tokens.textPrimary,
-                    fontSize: 16,
-                    fontWeight: FontWeight.w600,
-                                      ),
-                ),
-                const SizedBox(height: 2),
-                Text(
-                  'Balance: ${wallet.balanceFormatted}',
-                  style: TextStyle(
-                    color: context.tokens.textPrimary.withValues(alpha: 0.7),
-                    fontSize: 14,
-                                      ),
-                ),
-              ],
-            ),
-          ),
-        ],
-      ),
+      child: _buildQRImage(defaultAddress),
     );
   }
 
-  Widget _buildAddressDisplay(LNAddress defaultAddress) {
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(12),
-      decoration: BoxDecoration(
-        color: context.tokens.inputFill,
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(
-          color: context.tokens.outline,
-        ),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          // Centered address
-          SizedBox(
-            width: double.infinity,
-            child: Text(
-              defaultAddress.fullAddress,
-              style: TextStyle(
-                color: context.tokens.textPrimary,
-                fontSize: 14,
-                fontWeight: FontWeight.w400,
-                              ),
-              textAlign: TextAlign.center,
-              softWrap: true,
-              overflow: TextOverflow.visible,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-
-  Widget _buildQRSection(LNAddress defaultAddress) {
-    return Center(
-      child: Container(
-        // No fixed width, adjusts to content
-        padding: const EdgeInsets.all(8), // Reduced to 8 for tighter frame
-        decoration: BoxDecoration(
-          color: context.tokens.textPrimary,
-          borderRadius: BorderRadius.circular(6), // More square: from 16 to 6
-          border: Border.all(
-            color: context.tokens.outlineStrong,
-          ),
-        ),
-        child: _buildQRCodeWithLNURL(defaultAddress),
-      ),
-    );
-  }
-
-  Widget _buildQRCodeWithLNURL(LNAddress defaultAddress) {
-    // If there's a generated invoice, show its QR
+  Widget _buildQRImage(LNAddress? defaultAddress) {
     if (_generatedInvoice != null) {
-      print('[RECEIVE_SCREEN] Mostrando QR de factura: ${_generatedInvoice!.paymentRequest.substring(0, 20)}...');
-      return _buildInvoiceQR(_generatedInvoice!);
+      return _buildQR(_generatedInvoice!.paymentRequest);
     }
-    
-    // If there's no invoice, show Lightning Address
-    final lnurl = defaultAddress.lnurl;
-    
+
+    final lnurl = defaultAddress?.lnurl;
     if (lnurl != null && lnurl.isNotEmpty) {
-      print('[RECEIVE_SCREEN] Usando LNURL de LNBits: ${lnurl.substring(0, 20)}...${lnurl.substring(lnurl.length - 10)}');
-      return _buildSuccessQR(lnurl);
-    } else {
-      print('[RECEIVE_SCREEN] No hay LNURL en el modelo, usando fallback');
-      return _buildFallbackQR(defaultAddress.fullAddress, 'LNURL no disponible en LNBits');
+      return _buildQR(lnurl);
     }
+    return _buildQR(defaultAddress?.fullAddress.toUpperCase() ?? '');
   }
 
-  Widget _buildLoadingQR() {
-    return SizedBox(
-      height: 220, // Reduced from 280 to 220
-      width: 220,  // Reduced from 280 to 220
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          SizedBox(
-            width: 32, // Reduced from 40 to 32
-            height: 32, // Reduced from 40 to 32
-            child: CircularProgressIndicator(
-              color: context.tokens.accentSolid,
-              strokeWidth: 3, // Reduced from 4 to 3
-            ),
-          ),
-          SizedBox(height: 16), // Reduced from 20 to 16
-          Text(
-            AppLocalizations.of(context)!.loading_text,
-            style: TextStyle(
-              fontSize: 14, // Reduced from 16 to 14
-              color: Colors.grey,
-                          ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildSuccessQR(String lnurl) {
+  Widget _buildQR(String data) {
     return QrImageView(
-      data: lnurl,
+      data: data,
       version: QrVersions.auto,
-      size: 220.0, // Reduced from 280 to 220
-      backgroundColor: Colors.white,
-      errorCorrectionLevel: QrErrorCorrectLevel.H, // High level to support logo
-      eyeStyle: const QrEyeStyle(
-        eyeShape: QrEyeShape.square,
-        color: Colors.black,
-      ),
-      dataModuleStyle: const QrDataModuleStyle(
-        dataModuleShape: QrDataModuleShape.square,
-        color: Colors.black,
-      ),
-      embeddedImage: const AssetImage('Logo/chispalogoredondo.png'),
-      embeddedImageStyle: const QrEmbeddedImageStyle(
-        size: Size(44, 44), // Proportionally reduced from 56x56 to 44x44
-      ),
-    );
-  }
-
-  Widget _buildFallbackQR(String lightningAddress, String error) {
-    return QrImageView(
-      data: lightningAddress.toUpperCase(),
-      version: QrVersions.auto,
-      size: 220.0, // Reduced from 280 to 220
-      backgroundColor: Colors.white,
-      errorCorrectionLevel: QrErrorCorrectLevel.H, // High level to support logo
-      eyeStyle: const QrEyeStyle(
-        eyeShape: QrEyeShape.square,
-        color: Colors.black,
-      ),
-      dataModuleStyle: const QrDataModuleStyle(
-        dataModuleShape: QrDataModuleShape.square,
-        color: Colors.black,
-      ),
-      embeddedImage: const AssetImage('Logo/chispalogoredondo.png'),
-      embeddedImageStyle: const QrEmbeddedImageStyle(
-        size: Size(44, 44), // Proportionally reduced from 56x56 to 44x44
-      ),
-    );
-  }
-
-  Widget _buildInvoiceQR(LightningInvoice invoice) {
-    return QrImageView(
-      data: invoice.paymentRequest,
-      version: QrVersions.auto,
-      size: 220.0, // Reduced from 280 to 220
+      size: 220.0,
       backgroundColor: Colors.white,
       errorCorrectionLevel: QrErrorCorrectLevel.H,
       eyeStyle: const QrEyeStyle(
@@ -952,12 +335,110 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
       ),
       embeddedImage: const AssetImage('Logo/chispalogoredondo.png'),
       embeddedImageStyle: const QrEmbeddedImageStyle(
-        size: Size(44, 44), // Proportionally reduced from 56x56 to 44x44
+        size: Size(44, 44),
       ),
     );
   }
 
-  Widget _buildCopyButton(LNAddress defaultAddress) {
+  Widget _buildAddressDisplay(LNAddress defaultAddress) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: context.tokens.inputFill,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: context.tokens.outline),
+      ),
+      child: Text(
+        defaultAddress.fullAddress,
+        style: TextStyle(
+          color: context.tokens.textPrimary,
+          fontSize: 14,
+          fontWeight: FontWeight.w500,
+        ),
+        textAlign: TextAlign.center,
+        softWrap: true,
+      ),
+    );
+  }
+
+  Widget _buildAmountChip(LightningInvoice invoice) {
+    final hasMemo = invoice.memo.isNotEmpty;
+    return Center(
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+        decoration: BoxDecoration(
+          color: context.tokens.accentSolid.withValues(alpha: 0.12),
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(
+            color: context.tokens.accentSolid.withValues(alpha: 0.32),
+          ),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.bolt, color: context.tokens.accentSolid, size: 16),
+            const SizedBox(width: 6),
+            Text(
+              invoice.formattedAmount,
+              style: TextStyle(
+                color: context.tokens.textPrimary,
+                fontSize: 14,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            if (hasMemo) ...[
+              const SizedBox(width: 8),
+              Container(
+                width: 1,
+                height: 12,
+                color: context.tokens.textPrimary.withValues(alpha: 0.25),
+              ),
+              const SizedBox(width: 8),
+              Flexible(
+                child: Text(
+                  invoice.memo,
+                  style: TextStyle(
+                    color: context.tokens.textPrimary.withValues(alpha: 0.8),
+                    fontSize: 13,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPrimaryCta() {
+    final hasInvoice = _generatedInvoice != null;
+    if (hasInvoice) {
+      return SizedBox(
+        width: double.infinity,
+        child: OutlinedButton.icon(
+          onPressed: _clearInvoice,
+          style: OutlinedButton.styleFrom(
+            foregroundColor: context.tokens.accentForeground,
+            side: BorderSide(
+              color: context.tokens.textTertiary,
+              width: 1.5,
+            ),
+            padding: const EdgeInsets.symmetric(vertical: 16),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(16),
+            ),
+          ),
+          icon: const Icon(Icons.close, size: 20),
+          label: Text(
+            AppLocalizations.of(context)!.clear_invoice_button,
+            style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+          ),
+        ),
+      );
+    }
+
     return SizedBox(
       width: double.infinity,
       child: Container(
@@ -977,7 +458,7 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
           ],
         ),
         child: ElevatedButton.icon(
-          onPressed: () => _copyPaymentInfo(defaultAddress),
+          onPressed: _isGeneratingInvoice ? null : _showRequestAmountModal,
           style: ElevatedButton.styleFrom(
             backgroundColor: Colors.transparent,
             shadowColor: Colors.transparent,
@@ -986,13 +467,13 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
               borderRadius: BorderRadius.circular(16),
             ),
           ),
-          icon: Icon(Icons.copy, color: context.tokens.textPrimary, size: 20),
+          icon: Icon(Icons.request_quote, color: context.tokens.textPrimary),
           label: Text(
-            _generatedInvoice != null ? AppLocalizations.of(context)!.copy_button : AppLocalizations.of(context)!.copy_lightning_address,
+            AppLocalizations.of(context)!.amount_sats_label,
             style: TextStyle(
               fontSize: 16,
               fontWeight: FontWeight.w600,
-                            color: context.tokens.textPrimary,
+              color: context.tokens.textPrimary,
             ),
           ),
         ),
@@ -1000,225 +481,556 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
     );
   }
 
-  Widget _buildAddressWithCopySection(LNAddress defaultAddress) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        // Lightning Address display
-        _buildAddressDisplay(defaultAddress),
-        
-        const SizedBox(height: 12),
-        
-        // Copy button right below
-        _buildCopyButton(defaultAddress),
-        
-        const SizedBox(height: 12),
-        
-        // LNURL copy button
-        _buildCopyLNURLButton(defaultAddress),
-        
-        const SizedBox(height: 12),
-        
-        // Request amount button or clear invoice button
-        _generatedInvoice != null 
-          ? _buildClearInvoiceButton()
-          : _buildRequestAmountButton(),
-      ],
-    );
-  }
-
-  Widget _buildCollapsibleInfoSection() {
+  Widget _buildBottomActionBar(LNAddress? defaultAddress) {
     return Container(
       decoration: BoxDecoration(
-        color: context.tokens.accentSolid.withValues(alpha: 0.1),
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(
-          color: context.tokens.accentSolid.withValues(alpha: 0.2),
+        color: context.tokens.surface,
+        border: Border(
+          top: BorderSide(color: context.tokens.outline, width: 1),
         ),
-      ),
-      child: Column(
-        children: [
-          // Button to expand/collapse
-          Material(
-            color: Colors.transparent,
-            child: InkWell(
-              borderRadius: BorderRadius.circular(12),
-              onTap: () {
-                setState(() {
-                  _isInfoExpanded = !_isInfoExpanded;
-                });
-              },
-              child: Container(
-                padding: const EdgeInsets.all(16),
-                child: Row(
-                  children: [
-                    Icon(
-                      Icons.info_outline,
-                      color: context.tokens.accentSolid,
-                      size: 20,
-                    ),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: Text(
-                        AppLocalizations.of(context)!.settings_title,
-                        style: TextStyle(
-                          fontSize: 16,
-                          fontWeight: FontWeight.w600,
-                          color: Color(0xFF4C63F7),
-                                                  ),
-                      ),
-                    ),
-                    Icon(
-                      _isInfoExpanded ? Icons.expand_less : Icons.expand_more,
-                      color: context.tokens.accentSolid,
-                      size: 24,
-                    ),
-                  ],
-                ),
-              ),
-            ),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.08),
+            blurRadius: 12,
+            offset: const Offset(0, -4),
           ),
-          
-          // Expandable content
-          if (_isInfoExpanded)
-            Container(
-              padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Divider(
-                    color: context.tokens.accentSolid,
-                    thickness: 1,
-                    height: 1,
-                  ),
-                  const SizedBox(height: 12),
-                  Text(
-                    AppLocalizations.of(context)!.receive_info_text,
-                    style: TextStyle(
-                      fontSize: 14,
-                      color: context.tokens.textPrimary.withValues(alpha: 0.8),
-                                            height: 1.4,
-                    ),
-                  ),
-                ],
-              ),
-            ),
+        ],
+      ),
+      padding: EdgeInsets.fromLTRB(
+        8,
+        10,
+        8,
+        10 + MediaQuery.of(context).viewPadding.bottom,
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: [
+          _buildBarAction(
+            icon: Icons.content_copy_rounded,
+            label: AppLocalizations.of(context)!.copy_button,
+            onTap: () => _showCopySheet(defaultAddress),
+          ),
+          _buildBarAction(
+            icon: Icons.ios_share_rounded,
+            label: AppLocalizations.of(context)!.share_button,
+            onTap: () => _shareContent(defaultAddress),
+          ),
+          _buildBarAction(
+            icon: Icons.nfc_rounded,
+            label: AppLocalizations.of(context)!.nfc_action_label,
+            enabled: _nfcAvailable,
+            onTap: _nfcAvailable ? _activateNfc : _showNfcUnavailable,
+          ),
         ],
       ),
     );
   }
 
-  Widget _buildRequestAmountButton() {
-    return SizedBox(
-      width: double.infinity,
-      child: OutlinedButton.icon(
-        onPressed: _showRequestAmountModal,
-        style: OutlinedButton.styleFrom(
-          foregroundColor: context.tokens.accentForeground,
-          side: BorderSide(
-            color: context.tokens.textTertiary,
-            width: 1.5,
+  Widget _buildBarAction({
+    required IconData icon,
+    required String label,
+    required VoidCallback onTap,
+    bool enabled = true,
+  }) {
+    final color = enabled
+        ? context.tokens.textPrimary
+        : context.tokens.textPrimary.withValues(alpha: 0.32);
+    return Expanded(
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(12),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 4),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(icon, color: color, size: 24),
+                const SizedBox(height: 4),
+                Text(
+                  label,
+                  style: TextStyle(
+                    color: color,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ],
+            ),
           ),
-          padding: const EdgeInsets.symmetric(vertical: 16),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(16),
-          ),
-        ),
-        icon: const Icon(Icons.request_quote, size: 20),
-        label: Text(
-          AppLocalizations.of(context)!.amount_sats_label,
-          style: TextStyle(
-            fontSize: 16,
-            fontWeight: FontWeight.w600,
-                      ),
         ),
       ),
     );
   }
 
-  Widget _buildClearInvoiceButton() {
-    return SizedBox(
-      width: double.infinity,
-      child: OutlinedButton.icon(
-        onPressed: () {
-          // Cancel monitoring of current invoice
-          _invoicePaymentTimer?.cancel();
-          _invoicePaymentTimeoutTimer?.cancel();
+  Widget _buildLoadingState() {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          SizedBox(
+            width: 48,
+            height: 48,
+            child: CircularProgressIndicator(
+              color: context.tokens.accentSolid,
+              strokeWidth: 3,
+            ),
+          ),
+          const SizedBox(height: 24),
+          Text(
+            AppLocalizations.of(context)!.loading_address_text,
+            style: TextStyle(
+              color: context.tokens.textPrimary.withValues(alpha: 0.8),
+              fontSize: 16,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
 
-          setState(() {
-            _generatedInvoice = null;
-          });
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Row(
-                children: [
-                  Icon(Icons.check_circle, color: context.tokens.textPrimary, size: 20),
-                  SizedBox(width: 12),
-                  Text(
-                    AppLocalizations.of(context)!.invoice_cleared_message,
+  Widget _buildErrorState(String error) {
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Container(
+        padding: const EdgeInsets.all(24),
+        decoration: BoxDecoration(
+          color: context.tokens.surface,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: context.tokens.outline, width: 1),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.error_outline,
+              color: context.tokens.statusUnhealthy.withValues(alpha: 0.8),
+              size: 48,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              AppLocalizations.of(context)!.loading_address_error_prefix,
+              style: TextStyle(
+                color: context.tokens.textPrimary,
+                fontSize: 18,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              error,
+              style: TextStyle(
+                color: context.tokens.textPrimary.withValues(alpha: 0.8),
+                fontSize: 14,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: () => context.read<LNAddressProvider>().refresh(),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: context.tokens.accentSolid,
+                  foregroundColor: context.tokens.accentForeground,
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(16),
+                  ),
+                  elevation: 0,
+                ),
+                child: Text(
+                  AppLocalizations.of(context)!.connect_button,
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildNoAddressState() {
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Container(
+        padding: const EdgeInsets.all(24),
+        decoration: BoxDecoration(
+          color: context.tokens.surface,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: context.tokens.outline, width: 1),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.alternate_email,
+              color: context.tokens.textSecondary,
+              size: 64,
+            ),
+            const SizedBox(height: 24),
+            Text(
+              AppLocalizations.of(context)!.not_available_text,
+              style: TextStyle(
+                color: context.tokens.textPrimary,
+                fontSize: 20,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              AppLocalizations.of(context)!.lightning_address_description,
+              style: TextStyle(
+                color: context.tokens.textPrimary.withValues(alpha: 0.8),
+                fontSize: 16,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 32),
+            SizedBox(
+              width: double.infinity,
+              child: Container(
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    colors: [context.tokens.accentSolid, context.tokens.accentSolid],
+                    begin: Alignment.centerLeft,
+                    end: Alignment.centerRight,
+                  ),
+                  borderRadius: BorderRadius.circular(16),
+                  boxShadow: [
+                    BoxShadow(
+                      color: context.tokens.accentSolid.withValues(alpha: 0.3),
+                      blurRadius: 12,
+                      offset: const Offset(0, 6),
+                    ),
+                  ],
+                ),
+                child: ElevatedButton.icon(
+                  onPressed: _showRequestAmountModal,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.transparent,
+                    shadowColor: Colors.transparent,
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(16),
+                    ),
+                  ),
+                  icon: Icon(Icons.request_quote, color: context.tokens.textPrimary),
+                  label: Text(
+                    AppLocalizations.of(context)!.amount_sats_label,
                     style: TextStyle(
-                                            fontWeight: FontWeight.w500,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                      color: context.tokens.textPrimary,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              AppLocalizations.of(context)!.create_lnaddress_label,
+              style: TextStyle(
+                color: context.tokens.textPrimary.withValues(alpha: 0.6),
+                fontSize: 14,
+              ),
+            ),
+            const SizedBox(height: 12),
+            SizedBox(
+              width: double.infinity,
+              child: OutlinedButton.icon(
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => const LNAddressScreen(),
+                    ),
+                  );
+                },
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: context.tokens.accentForeground,
+                  side: BorderSide(
+                    color: context.tokens.textTertiary,
+                    width: 1.5,
+                  ),
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(16),
+                  ),
+                ),
+                icon: const Icon(Icons.add, size: 20),
+                label: Text(
+                  AppLocalizations.of(context)!.lightning_address_title,
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _clearInvoice() {
+    _invoicePaymentTimer?.cancel();
+    _invoicePaymentTimeoutTimer?.cancel();
+    setState(() {
+      _generatedInvoice = null;
+    });
+    _showAccentSnackBar(
+      icon: Icons.check_circle,
+      message: AppLocalizations.of(context)!.invoice_cleared_message,
+    );
+  }
+
+  void _showCopySheet(LNAddress? defaultAddress) {
+    final hasInvoice = _generatedInvoice != null;
+    final lnurl = defaultAddress?.lnurl;
+
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: Colors.transparent,
+      builder: (sheetContext) => Container(
+        decoration: BoxDecoration(
+          color: context.tokens.dialogBackground,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
+        ),
+        padding: EdgeInsets.fromLTRB(
+          0,
+          12,
+          0,
+          16 + MediaQuery.of(sheetContext).viewPadding.bottom,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 40,
+              height: 4,
+              decoration: BoxDecoration(
+                color: context.tokens.textTertiary,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            const SizedBox(height: 16),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: Row(
+                children: [
+                  Icon(Icons.content_copy_rounded,
+                      color: context.tokens.accentSolid, size: 22),
+                  const SizedBox(width: 12),
+                  Text(
+                    AppLocalizations.of(context)!.copy_button,
+                    style: TextStyle(
+                      color: context.tokens.textPrimary,
+                      fontSize: 18,
+                      fontWeight: FontWeight.w700,
                     ),
                   ),
                 ],
               ),
-              backgroundColor: context.tokens.accentSolid,
-              behavior: SnackBarBehavior.floating,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
-              ),
-              duration: const Duration(seconds: 2),
             ),
-          );
-        },
-        style: OutlinedButton.styleFrom(
-          foregroundColor: context.tokens.accentForeground,
-          side: BorderSide(
-            color: context.tokens.textTertiary,
-            width: 1.5,
-          ),
-          padding: const EdgeInsets.symmetric(vertical: 16),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(16),
-          ),
-        ),
-        icon: const Icon(Icons.close, size: 20),
-        label: Text(
-          AppLocalizations.of(context)!.clear_invoice_button,
-          style: TextStyle(
-            fontSize: 16,
-            fontWeight: FontWeight.w600,
-                      ),
+            const SizedBox(height: 12),
+            if (defaultAddress != null)
+              _buildSheetItem(
+                icon: Icons.alternate_email,
+                title: AppLocalizations.of(context)!.lightning_address_title,
+                subtitle: defaultAddress.fullAddress,
+                onTap: () {
+                  Navigator.pop(sheetContext);
+                  _copyToClipboard(
+                    defaultAddress.fullAddress,
+                    AppLocalizations.of(context)!.address_copied_message,
+                  );
+                },
+              ),
+            if (lnurl != null && lnurl.isNotEmpty)
+              _buildSheetItem(
+                icon: Icons.link_rounded,
+                title: 'LNURL',
+                subtitle: _truncate(lnurl),
+                onTap: () {
+                  Navigator.pop(sheetContext);
+                  _copyToClipboard(
+                    lnurl,
+                    AppLocalizations.of(context)!.lnurl_copied_message,
+                  );
+                },
+              ),
+            if (hasInvoice)
+              _buildSheetItem(
+                icon: Icons.receipt_long_rounded,
+                title: AppLocalizations.of(context)!.copy_invoice_button,
+                subtitle: _truncate(_generatedInvoice!.paymentRequest),
+                onTap: () {
+                  Navigator.pop(sheetContext);
+                  _copyToClipboard(
+                    _generatedInvoice!.paymentRequest,
+                    AppLocalizations.of(context)!.invoice_copied_message,
+                  );
+                },
+              ),
+          ],
         ),
       ),
     );
   }
 
-  void _showRequestAmountModal() {
-    // Clear fields when opening modal
+  Widget _buildSheetItem({
+    required IconData icon,
+    required String title,
+    required String subtitle,
+    required VoidCallback onTap,
+  }) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 14),
+          child: Row(
+            children: [
+              Container(
+                width: 40,
+                height: 40,
+                decoration: BoxDecoration(
+                  color: context.tokens.accentSolid.withValues(alpha: 0.12),
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: Icon(icon, color: context.tokens.accentSolid, size: 20),
+              ),
+              const SizedBox(width: 14),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: TextStyle(
+                        color: context.tokens.textPrimary,
+                        fontSize: 15,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      subtitle,
+                      style: TextStyle(
+                        color: context.tokens.textPrimary.withValues(alpha: 0.7),
+                        fontSize: 12,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              ),
+              Icon(
+                Icons.chevron_right_rounded,
+                color: context.tokens.textTertiary,
+                size: 20,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _truncate(String value) {
+    if (value.length <= 32) return value;
+    return '${value.substring(0, 16)}…${value.substring(value.length - 12)}';
+  }
+
+  void _shareContent(LNAddress? defaultAddress) async {
+    String? text;
+    if (_generatedInvoice != null) {
+      text = 'lightning:${_generatedInvoice!.paymentRequest}';
+    } else if (defaultAddress != null) {
+      text = defaultAddress.fullAddress;
+    }
+    if (text == null) return;
+
+    final box = context.findRenderObject() as RenderBox?;
+    await Share.share(
+      text,
+      subject: AppLocalizations.of(context)!.receive_title,
+      sharePositionOrigin:
+          box != null ? box.localToGlobal(Offset.zero) & box.size : null,
+    );
+  }
+
+  void _showNfcUnavailable() {
+    _showInfoSnackBar(AppLocalizations.of(context)!.nfc_unavailable_message);
+  }
+
+  Future<void> _activateNfc() async {
+    if (!_nfcAvailable) {
+      _showNfcUnavailable();
+      return;
+    }
+
+    if (_generatedInvoice != null) {
+      _openNfcChargeSheet(_generatedInvoice!.paymentRequest);
+      return;
+    }
+
+    _showRequestAmountModal(autoStartNfcAfterGenerate: true);
+  }
+
+  void _openNfcChargeSheet(String invoice) {
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: Colors.transparent,
+      isScrollControlled: true,
+      isDismissible: false,
+      enableDrag: false,
+      builder: (sheetContext) => _NfcChargeSheet(invoice: invoice),
+    );
+  }
+
+  void _copyToClipboard(String text, String successMessage) async {
+    await Clipboard.setData(ClipboardData(text: text));
+    if (!mounted) return;
+    _showAccentSnackBar(
+      icon: Icons.check_circle,
+      message: successMessage,
+    );
+  }
+
+  void _showRequestAmountModal({bool autoStartNfcAfterGenerate = false}) {
     _amountController.clear();
     _noteController.clear();
     setState(() {
-      _selectedCurrency = 'sats';
+      _selectedCurrency = _currencies.contains('sats') ? 'sats' : _currencies.first;
     });
 
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
-      builder: (context) => StatefulBuilder(
-        builder: (context, setModalState) => Container(
+      builder: (modalContext) => StatefulBuilder(
+        builder: (modalContext, setModalState) => Container(
           padding: EdgeInsets.only(
-            bottom: MediaQuery.of(context).viewInsets.bottom,
+            bottom: MediaQuery.of(modalContext).viewInsets.bottom,
           ),
           child: Container(
             constraints: BoxConstraints(
-              maxHeight: MediaQuery.of(context).size.height * 0.9,
-              minHeight: MediaQuery.of(context).size.height * 0.5,
+              maxHeight: MediaQuery.of(modalContext).size.height * 0.9,
+              minHeight: MediaQuery.of(modalContext).size.height * 0.5,
             ),
-            decoration: const BoxDecoration(
-              color: Color(0xFF1A1D47),
-              borderRadius: BorderRadius.only(
+            decoration: BoxDecoration(
+              color: context.tokens.dialogBackground,
+              borderRadius: const BorderRadius.only(
                 topLeft: Radius.circular(24),
                 topRight: Radius.circular(24),
               ),
@@ -1227,7 +1039,6 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  // Handle bar
                   Container(
                     margin: const EdgeInsets.only(top: 12),
                     width: 40,
@@ -1237,15 +1048,13 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                       borderRadius: BorderRadius.circular(2),
                     ),
                   ),
-                  
-                  // Header
-                  Container(
+                  Padding(
                     padding: const EdgeInsets.all(24),
                     child: Row(
                       children: [
-                        const Icon(
+                        Icon(
                           Icons.request_quote,
-                          color: Color(0xFF4C63F7),
+                          color: context.tokens.accentSolid,
                           size: 24,
                         ),
                         const SizedBox(width: 12),
@@ -1256,11 +1065,11 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                               color: context.tokens.textPrimary,
                               fontSize: 20,
                               fontWeight: FontWeight.w600,
-                                                          ),
+                            ),
                           ),
                         ),
                         IconButton(
-                          onPressed: () => Navigator.pop(context),
+                          onPressed: () => Navigator.pop(modalContext),
                           icon: Icon(
                             Icons.close,
                             color: context.tokens.textPrimary.withValues(alpha: 0.7),
@@ -1269,19 +1078,15 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                       ],
                     ),
                   ),
-                  
-                  // Modal content
                   Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 24),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        // Row for amount and currency selector
                         Row(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            // Amount input
                             Expanded(
                               child: Column(
                                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -1292,7 +1097,7 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                                       color: context.tokens.textPrimary.withValues(alpha: 0.8),
                                       fontSize: 14,
                                       fontWeight: FontWeight.w500,
-                                                                          ),
+                                    ),
                                   ),
                                   const SizedBox(height: 8),
                                   TextFormField(
@@ -1301,7 +1106,7 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                                     style: TextStyle(
                                       color: context.tokens.textPrimary,
                                       fontSize: 16,
-                                                                          ),
+                                    ),
                                     decoration: InputDecoration(
                                       hintText: '0',
                                       hintStyle: TextStyle(
@@ -1311,21 +1116,15 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                                       fillColor: context.tokens.inputFill,
                                       border: OutlineInputBorder(
                                         borderRadius: BorderRadius.circular(12),
-                                        borderSide: BorderSide(
-                                          color: context.tokens.outline,
-                                        ),
+                                        borderSide: BorderSide(color: context.tokens.outline),
                                       ),
                                       enabledBorder: OutlineInputBorder(
                                         borderRadius: BorderRadius.circular(12),
-                                        borderSide: BorderSide(
-                                          color: context.tokens.outline,
-                                        ),
+                                        borderSide: BorderSide(color: context.tokens.outline),
                                       ),
                                       focusedBorder: OutlineInputBorder(
                                         borderRadius: BorderRadius.circular(12),
-                                        borderSide: const BorderSide(
-                                          color: Color(0xFF4C63F7),
-                                        ),
+                                        borderSide: BorderSide(color: context.tokens.accentSolid),
                                       ),
                                       contentPadding: const EdgeInsets.symmetric(
                                         horizontal: 16,
@@ -1336,10 +1135,7 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                                 ],
                               ),
                             ),
-                            
                             const SizedBox(width: 12),
-                            
-                            // Currency selector
                             Column(
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
@@ -1349,7 +1145,7 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                                     color: context.tokens.textPrimary.withValues(alpha: 0.8),
                                     fontSize: 14,
                                     fontWeight: FontWeight.w500,
-                                                                      ),
+                                  ),
                                 ),
                                 const SizedBox(height: 8),
                                 SizedBox(
@@ -1370,9 +1166,7 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                                       child: Container(
                                         decoration: BoxDecoration(
                                           borderRadius: BorderRadius.circular(12),
-                                          border: Border.all(
-                                            color: context.tokens.outline,
-                                          ),
+                                          border: Border.all(color: context.tokens.outline),
                                         ),
                                         child: Center(
                                           child: Text(
@@ -1381,7 +1175,7 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                                               color: context.tokens.textPrimary,
                                               fontSize: 14,
                                               fontWeight: FontWeight.w600,
-                                                                                          ),
+                                            ),
                                           ),
                                         ),
                                       ),
@@ -1392,78 +1186,59 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                             ),
                           ],
                         ),
-                        
                         const SizedBox(height: 16),
-                        
-                        // Note input
-                        Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              AppLocalizations.of(context)!.optional_description_label,
-                              style: TextStyle(
-                                color: context.tokens.textPrimary.withValues(alpha: 0.8),
-                                fontSize: 14,
-                                fontWeight: FontWeight.w500,
-                                                              ),
-                            ),
-                            const SizedBox(height: 8),
-                            TextFormField(
-                              controller: _noteController,
-                              style: TextStyle(
-                                color: context.tokens.textPrimary,
-                                fontSize: 16,
-                                                              ),
-                              decoration: InputDecoration(
-                                hintText: AppLocalizations.of(context)!.payment_description_example,
-                                hintStyle: TextStyle(
-                                  color: context.tokens.textSecondary,
-                                ),
-                                filled: true,
-                                fillColor: context.tokens.inputFill,
-                                border: OutlineInputBorder(
-                                  borderRadius: BorderRadius.circular(12),
-                                  borderSide: BorderSide(
-                                    color: context.tokens.outline,
-                                  ),
-                                ),
-                                enabledBorder: OutlineInputBorder(
-                                  borderRadius: BorderRadius.circular(12),
-                                  borderSide: BorderSide(
-                                    color: context.tokens.outline,
-                                  ),
-                                ),
-                                focusedBorder: OutlineInputBorder(
-                                  borderRadius: BorderRadius.circular(12),
-                                  borderSide: const BorderSide(
-                                    color: Color(0xFF4C63F7),
-                                  ),
-                                ),
-                                contentPadding: const EdgeInsets.symmetric(
-                                  horizontal: 16,
-                                  vertical: 16,
-                                ),
-                              ),
-                              maxLines: 2,
-                            ),
-                          ],
+                        Text(
+                          AppLocalizations.of(context)!.optional_description_label,
+                          style: TextStyle(
+                            color: context.tokens.textPrimary.withValues(alpha: 0.8),
+                            fontSize: 14,
+                            fontWeight: FontWeight.w500,
+                          ),
                         ),
-                        
+                        const SizedBox(height: 8),
+                        TextFormField(
+                          controller: _noteController,
+                          style: TextStyle(
+                            color: context.tokens.textPrimary,
+                            fontSize: 16,
+                          ),
+                          decoration: InputDecoration(
+                            hintText: AppLocalizations.of(context)!.payment_description_example,
+                            hintStyle: TextStyle(
+                              color: context.tokens.textSecondary,
+                            ),
+                            filled: true,
+                            fillColor: context.tokens.inputFill,
+                            border: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(12),
+                              borderSide: BorderSide(color: context.tokens.outline),
+                            ),
+                            enabledBorder: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(12),
+                              borderSide: BorderSide(color: context.tokens.outline),
+                            ),
+                            focusedBorder: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(12),
+                              borderSide: BorderSide(color: context.tokens.accentSolid),
+                            ),
+                            contentPadding: const EdgeInsets.symmetric(
+                              horizontal: 16,
+                              vertical: 16,
+                            ),
+                          ),
+                          maxLines: 2,
+                        ),
                         const SizedBox(height: 24),
-                        
-                        // Buttons
                         Padding(
                           padding: const EdgeInsets.only(bottom: 24),
                           child: Row(
                             children: [
                               Expanded(
                                 child: OutlinedButton(
-                                  onPressed: () => Navigator.pop(context),
+                                  onPressed: () => Navigator.pop(modalContext),
                                   style: OutlinedButton.styleFrom(
                                     foregroundColor: context.tokens.accentForeground,
-                                    side: BorderSide(
-                                      color: context.tokens.textTertiary,
-                                    ),
+                                    side: BorderSide(color: context.tokens.textTertiary),
                                     padding: const EdgeInsets.symmetric(vertical: 16),
                                     shape: RoundedRectangleBorder(
                                       borderRadius: BorderRadius.circular(12),
@@ -1471,17 +1246,20 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                                   ),
                                   child: Text(
                                     AppLocalizations.of(context)!.cancel_button,
-                                    style: TextStyle(
+                                    style: const TextStyle(
                                       fontSize: 16,
                                       fontWeight: FontWeight.w600,
-                                                                          ),
+                                    ),
                                   ),
                                 ),
                               ),
                               const SizedBox(width: 12),
                               Expanded(
                                 child: ElevatedButton(
-                                  onPressed: () => _confirmRequestAmount(),
+                                  onPressed: () => _confirmRequestAmount(
+                                    modalContext,
+                                    autoStartNfcAfterGenerate: autoStartNfcAfterGenerate,
+                                  ),
                                   style: ElevatedButton.styleFrom(
                                     backgroundColor: context.tokens.accentSolid,
                                     foregroundColor: context.tokens.accentForeground,
@@ -1493,10 +1271,10 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                                   ),
                                   child: Text(
                                     AppLocalizations.of(context)!.confirm_button,
-                                    style: TextStyle(
+                                    style: const TextStyle(
                                       fontSize: 16,
                                       fontWeight: FontWeight.w600,
-                                                                          ),
+                                    ),
                                   ),
                                 ),
                               ),
@@ -1515,84 +1293,55 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
     );
   }
 
-  void _confirmRequestAmount() async {
-    // Validate that an amount has been entered
+  void _confirmRequestAmount(
+    BuildContext modalContext, {
+    bool autoStartNfcAfterGenerate = false,
+  }) async {
     if (_amountController.text.trim().isEmpty) {
       _showErrorSnackBar(AppLocalizations.of(context)!.invalid_amount_error);
       return;
     }
 
-    // Validate that the amount is valid
     final amount = double.tryParse(_amountController.text.trim());
     if (amount == null || amount <= 0) {
       _showErrorSnackBar(AppLocalizations.of(context)!.invalid_amount_error);
       return;
     }
 
-    // Close modal
-    Navigator.pop(context);
+    Navigator.pop(modalContext);
 
-    // Show loading
     setState(() {
       _isGeneratingInvoice = true;
     });
 
     try {
-      // Get necessary data
       final walletProvider = context.read<WalletProvider>();
       final authProvider = context.read<AuthProvider>();
-      
+
       final wallet = walletProvider.primaryWallet;
       final serverUrl = authProvider.sessionData?.serverUrl;
-      
+
       if (wallet == null || serverUrl == null) {
         throw Exception(AppLocalizations.of(context)!.no_wallet_error);
       }
 
-      // CURRENCY CONVERSION TO SATOSHIS
-      print('[RECEIVE_SCREEN] === STARTING CURRENCY CONVERSION ===');
-      print('[RECEIVE_SCREEN] Amount: $amount $_selectedCurrency');
-      
-      // ALWAYS use fresh conversion with consistent rates
       final amountInSats = await _getAmountInSats(amount, _selectedCurrency);
-      final conversionMessage = _selectedCurrency == 'sats' 
-          ? 'Factura: $amountInSats sats'
-          : '$amount $_selectedCurrency / $amountInSats sats';
-      
-      print('[RECEIVE_SCREEN] Final conversion result: $conversionMessage');
-      
-      // Basic validations
+
       if (amountInSats < 1) {
         throw Exception('Monto convertido muy pequeño (mínimo 1 sat)');
       }
-        
-      // Validate extremely large amounts that can cause server problems
-      if (amountInSats > 2100000000000000) { // 21M BTC en sats
+
+      if (amountInSats > 2100000000000000) {
         throw Exception('Monto muy grande. Máximo: 21M BTC');
       }
-      
-      if (amountInSats > 100000000000) { // 1000 BTC as practical limit
-        print('[RECEIVE_SCREEN] ⚠️ WARNING: Very large amount ($amountInSats sats = ${(amountInSats/100000000).toStringAsFixed(2)} BTC)');
-      }
 
-      print('[RECEIVE_SCREEN] Generando factura: $amountInSats sats');
-      print('[RECEIVE_SCREEN] Server: $serverUrl');
-      print('[RECEIVE_SCREEN] Wallet: ${wallet.name}');
-      print('[RECEIVE_SCREEN] Original currency: $_selectedCurrency');
-      print('[RECEIVE_SCREEN] Original amount: $amount');
-      print('[RECEIVE_SCREEN] Original rate: ${_selectedCurrency != 'sats' ? (amountInSats / amount) : 'N/A'}');
-
-      // Prepare memo with fiat info as fallback for LNBits limitations
       String? finalMemo;
       if (_noteController.text.trim().isNotEmpty) {
         finalMemo = _noteController.text.trim();
       } else if (_selectedCurrency != 'sats') {
-        // Use fiat amount as memo when no custom note (fallback for LNBits)
         finalMemo = '${amount.toStringAsFixed(amount.truncateToDouble() == amount ? 0 : 2)} $_selectedCurrency';
       }
 
-      // Generate invoice with amount in satoshis and original fiat information.
-      // Receiving only needs LNbits invoice key (read+create), not admin.
       final invoice = await _invoiceService.createInvoice(
         serverUrl: serverUrl,
         adminKey: wallet.inKey,
@@ -1604,59 +1353,127 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
         originalFiatRate: _selectedCurrency != 'sats' ? (amountInSats / amount) : null,
       );
 
-      // Update state
+      if (!mounted) return;
       setState(() {
         _generatedInvoice = invoice;
         _isGeneratingInvoice = false;
       });
 
-      // Show confirmation
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Row(
-            children: [
-              Icon(Icons.check_circle, color: context.tokens.textPrimary, size: 20),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Text(
-                      conversionMessage.isNotEmpty ? conversionMessage : 'Factura: ${invoice.formattedAmount}',
-                      style: const TextStyle(
-                                                fontWeight: FontWeight.w500,
-                      ),
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-          backgroundColor: context.tokens.statusHealthy,
-          behavior: SnackBarBehavior.floating,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(12),
-          ),
-          duration: const Duration(seconds: 3),
-        ),
+      _showAccentSnackBar(
+        icon: Icons.check_circle,
+        message: AppLocalizations.of(context)!.invoice_generated_message,
+        backgroundColor: context.tokens.statusHealthy,
       );
 
-      print('[RECEIVE_SCREEN] Factura generada exitosamente: ${invoice.paymentHash}');
-      
-      // Start automatic verification of invoice payment
       _startInvoicePaymentMonitoring(invoice, wallet, serverUrl);
 
+      if (autoStartNfcAfterGenerate && _nfcAvailable) {
+        _openNfcChargeSheet(invoice.paymentRequest);
+      }
     } catch (e) {
-      print('[RECEIVE_SCREEN] Error generando factura: $e');
-      
       setState(() {
         _isGeneratingInvoice = false;
       });
-      
       _showErrorSnackBar('Error generando factura: ${e.toString()}');
     }
+  }
+
+  void _startInvoicePaymentMonitoring(LightningInvoice invoice, WalletInfo wallet, String serverUrl) {
+    _invoicePaymentTimer?.cancel();
+    _invoicePaymentTimeoutTimer?.cancel();
+
+    _invoicePaymentTimer = Timer.periodic(const Duration(seconds: 5), (timer) async {
+      if (!mounted) {
+        timer.cancel();
+        return;
+      }
+
+      try {
+        final isPaid = await _invoiceService.checkInvoiceStatus(
+          serverUrl: serverUrl,
+          adminKey: wallet.inKey,
+          paymentHash: invoice.paymentHash,
+        );
+
+        if (isPaid) {
+          timer.cancel();
+
+          if (mounted) {
+            _transactionDetector.triggerEventSpark('invoice_paid');
+            Navigator.of(context).popUntil((route) => route.isFirst);
+
+            Future.delayed(const Duration(milliseconds: 800), () {
+              if (mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(
+                    content: Row(
+                      children: [
+                        Icon(Icons.check_circle, color: context.tokens.textPrimary, size: 20),
+                        const SizedBox(width: 12),
+                        Text(
+                          '${AppLocalizations.of(context)!.received_label}! ${invoice.formattedAmount}',
+                          style: const TextStyle(fontWeight: FontWeight.w500),
+                        ),
+                      ],
+                    ),
+                    backgroundColor: context.tokens.statusHealthy,
+                    behavior: SnackBarBehavior.floating,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    duration: const Duration(seconds: 3),
+                  ),
+                );
+              }
+            });
+          }
+        }
+      } catch (_) {
+        // Continue checking on temporary errors
+      }
+    });
+
+    _invoicePaymentTimeoutTimer = Timer(const Duration(minutes: 10), () {
+      _invoicePaymentTimer?.cancel();
+      if (!mounted) return;
+      setState(() {
+        _generatedInvoice = null;
+      });
+      _showInfoSnackBar(
+        AppLocalizations.of(context)!.invoice_monitoring_timeout_message,
+      );
+    });
+  }
+
+  void _showAccentSnackBar({
+    required IconData icon,
+    required String message,
+    Color? backgroundColor,
+  }) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Row(
+          children: [
+            Icon(icon, color: context.tokens.textPrimary, size: 20),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                message,
+                style: const TextStyle(fontWeight: FontWeight.w500),
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ],
+        ),
+        backgroundColor: backgroundColor ?? context.tokens.accentSolid,
+        behavior: SnackBarBehavior.floating,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12),
+        ),
+        duration: const Duration(seconds: 2),
+      ),
+    );
   }
 
   void _showErrorSnackBar(String message) {
@@ -1669,9 +1486,7 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
             Expanded(
               child: Text(
                 message,
-                style: const TextStyle(
-                                    fontWeight: FontWeight.w500,
-                ),
+                style: const TextStyle(fontWeight: FontWeight.w500),
                 overflow: TextOverflow.ellipsis,
                 maxLines: 2,
               ),
@@ -1695,10 +1510,11 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
           children: [
             Icon(Icons.info, color: context.tokens.textPrimary, size: 20),
             const SizedBox(width: 12),
-            Text(
-              message,
-              style: const TextStyle(
-                                fontWeight: FontWeight.w500,
+            Expanded(
+              child: Text(
+                message,
+                style: const TextStyle(fontWeight: FontWeight.w500),
+                overflow: TextOverflow.ellipsis,
               ),
             ),
           ],
@@ -1713,249 +1529,203 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
     );
   }
 
-  void _copyPaymentInfo(LNAddress defaultAddress) async {
-    String textToCopy;
-    String successMessage;
-    
-    if (_generatedInvoice != null) {
-      // If there's a generated invoice, copy the invoice
-      textToCopy = _generatedInvoice!.paymentRequest;
-      successMessage = AppLocalizations.of(context)!.copy_button;
-    } else {
-      // If there's no invoice, copy the Lightning Address
-      textToCopy = defaultAddress.fullAddress;
-      successMessage = AppLocalizations.of(context)!.address_copied_message;
-    }
-    
-    await Clipboard.setData(ClipboardData(text: textToCopy));
-    if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Row(
-            children: [
-              Icon(Icons.check_circle, color: context.tokens.textPrimary, size: 20),
-              const SizedBox(width: 12),
-              Text(
-                successMessage,
-                style: const TextStyle(
-                                    fontWeight: FontWeight.w500,
-                ),
-              ),
-            ],
-          ),
-          backgroundColor: context.tokens.accentSolid,
-          behavior: SnackBarBehavior.floating,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(12),
-          ),
-          duration: const Duration(seconds: 2),
-        ),
-      );
-    }
-  }
-
-  void _startInvoicePaymentMonitoring(LightningInvoice invoice, WalletInfo wallet, String serverUrl) {
-    print('[RECEIVE_SCREEN] Iniciando monitoreo de pago para factura: ${invoice.paymentHash}');
-
-    // Cancel previous timers if they exist
-    _invoicePaymentTimer?.cancel();
-    _invoicePaymentTimeoutTimer?.cancel();
-
-    // Check every 5 seconds if the invoice was paid (gentle on rate-limited servers)
-    _invoicePaymentTimer = Timer.periodic(const Duration(seconds: 5), (timer) async {
-      if (!mounted) {
-        timer.cancel();
-        return;
-      }
-
-      try {
-        // Check invoice status — read-only operation, invoice key is enough
-        final isPaid = await _invoiceService.checkInvoiceStatus(
-          serverUrl: serverUrl,
-          adminKey: wallet.inKey,
-          paymentHash: invoice.paymentHash,
-        );
-        
-        if (isPaid) {
-          print('[RECEIVE_SCREEN] Invoice paid! Starting celebration sequence');
-          timer.cancel();
-          
-          if (mounted) {
-            // 1. FIRST: Activate spark effect
-            print('[RECEIVE_SCREEN] 🎆 Activando efecto chispa por pago recibido');
-            _transactionDetector.triggerEventSpark('invoice_paid');
-            
-            // 2. AFTER: Navigate to HomeScreen to show spark effect
-            Navigator.of(context).popUntil((route) => route.isFirst);
-            
-            // 3. FINALLY: Wait a moment and show green notification
-            Future.delayed(const Duration(milliseconds: 800), () {
-              if (mounted) {
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(
-                    content: Row(
-                      children: [
-                        Icon(Icons.check_circle, color: context.tokens.textPrimary, size: 20),
-                        const SizedBox(width: 12),
-                        Text(
-                          '${AppLocalizations.of(context)!.received_label}! ${invoice.formattedAmount}',
-                          style: const TextStyle(
-                                                        fontWeight: FontWeight.w500,
-                          ),
-                        ),
-                      ],
-                    ),
-                    backgroundColor: context.tokens.statusHealthy,
-                    behavior: SnackBarBehavior.floating,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                    duration: const Duration(seconds: 3),
-                  ),
-                );
-              }
-            });
-          }
-        }
-      } catch (e) {
-        print('[RECEIVE_SCREEN] Error verificando estado de factura: $e');
-        // Continue checking in case of temporary error
-      }
-    });
-    
-    // Auto-cancel after 10 minutes to avoid infinite monitoring.
-    // Notify the user and clear the QR so they can regenerate a fresh invoice.
-    _invoicePaymentTimeoutTimer = Timer(const Duration(minutes: 10), () {
-      _invoicePaymentTimer?.cancel();
-      print('[RECEIVE_SCREEN] Timeout: Deteniendo monitoreo de factura');
-      if (!mounted) return;
-      setState(() {
-        _generatedInvoice = null;
-      });
-      _showInfoSnackBar(
-        AppLocalizations.of(context)!.invoice_monitoring_timeout_message,
-      );
-    });
-  }
-
-  Widget _buildCopyLNURLButton(LNAddress defaultAddress) {
-    return SizedBox(
-      width: double.infinity,
-      child: OutlinedButton.icon(
-        onPressed: () => _copyLNURL(defaultAddress),
-        style: OutlinedButton.styleFrom(
-          foregroundColor: context.tokens.accentForeground,
-          side: BorderSide(
-            color: context.tokens.textTertiary,
-            width: 1.5,
-          ),
-          padding: const EdgeInsets.symmetric(vertical: 16),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(16),
-          ),
-        ),
-        icon: const Icon(Icons.copy, size: 20),
-        label: Text(
-          AppLocalizations.of(context)!.copy_lnurl,
-          style: const TextStyle(
-            fontSize: 16,
-            fontWeight: FontWeight.w600,
-                      ),
-        ),
-      ),
-    );
-  }
-
-  void _copyLNURL(LNAddress defaultAddress) async {
-    final lnurl = defaultAddress.lnurl;
-    
-    if (lnurl != null && lnurl.isNotEmpty) {
-      await Clipboard.setData(ClipboardData(text: lnurl));
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Row(
-              children: [
-                Icon(Icons.check_circle, color: context.tokens.textPrimary, size: 20),
-                const SizedBox(width: 12),
-                const Text(
-                  'LNURL copiado',
-                  style: TextStyle(
-                                        fontWeight: FontWeight.w500,
-                  ),
-                ),
-              ],
-            ),
-            backgroundColor: context.tokens.accentSolid,
-            behavior: SnackBarBehavior.floating,
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(12),
-            ),
-            duration: const Duration(seconds: 2),
-          ),
-        );
-      }
-    } else {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Row(
-              children: [
-                Icon(Icons.error, color: context.tokens.textPrimary, size: 20),
-                const SizedBox(width: 12),
-                const Text(
-                  'LNURL no disponible',
-                  style: TextStyle(
-                                        fontWeight: FontWeight.w500,
-                  ),
-                ),
-              ],
-            ),
-            backgroundColor: context.tokens.statusUnhealthy,
-            behavior: SnackBarBehavior.floating,
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(12),
-            ),
-            duration: const Duration(seconds: 2),
-          ),
-        );
-      }
-    }
-  }
-
-  void _copyLightningAddress(String address) async {
-    await Clipboard.setData(ClipboardData(text: address));
-    if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Row(
-            children: [
-              Icon(Icons.check_circle, color: context.tokens.textPrimary, size: 20),
-              const SizedBox(width: 12),
-              Text(
-                AppLocalizations.of(context)!.address_copied_message,
-                style: const TextStyle(
-                                    fontWeight: FontWeight.w500,
-                ),
-              ),
-            ],
-          ),
-          backgroundColor: context.tokens.accentSolid,
-          behavior: SnackBarBehavior.floating,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(12),
-          ),
-          duration: const Duration(seconds: 2),
-        ),
-      );
-    }
-  }
-
   void _navigateToVoucherScreen() {
     Navigator.push(
       context,
       MaterialPageRoute(
         builder: (context) => const VoucherScanScreen(),
+      ),
+    );
+  }
+}
+
+class _NfcChargeSheet extends StatefulWidget {
+  final String invoice;
+  const _NfcChargeSheet({required this.invoice});
+
+  @override
+  State<_NfcChargeSheet> createState() => _NfcChargeSheetState();
+}
+
+class _NfcChargeSheetState extends State<_NfcChargeSheet> {
+  late final NfcChargeService _service;
+  NfcChargeStatus _status = NfcChargeStatus.scanning;
+  String? _errorMessage;
+  bool _autoCloseScheduled = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _service = NfcChargeService();
+    _start();
+  }
+
+  Future<void> _start() async {
+    await _service.startChargeSession(
+      invoice: widget.invoice,
+      onStatus: (result) {
+        if (!mounted) return;
+        setState(() {
+          _status = result.status;
+          _errorMessage = result.message;
+        });
+        if (result.status == NfcChargeStatus.success && !_autoCloseScheduled) {
+          _autoCloseScheduled = true;
+          Future.delayed(const Duration(milliseconds: 1400), () {
+            if (mounted) Navigator.of(context).pop();
+          });
+        }
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _service.stopSession();
+    _service.dispose();
+    super.dispose();
+  }
+
+  Color _statusColor(BuildContext context) {
+    switch (_status) {
+      case NfcChargeStatus.success:
+        return context.tokens.statusHealthy;
+      case NfcChargeStatus.invalidTag:
+      case NfcChargeStatus.networkError:
+      case NfcChargeStatus.callbackError:
+        return context.tokens.statusUnhealthy;
+      default:
+        return context.tokens.accentSolid;
+    }
+  }
+
+  IconData _statusIcon() {
+    switch (_status) {
+      case NfcChargeStatus.success:
+        return Icons.check_circle_rounded;
+      case NfcChargeStatus.invalidTag:
+      case NfcChargeStatus.networkError:
+      case NfcChargeStatus.callbackError:
+        return Icons.error_rounded;
+      case NfcChargeStatus.charging:
+        return Icons.bolt_rounded;
+      case NfcChargeStatus.reading:
+        return Icons.contactless_rounded;
+      case NfcChargeStatus.scanning:
+        return Icons.nfc_rounded;
+    }
+  }
+
+  String _statusText(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    switch (_status) {
+      case NfcChargeStatus.scanning:
+      case NfcChargeStatus.reading:
+        return l10n.nfc_scanning_message;
+      case NfcChargeStatus.charging:
+        return l10n.nfc_charging_message;
+      case NfcChargeStatus.success:
+        return l10n.invoice_generated_message;
+      case NfcChargeStatus.invalidTag:
+        return l10n.nfc_invalid_tag_message;
+      case NfcChargeStatus.networkError:
+      case NfcChargeStatus.callbackError:
+        return '${l10n.nfc_charge_error_prefix}${_errorMessage ?? ''}';
+    }
+  }
+
+  bool get _isFinal =>
+      _status == NfcChargeStatus.success ||
+      _status == NfcChargeStatus.invalidTag ||
+      _status == NfcChargeStatus.networkError ||
+      _status == NfcChargeStatus.callbackError;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final accent = _statusColor(context);
+
+    return Container(
+      decoration: BoxDecoration(
+        color: context.tokens.dialogBackground,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      padding: EdgeInsets.fromLTRB(
+        24,
+        12,
+        24,
+        24 + MediaQuery.of(context).viewPadding.bottom,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: 40,
+            height: 4,
+            decoration: BoxDecoration(
+              color: context.tokens.textTertiary,
+              borderRadius: BorderRadius.circular(2),
+            ),
+          ),
+          const SizedBox(height: 20),
+          Text(
+            l10n.nfc_scanning_title,
+            style: TextStyle(
+              color: context.tokens.textPrimary,
+              fontSize: 20,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: 32),
+          Container(
+            width: 96,
+            height: 96,
+            decoration: BoxDecoration(
+              color: accent.withValues(alpha: 0.12),
+              shape: BoxShape.circle,
+              border: Border.all(
+                color: accent.withValues(alpha: 0.4),
+                width: 2,
+              ),
+            ),
+            child: Icon(_statusIcon(), color: accent, size: 48),
+          ),
+          const SizedBox(height: 24),
+          Text(
+            _statusText(context),
+            style: TextStyle(
+              color: context.tokens.textPrimary,
+              fontSize: 16,
+              fontWeight: FontWeight.w500,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 32),
+          SizedBox(
+            width: double.infinity,
+            child: OutlinedButton(
+              onPressed: () => Navigator.of(context).pop(),
+              style: OutlinedButton.styleFrom(
+                foregroundColor: context.tokens.accentForeground,
+                side: BorderSide(
+                  color: context.tokens.textTertiary,
+                  width: 1.5,
+                ),
+                padding: const EdgeInsets.symmetric(vertical: 16),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(16),
+                ),
+              ),
+              child: Text(
+                _isFinal ? l10n.close_dialog : l10n.cancel_button,
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/screens/9receive_screen.dart
+++ b/lib/screens/9receive_screen.dart
@@ -1630,7 +1630,10 @@ class _NfcChargeSheetState extends State<_NfcChargeSheet> {
         return l10n.nfc_invalid_tag_message;
       case NfcChargeStatus.networkError:
       case NfcChargeStatus.callbackError:
-        return '${l10n.nfc_charge_error_prefix}${_errorMessage ?? ''}';
+        final detail = _errorMessage?.trim() ?? '';
+        return detail.isNotEmpty
+            ? '${l10n.nfc_charge_error_prefix}$detail'
+            : l10n.nfc_charge_unknown_error;
     }
   }
 

--- a/lib/services/nfc_charge_service.dart
+++ b/lib/services/nfc_charge_service.dart
@@ -1,0 +1,211 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io' show Platform;
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:nfc_manager/nfc_manager.dart';
+import '../core/utils/proxy_config.dart';
+import 'app_info_service.dart';
+
+void _debugLog(String message) {
+  if (kDebugMode) {
+    print('[NFC_CHARGE] $message');
+  }
+}
+
+enum NfcChargeStatus {
+  scanning,
+  reading,
+  charging,
+  success,
+  invalidTag,
+  networkError,
+  callbackError,
+}
+
+class NfcChargeResult {
+  final NfcChargeStatus status;
+  final String? message;
+  const NfcChargeResult(this.status, {this.message});
+}
+
+class NfcChargeService {
+  final Dio _dio = Dio();
+  bool _sessionActive = false;
+
+  NfcChargeService() {
+    _configureDio();
+  }
+
+  void _configureDio() {
+    final isAndroid = !kIsWeb && Platform.isAndroid;
+    _dio.options.headers['User-Agent'] = isAndroid
+        ? AppInfoService.getUserAgent('Android')
+        : AppInfoService.getUserAgent();
+    _dio.options.headers['Accept'] = 'application/json';
+    _dio.options.connectTimeout = const Duration(seconds: 15);
+    _dio.options.receiveTimeout = const Duration(seconds: 15);
+    _dio.options.sendTimeout = const Duration(seconds: 15);
+    _dio.options.followRedirects = true;
+    _dio.options.maxRedirects = 5;
+    _dio.options.validateStatus =
+        (status) => status != null && status >= 200 && status < 400;
+    ProxyConfig.configureProxy(_dio);
+  }
+
+  static Future<bool> isAvailable() async {
+    try {
+      return await NfcManager.instance.isAvailable();
+    } catch (e) {
+      _debugLog('isAvailable threw: $e');
+      return false;
+    }
+  }
+
+  bool get isSessionActive => _sessionActive;
+
+  Future<void> startChargeSession({
+    required String invoice,
+    required void Function(NfcChargeResult) onStatus,
+  }) async {
+    if (_sessionActive) return;
+    _sessionActive = true;
+    onStatus(const NfcChargeResult(NfcChargeStatus.scanning));
+
+    try {
+      await NfcManager.instance.startSession(
+        pollingOptions: NfcPollingOption.values.toSet(),
+        invalidateAfterFirstRead: true,
+        alertMessage: 'Acerca la tarjeta',
+        onDiscovered: (NfcTag tag) async {
+          try {
+            onStatus(const NfcChargeResult(NfcChargeStatus.reading));
+
+            final url = _extractUriFromTag(tag);
+            if (url == null) {
+              onStatus(const NfcChargeResult(NfcChargeStatus.invalidTag));
+              await _safeStop(errorMessage: 'Tag no compatible');
+              return;
+            }
+            _debugLog('Tag URL: $url');
+
+            final metaResponse = await _dio.get(url);
+            final meta = metaResponse.data;
+            if (meta is! Map) {
+              onStatus(const NfcChargeResult(NfcChargeStatus.invalidTag));
+              await _safeStop(errorMessage: 'Respuesta inválida');
+              return;
+            }
+            if (meta['tag'] != 'withdrawRequest') {
+              onStatus(const NfcChargeResult(NfcChargeStatus.invalidTag));
+              await _safeStop(errorMessage: 'No es Boltcard');
+              return;
+            }
+            final callback = meta['callback'] as String?;
+            final k1 = meta['k1'] as String?;
+            if (callback == null || k1 == null) {
+              onStatus(const NfcChargeResult(NfcChargeStatus.invalidTag));
+              await _safeStop(errorMessage: 'Datos incompletos');
+              return;
+            }
+
+            onStatus(const NfcChargeResult(NfcChargeStatus.charging));
+
+            final claim = await _dio.get(callback, queryParameters: {
+              'k1': k1,
+              'pr': invoice,
+            });
+
+            final claimData = claim.data;
+            if (claimData is Map && claimData['status'] == 'OK') {
+              onStatus(const NfcChargeResult(NfcChargeStatus.success));
+              await _safeStop(alertMessage: 'OK');
+            } else {
+              final reason = claimData is Map
+                  ? (claimData['reason']?.toString() ?? 'Error desconocido')
+                  : 'Error desconocido';
+              onStatus(NfcChargeResult(
+                NfcChargeStatus.callbackError,
+                message: reason,
+              ));
+              await _safeStop(errorMessage: reason);
+            }
+          } catch (e) {
+            _debugLog('Discovery handler error: $e');
+            onStatus(NfcChargeResult(
+              NfcChargeStatus.networkError,
+              message: e.toString(),
+            ));
+            await _safeStop(errorMessage: 'Error de red');
+          } finally {
+            _sessionActive = false;
+          }
+        },
+      );
+    } catch (e) {
+      _debugLog('startSession error: $e');
+      _sessionActive = false;
+      onStatus(NfcChargeResult(
+        NfcChargeStatus.networkError,
+        message: e.toString(),
+      ));
+    }
+  }
+
+  Future<void> stopSession() async {
+    await _safeStop();
+    _sessionActive = false;
+  }
+
+  Future<void> _safeStop({String? alertMessage, String? errorMessage}) async {
+    try {
+      await NfcManager.instance.stopSession(
+        alertMessage: alertMessage,
+        errorMessage: errorMessage,
+      );
+    } catch (_) {
+      // ignore
+    }
+  }
+
+  String? _extractUriFromTag(NfcTag tag) {
+    final ndef = Ndef.from(tag);
+    if (ndef == null) return null;
+    final message = ndef.cachedMessage;
+    if (message == null || message.records.isEmpty) return null;
+
+    for (final record in message.records) {
+      if (record.typeNameFormat == NdefTypeNameFormat.nfcWellknown &&
+          record.type.length == 1 &&
+          record.type[0] == 0x55 &&
+          record.payload.isNotEmpty) {
+        final prefixIndex = record.payload[0];
+        final prefix = (prefixIndex < NdefRecord.URI_PREFIX_LIST.length)
+            ? NdefRecord.URI_PREFIX_LIST[prefixIndex]
+            : '';
+        final urlBytes = record.payload.sublist(1);
+        final raw = prefix + utf8.decode(urlBytes, allowMalformed: true);
+        return _normalizeLnurlw(raw);
+      }
+    }
+    return null;
+  }
+
+  String? _normalizeLnurlw(String raw) {
+    if (raw.isEmpty) return null;
+    if (raw.startsWith('lnurlw://')) {
+      return 'https://${raw.substring(9)}';
+    }
+    if (raw.startsWith('lnurlw:')) {
+      return 'https://${raw.substring(7)}';
+    }
+    if (raw.startsWith('https://') || raw.startsWith('http://')) {
+      return raw;
+    }
+    return null;
+  }
+
+  void dispose() {
+    _dio.close(force: true);
+  }
+}

--- a/lib/services/nfc_charge_service.dart
+++ b/lib/services/nfc_charge_service.dart
@@ -101,13 +101,18 @@ class NfcChargeService {
               await _safeStop(errorMessage: 'No es Boltcard');
               return;
             }
-            final callback = meta['callback'] as String?;
-            final k1 = meta['k1'] as String?;
-            if (callback == null || k1 == null) {
+            final callbackValue = meta['callback'];
+            final k1Value = meta['k1'];
+            if (callbackValue is! String ||
+                callbackValue.isEmpty ||
+                k1Value is! String ||
+                k1Value.isEmpty) {
               onStatus(const NfcChargeResult(NfcChargeStatus.invalidTag));
               await _safeStop(errorMessage: 'Datos incompletos');
               return;
             }
+            final callback = callbackValue;
+            final k1 = k1Value;
 
             onStatus(const NfcChargeResult(NfcChargeStatus.charging));
 

--- a/lib/services/nfc_charge_service.dart
+++ b/lib/services/nfc_charge_service.dart
@@ -122,8 +122,8 @@ class NfcChargeService {
               await _safeStop(alertMessage: 'OK');
             } else {
               final reason = claimData is Map
-                  ? (claimData['reason']?.toString() ?? 'Error desconocido')
-                  : 'Error desconocido';
+                  ? claimData['reason']?.toString()
+                  : null;
               onStatus(NfcChargeResult(
                 NfcChargeStatus.callbackError,
                 message: reason,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -105,6 +105,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+2"
   crypto:
     dependency: "direct main"
     description:
@@ -161,6 +169,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -381,6 +397,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  nfc_manager:
+    dependency: "direct main"
+    description:
+      name: nfc_manager
+      sha256: "071faa6e43317f9feeef316067456ae6e61a40f7748ed6e93470a812e103c326"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.5.1"
   package_info_plus:
     dependency: "direct main"
     description:
@@ -509,6 +533,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: fce43200aa03ea87b91ce4c3ac79f0cecd52e2a7a56c7a4185023c271fbfa6da
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.1.4"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: cc012a23fc2d479854e6c80150696c4a5f5bb62cb89af4de1c505cf78d0a5d0b
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.2"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -690,6 +730,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.4"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.3"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 0.4.1+5
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: '>=3.4.0 <4.0.0'
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,8 @@ dependencies:
   webview_flutter: ^4.4.2
   package_info_plus: ^8.3.1
   app_links: ^6.3.2
+  share_plus: ^10.1.4
+  nfc_manager: ^3.5.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Restructure receive screen to Option 3 layout: QR + address + optional invoice chip + primary CTA + bottom action bar (Copy/Share/NFC)
- Replace stacked full-width buttons with compact icon bar
- Copy bottom sheet with LN Address / LNURL / Invoice options
- Real share via share_plus (Android/iOS native share sheet)
- Real NFC charging flow with nfc_manager:
  - Detects NFC availability on screen open
  - Greys out button when device lacks NFC
  - Snackbar 'NFC no disponible' if user taps disabled button
  - Reads NDEF URI, normalizes lnurlw:// → https://
  - Resolves LNURLw, posts invoice to callback
  - Status sheet with scanning/reading/charging/success/error states
- NFC entry without invoice opens amount modal then auto-starts scan
- Add 6 NFC localization keys + share/lnurl_copied keys in 7 locales
- Android NFC permission with required=false to keep install on non-NFC devices"                                                                                                                                    
                         

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NFC-based charging/invoice intake with scanning, charging progress, and error handling
  * Content sharing and LNURL copy-to-clipboard confirmations
  * Full localization for these flows in English, German, Spanish, French, Italian, Portuguese, and Russian
  * NFC availability and handling on Android devices

* **Chores**
  * Added runtime support for NFC and sharing functionality and tightened platform requirements
<!-- end of auto-generated comment: release notes by coderabbit.ai -->