### PR TITLE
fix: move NFC action to center in receive bottom bar

### DIFF
--- a/lib/screens/9receive_screen.dart
+++ b/lib/screens/9receive_screen.dart
@@ -511,15 +511,15 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
             onTap: () => _showCopySheet(defaultAddress),
           ),
           _buildBarAction(
-            icon: Icons.ios_share_rounded,
-            label: AppLocalizations.of(context)!.share_button,
-            onTap: () => _shareContent(defaultAddress),
-          ),
-          _buildBarAction(
             icon: Icons.nfc_rounded,
             label: AppLocalizations.of(context)!.nfc_action_label,
             enabled: _nfcAvailable,
             onTap: _nfcAvailable ? _activateNfc : _showNfcUnavailable,
+          ),
+          _buildBarAction(
+            icon: Icons.ios_share_rounded,
+            label: AppLocalizations.of(context)!.share_button,
+            onTap: () => _shareContent(defaultAddress),
           ),
         ],
       ),


### PR DESCRIPTION
Reorders bottom action bar on receive screen: Copy | NFC | Share

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reordered action buttons in the receive screen, with NFC functionality now appearing before the share option.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lachispame/lachispa/pull/100)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->