### PR TITLE
chore: update Dart SDK constraint to >=3.11.5

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 0.4.1+5
 
 environment:
-  sdk: '>=3.4.0 <4.0.0'
+  sdk: '>=3.11.5 <4.0.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
Bumps minimum Dart SDK from 3.4.0 to 3.11.5 following Flutter upgrade to 3.41.9