### PR TITLE
chore: migrate dart:io Platform checks to defaultTargetPlatform

### DIFF
--- a/lib/screens/14fixed_float_screen.dart
+++ b/lib/screens/14fixed_float_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
-import 'dart:io' show Platform;
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart' show kIsWeb, defaultTargetPlatform, TargetPlatform;
 import 'package:url_launcher/url_launcher.dart';
 import '../l10n/generated/app_localizations.dart';
 import '../theme/app_tokens.dart';
@@ -28,7 +27,7 @@ class _FixedFloatScreenState extends State<FixedFloatScreen> {
   void _initializeWebView() {
     try {
       // Only initialize WebView on mobile platforms
-      if (!kIsWeb && (Platform.isAndroid || Platform.isIOS)) {
+      if (!kIsWeb && (defaultTargetPlatform == TargetPlatform.android || defaultTargetPlatform == TargetPlatform.iOS)) {
         _controller = WebViewController()
           ..setJavaScriptMode(JavaScriptMode.unrestricted)
           ..setNavigationDelegate(
@@ -310,7 +309,7 @@ class _FixedFloatScreenState extends State<FixedFloatScreen> {
 
           // Info text
           Text(
-            kIsWeb || !(Platform.isAndroid || Platform.isIOS)
+            kIsWeb || !(defaultTargetPlatform == TargetPlatform.android || defaultTargetPlatform == TargetPlatform.iOS)
                 ? AppLocalizations.of(context)!.fixed_float_external_browser
                 : AppLocalizations.of(context)!.fixed_float_within_app,
             textAlign: TextAlign.center,

--- a/lib/screens/14fixed_float_screen.dart
+++ b/lib/screens/14fixed_float_screen.dart
@@ -18,6 +18,11 @@ class _FixedFloatScreenState extends State<FixedFloatScreen> {
   bool _hasError = false;
   String? _errorMessage;
 
+  bool get _isMobilePlatform =>
+      !kIsWeb &&
+      (defaultTargetPlatform == TargetPlatform.android ||
+          defaultTargetPlatform == TargetPlatform.iOS);
+
   @override
   void initState() {
     super.initState();
@@ -27,7 +32,7 @@ class _FixedFloatScreenState extends State<FixedFloatScreen> {
   void _initializeWebView() {
     try {
       // Only initialize WebView on mobile platforms
-      if (!kIsWeb && (defaultTargetPlatform == TargetPlatform.android || defaultTargetPlatform == TargetPlatform.iOS)) {
+      if (_isMobilePlatform) {
         _controller = WebViewController()
           ..setJavaScriptMode(JavaScriptMode.unrestricted)
           ..setNavigationDelegate(
@@ -309,7 +314,7 @@ class _FixedFloatScreenState extends State<FixedFloatScreen> {
 
           // Info text
           Text(
-            kIsWeb || !(defaultTargetPlatform == TargetPlatform.android || defaultTargetPlatform == TargetPlatform.iOS)
+            !_isMobilePlatform
                 ? AppLocalizations.of(context)!.fixed_float_external_browser
                 : AppLocalizations.of(context)!.fixed_float_within_app,
             textAlign: TextAlign.center,

--- a/lib/screens/15boltz_screen.dart
+++ b/lib/screens/15boltz_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
-import 'dart:io' show Platform;
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart' show kIsWeb, defaultTargetPlatform, TargetPlatform;
 import 'package:url_launcher/url_launcher.dart';
 import '../l10n/generated/app_localizations.dart';
 import '../theme/app_tokens.dart';
@@ -28,7 +27,7 @@ class _BoltzScreenState extends State<BoltzScreen> {
   void _initializeWebView() {
     try {
       // Only initialize WebView on mobile platforms
-      if (!kIsWeb && (Platform.isAndroid || Platform.isIOS)) {
+      if (!kIsWeb && (defaultTargetPlatform == TargetPlatform.android || defaultTargetPlatform == TargetPlatform.iOS)) {
         _controller = WebViewController()
           ..setJavaScriptMode(JavaScriptMode.unrestricted)
           ..setNavigationDelegate(
@@ -310,7 +309,7 @@ class _BoltzScreenState extends State<BoltzScreen> {
 
           // Info text
           Text(
-            kIsWeb || !(Platform.isAndroid || Platform.isIOS)
+            kIsWeb || !(defaultTargetPlatform == TargetPlatform.android || defaultTargetPlatform == TargetPlatform.iOS)
                 ? AppLocalizations.of(context)!.boltz_external_browser
                 : AppLocalizations.of(context)!.boltz_within_app,
             textAlign: TextAlign.center,

--- a/lib/screens/15boltz_screen.dart
+++ b/lib/screens/15boltz_screen.dart
@@ -18,6 +18,11 @@ class _BoltzScreenState extends State<BoltzScreen> {
   bool _hasError = false;
   String? _errorMessage;
 
+  bool get _isMobilePlatform =>
+      !kIsWeb &&
+      (defaultTargetPlatform == TargetPlatform.android ||
+          defaultTargetPlatform == TargetPlatform.iOS);
+
   @override
   void initState() {
     super.initState();
@@ -27,7 +32,7 @@ class _BoltzScreenState extends State<BoltzScreen> {
   void _initializeWebView() {
     try {
       // Only initialize WebView on mobile platforms
-      if (!kIsWeb && (defaultTargetPlatform == TargetPlatform.android || defaultTargetPlatform == TargetPlatform.iOS)) {
+      if (_isMobilePlatform) {
         _controller = WebViewController()
           ..setJavaScriptMode(JavaScriptMode.unrestricted)
           ..setNavigationDelegate(
@@ -309,7 +314,7 @@ class _BoltzScreenState extends State<BoltzScreen> {
 
           // Info text
           Text(
-            kIsWeb || !(defaultTargetPlatform == TargetPlatform.android || defaultTargetPlatform == TargetPlatform.iOS)
+            !_isMobilePlatform
                 ? AppLocalizations.of(context)!.boltz_external_browser
                 : AppLocalizations.of(context)!.boltz_within_app,
             textAlign: TextAlign.center,

--- a/lib/services/invoice_service.dart
+++ b/lib/services/invoice_service.dart
@@ -18,29 +18,31 @@ void _debugLog(String message) {
 class InvoiceService {
   final Dio _dio = Dio();
 
+  bool get _isAndroid =>
+      !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
+
   InvoiceService() {
     _configureDio();
   }
 
   void _configureDio() {
-    final isAndroid = !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
     final isWeb = kIsWeb;
     
     _dio.options.headers['Content-Type'] = 'application/json';
-    _dio.options.headers['User-Agent'] = isAndroid 
+    _dio.options.headers['User-Agent'] = _isAndroid 
         ? AppInfoService.getUserAgent('Android') 
         : isWeb 
           ? AppInfoService.getUserAgent('Web')
           : AppInfoService.getUserAgent();
     
     // Longer timeouts for proxy and Android devices
-    _dio.options.connectTimeout = isAndroid 
+    _dio.options.connectTimeout = _isAndroid 
         ? const Duration(seconds: 30) 
         : const Duration(seconds: 20);
-    _dio.options.receiveTimeout = isAndroid 
+    _dio.options.receiveTimeout = _isAndroid 
         ? const Duration(seconds: 30) 
         : const Duration(seconds: 20);
-    _dio.options.sendTimeout = isAndroid 
+    _dio.options.sendTimeout = _isAndroid 
         ? const Duration(seconds: 30) 
         : const Duration(seconds: 20);
     
@@ -51,7 +53,7 @@ class InvoiceService {
     }
     
     // Android WebView requires specific headers to avoid request blocking
-    if (isAndroid) {
+    if (_isAndroid) {
       _dio.options.headers['Accept'] = 'application/json';
       _dio.options.headers['Cache-Control'] = 'no-cache';
       _dio.options.headers.remove('Accept-Encoding');
@@ -61,21 +63,21 @@ class InvoiceService {
     }
     
     _dio.options.followRedirects = true;
-    _dio.options.maxRedirects = isAndroid ? 3 : 5;
+    _dio.options.maxRedirects = _isAndroid ? 3 : 5;
     _dio.options.validateStatus = (status) {
       return status != null && status >= 200 && status < 400;
     };
     
     _dio.interceptors.add(LogInterceptor(
-      requestBody: isAndroid,
+      requestBody: _isAndroid,
       responseBody: true,
-      requestHeader: isAndroid,
-      responseHeader: isAndroid,
+      requestHeader: _isAndroid,
+      responseHeader: _isAndroid,
       error: true,
       logPrint: (obj) => _debugLog('[INVOICE_SERVICE] $obj'),
     ));
     
-    _debugLog('[INVOICE_SERVICE] Configured for ${isAndroid ? "Android" : isWeb ? "Web" : "Desktop"}');
+    _debugLog('[INVOICE_SERVICE] Configured for ${_isAndroid ? "Android" : isWeb ? "Web" : "Desktop"}');
   }
 
   void _configureProxyForDio(Dio dio, {bool enableLogging = false}) {
@@ -119,8 +121,7 @@ class InvoiceService {
         'Content-Type': 'application/json',
       };
 
-      final isAndroid = !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
-      
+        
       // Build extras with fiat information if provided
       // Try multiple approaches to ensure LNBits accepts the fiat data
       Map<String, dynamic>? extras;
@@ -143,7 +144,7 @@ class InvoiceService {
       // Platform-optimized endpoint ordering for different LNBits API variants
       List<Map<String, dynamic>> endpoints;
       
-      if (isAndroid) {
+      if (_isAndroid) {
         // Android-optimized endpoints tested manually
         endpoints = [
           // Try LNBits LNURLP endpoint with fiat info (common pattern)
@@ -343,7 +344,7 @@ class InvoiceService {
         try {
           _debugLog('[INVOICE_SERVICE] Trying endpoint: $url (${i + 1}/${endpoints.length})');
           _debugLog('[INVOICE_SERVICE] Data: $data');
-          _debugLog('[INVOICE_SERVICE] Platform: ${isAndroid ? "Android" : "Web/Desktop"}');
+          _debugLog('[INVOICE_SERVICE] Platform: ${_isAndroid ? "Android" : "Web/Desktop"}');
           _debugLog('[INVOICE_SERVICE] Headers: $headers');
           
           // Special logging for fiat endpoints
@@ -666,8 +667,7 @@ class InvoiceService {
         'Content-Type': 'application/json',
       };
 
-      final isAndroid = !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
-
+  
       // For amountless invoices, convert sats to millisatoshis for LNBits API
       final int? amountMsat = amount != null ? amount * 1000 : null;
 
@@ -676,7 +676,7 @@ class InvoiceService {
       // Platform-optimized endpoints for payment processing
       List<Map<String, dynamic>> endpoints;
 
-      if (isAndroid) {
+      if (_isAndroid) {
         // Android-optimized payment endpoints tested
         endpoints = [
           {
@@ -799,7 +799,7 @@ class InvoiceService {
         try {
           _debugLog('[INVOICE_SERVICE] Trying endpoint $url (${i + 1}/${endpoints.length})');
           _debugLog('[INVOICE_SERVICE] Data: $data');
-          _debugLog('[INVOICE_SERVICE] Platform: ${isAndroid ? "Android" : "Web/Desktop"}');
+          _debugLog('[INVOICE_SERVICE] Platform: ${_isAndroid ? "Android" : "Web/Desktop"}');
           _debugLog('[INVOICE_SERVICE] Headers: $headers');
 
           final response = await _dio.post(
@@ -1081,8 +1081,7 @@ class InvoiceService {
       final username = parts[0];
       final domain = parts[1];
       
-      final isAndroid = !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
-      final isWeb = kIsWeb;
+        final isWeb = kIsWeb;
       
       // Check if it's external domain on web - exit immediately to avoid CORS
       if (isWeb && currentServerUrl != null) {
@@ -1116,14 +1115,14 @@ class InvoiceService {
       for (final url in urls) {
         try {
           _debugLog('[INVOICE_SERVICE] Trying resolution: $url');
-          _debugLog('[INVOICE_SERVICE] Platform: ${isAndroid ? "Android" : "Web/Desktop"}');
+          _debugLog('[INVOICE_SERVICE] Platform: ${_isAndroid ? "Android" : "Web/Desktop"}');
           
           // Create specific client for external request
           final externalDio = Dio();
-          externalDio.options.connectTimeout = isAndroid 
+          externalDio.options.connectTimeout = _isAndroid 
               ? const Duration(seconds: 20) 
               : const Duration(seconds: 15);
-          externalDio.options.receiveTimeout = isAndroid 
+          externalDio.options.receiveTimeout = _isAndroid 
               ? const Duration(seconds: 20) 
               : const Duration(seconds: 15);
           externalDio.options.headers['User-Agent'] = AppInfoService.getUserAgent();
@@ -1131,7 +1130,7 @@ class InvoiceService {
           
           _configureProxyForDio(externalDio);
           
-          if (isAndroid) {
+          if (_isAndroid) {
             externalDio.options.headers['Cache-Control'] = 'no-cache';
             externalDio.options.followRedirects = true;
             externalDio.options.maxRedirects = 3;

--- a/lib/services/invoice_service.dart
+++ b/lib/services/invoice_service.dart
@@ -1,9 +1,8 @@
 import 'package:dio/dio.dart';
 import 'dart:math' as math;
-import 'dart:io' show Platform;
 import 'dart:convert';
 import 'package:crypto/crypto.dart';
-import 'package:flutter/foundation.dart' show kIsWeb, kDebugMode;
+import 'package:flutter/foundation.dart' show kIsWeb, kDebugMode, defaultTargetPlatform, TargetPlatform;
 import '../models/lightning_invoice.dart';
 import '../models/decoded_invoice.dart';
 import '../core/utils/proxy_config.dart';
@@ -24,7 +23,7 @@ class InvoiceService {
   }
 
   void _configureDio() {
-    final isAndroid = !kIsWeb && Platform.isAndroid;
+    final isAndroid = !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
     final isWeb = kIsWeb;
     
     _dio.options.headers['Content-Type'] = 'application/json';
@@ -120,7 +119,7 @@ class InvoiceService {
         'Content-Type': 'application/json',
       };
 
-      final isAndroid = !kIsWeb && Platform.isAndroid;
+      final isAndroid = !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
       
       // Build extras with fiat information if provided
       // Try multiple approaches to ensure LNBits accepts the fiat data
@@ -667,7 +666,7 @@ class InvoiceService {
         'Content-Type': 'application/json',
       };
 
-      final isAndroid = !kIsWeb && Platform.isAndroid;
+      final isAndroid = !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
 
       // For amountless invoices, convert sats to millisatoshis for LNBits API
       final int? amountMsat = amount != null ? amount * 1000 : null;
@@ -1082,7 +1081,7 @@ class InvoiceService {
       final username = parts[0];
       final domain = parts[1];
       
-      final isAndroid = !kIsWeb && Platform.isAndroid;
+      final isAndroid = !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
       final isWeb = kIsWeb;
       
       // Check if it's external domain on web - exit immediately to avoid CORS

--- a/lib/services/nfc_charge_service.dart
+++ b/lib/services/nfc_charge_service.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io' show Platform;
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:nfc_manager/nfc_manager.dart';
@@ -38,7 +37,7 @@ class NfcChargeService {
   }
 
   void _configureDio() {
-    final isAndroid = !kIsWeb && Platform.isAndroid;
+    final isAndroid = !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
     _dio.options.headers['User-Agent'] = isAndroid
         ? AppInfoService.getUserAgent('Android')
         : AppInfoService.getUserAgent();


### PR DESCRIPTION
Migrates all Platform.is* checks to defaultTargetPlatform from package:flutter/foundation.dart across 4 files (5 occurrences).
proxy_config.dart untouched as it uses Platform.environment legitimately.
Closes #91


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated platform detection mechanisms across multiple components for improved cross-platform consistency and web compatibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lachispame/lachispa/pull/102)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->