### PR TITLE
fix: localize hardcoded strings in QRScannerWidget (closes #73)

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -373,5 +373,7 @@
   "nfc_charge_error_prefix": "NFC-Fehler beim Einziehen: ",
   "nfc_charge_unknown_error": "Unbekannter Fehler beim Einziehen",
   "share_ready_message": "Bereit zum Teilen",
-  "lnurl_copied_message": "LNURL in die Zwischenablage kopiert"
+  "lnurl_copied_message": "LNURL in die Zwischenablage kopiert",
+  "qr_scanner_title": "QR scannen",
+  "qr_scanner_instructions": "Kamera auf den QR-Code richten\num Rechnung oder Adresse zu scannen"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -388,5 +388,7 @@
   "nfc_charge_error_prefix": "NFC charge error: ",
   "nfc_charge_unknown_error": "Unknown error during charge",
   "share_ready_message": "Ready to share",
-  "lnurl_copied_message": "LNURL copied to clipboard"
+  "lnurl_copied_message": "LNURL copied to clipboard",
+  "qr_scanner_title": "Scan QR",
+  "qr_scanner_instructions": "Point the camera at the QR code\nto scan the invoice or address"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -373,5 +373,7 @@
   "nfc_charge_error_prefix": "Error en cobro NFC: ",
   "nfc_charge_unknown_error": "Error desconocido al cobrar",
   "share_ready_message": "Listo para compartir",
-  "lnurl_copied_message": "LNURL copiado al portapapeles"
+  "lnurl_copied_message": "LNURL copiado al portapapeles",
+  "qr_scanner_title": "Escanear QR",
+  "qr_scanner_instructions": "Apunta la cámara al código QR\npara escanear la factura o dirección"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -373,5 +373,7 @@
   "nfc_charge_error_prefix": "Erreur d'encaissement NFC : ",
   "nfc_charge_unknown_error": "Erreur inconnue lors de l'encaissement",
   "share_ready_message": "Prêt à partager",
-  "lnurl_copied_message": "LNURL copié dans le presse-papiers"
+  "lnurl_copied_message": "LNURL copié dans le presse-papiers",
+  "qr_scanner_title": "Scanner QR",
+  "qr_scanner_instructions": "Pointez la caméra vers le code QR\npour scanner la facture ou l'adresse"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -373,5 +373,7 @@
   "nfc_charge_error_prefix": "Errore incasso NFC: ",
   "nfc_charge_unknown_error": "Errore sconosciuto durante l'incasso",
   "share_ready_message": "Pronto da condividere",
-  "lnurl_copied_message": "LNURL copiato negli appunti"
+  "lnurl_copied_message": "LNURL copiato negli appunti",
+  "qr_scanner_title": "Scansiona QR",
+  "qr_scanner_instructions": "Punta la fotocamera sul codice QR\nper scansionare la fattura o l'indirizzo"
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -373,5 +373,7 @@
   "nfc_charge_error_prefix": "Erro ao cobrar com NFC: ",
   "nfc_charge_unknown_error": "Erro desconhecido ao cobrar",
   "share_ready_message": "Pronto para compartilhar",
-  "lnurl_copied_message": "LNURL copiado para a área de transferência"
+  "lnurl_copied_message": "LNURL copiado para a área de transferência",
+  "qr_scanner_title": "Escanear QR",
+  "qr_scanner_instructions": "Aponte a câmera para o código QR\npara escanear a fatura ou endereço"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -373,5 +373,7 @@
   "nfc_charge_error_prefix": "Ошибка приёма по NFC: ",
   "nfc_charge_unknown_error": "Неизвестная ошибка при списании",
   "share_ready_message": "Готово к отправке",
-  "lnurl_copied_message": "LNURL скопирован в буфер обмена"
+  "lnurl_copied_message": "LNURL скопирован в буфер обмена",
+  "qr_scanner_title": "Сканировать QR",
+  "qr_scanner_instructions": "Наведите камеру на QR-код\nчтобы сканировать счёт или адрес"
 }

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -68,7 +68,7 @@ import 'app_localizations_ru.dart';
 /// property.
 abstract class AppLocalizations {
   AppLocalizations(String locale)
-      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -91,11 +91,11 @@ abstract class AppLocalizations {
   /// of delegates is preferred or required.
   static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
       <LocalizationsDelegate<dynamic>>[
-    delegate,
-    GlobalMaterialLocalizations.delegate,
-    GlobalCupertinoLocalizations.delegate,
-    GlobalWidgetsLocalizations.delegate,
-  ];
+        delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
@@ -105,7 +105,7 @@ abstract class AppLocalizations {
     Locale('fr'),
     Locale('it'),
     Locale('pt'),
-    Locale('ru')
+    Locale('ru'),
   ];
 
   /// No description provided for @welcome_title.
@@ -1901,6 +1901,18 @@ abstract class AppLocalizations {
   /// In es, this message translates to:
   /// **'LNURL copiado al portapapeles'**
   String get lnurl_copied_message;
+
+  /// No description provided for @qr_scanner_title.
+  ///
+  /// In es, this message translates to:
+  /// **'Escanear QR'**
+  String get qr_scanner_title;
+
+  /// No description provided for @qr_scanner_instructions.
+  ///
+  /// In es, this message translates to:
+  /// **'Apunta la cámara al código QR\npara escanear la factura o dirección'**
+  String get qr_scanner_instructions;
 }
 
 class _AppLocalizationsDelegate
@@ -1914,14 +1926,14 @@ class _AppLocalizationsDelegate
 
   @override
   bool isSupported(Locale locale) => <String>[
-        'de',
-        'en',
-        'es',
-        'fr',
-        'it',
-        'pt',
-        'ru'
-      ].contains(locale.languageCode);
+    'de',
+    'en',
+    'es',
+    'fr',
+    'it',
+    'pt',
+    'ru',
+  ].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
@@ -1947,8 +1959,9 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
   }
 
   throw FlutterError(
-      'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-      'an issue with the localizations generation tool. Please file an issue '
-      'on GitHub with a reproducible sample app and the gen-l10n configuration '
-      'that was used.');
+    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.',
+  );
 }

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -943,7 +943,9 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String currency_not_available_on_server(
-      Object currency, Object currencyName) {
+    Object currency,
+    Object currencyName,
+  ) {
     return '$currencyName ($currency) ist auf diesem Server nicht verfügbar';
   }
 
@@ -998,4 +1000,11 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get lnurl_copied_message => 'LNURL in die Zwischenablage kopiert';
+
+  @override
+  String get qr_scanner_title => 'QR scannen';
+
+  @override
+  String get qr_scanner_instructions =>
+      'Kamera auf den QR-Code richten\num Rechnung oder Adresse zu scannen';
 }

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -919,7 +919,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String currency_not_available_on_server(
-      Object currency, Object currencyName) {
+    Object currency,
+    Object currencyName,
+  ) {
     return '$currencyName ($currency) is not available on this server';
   }
 
@@ -974,4 +976,11 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get lnurl_copied_message => 'LNURL copied to clipboard';
+
+  @override
+  String get qr_scanner_title => 'Scan QR';
+
+  @override
+  String get qr_scanner_instructions =>
+      'Point the camera at the QR code\nto scan the invoice or address';
 }

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -932,7 +932,9 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String currency_not_available_on_server(
-      Object currency, Object currencyName) {
+    Object currency,
+    Object currencyName,
+  ) {
     return '$currencyName ($currency) no está disponible en este servidor';
   }
 
@@ -987,4 +989,11 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get lnurl_copied_message => 'LNURL copiado al portapapeles';
+
+  @override
+  String get qr_scanner_title => 'Escanear QR';
+
+  @override
+  String get qr_scanner_instructions =>
+      'Apunta la cámara al código QR\npara escanear la factura o dirección';
 }

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -949,7 +949,9 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String currency_not_available_on_server(
-      Object currency, Object currencyName) {
+    Object currency,
+    Object currencyName,
+  ) {
     return '$currencyName ($currency) n\'est pas disponible sur ce serveur';
   }
 
@@ -1005,4 +1007,11 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get lnurl_copied_message => 'LNURL copié dans le presse-papiers';
+
+  @override
+  String get qr_scanner_title => 'Scanner QR';
+
+  @override
+  String get qr_scanner_instructions =>
+      'Pointez la caméra vers le code QR\npour scanner la facture ou l\'adresse';
 }

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -944,7 +944,9 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String currency_not_available_on_server(
-      Object currency, Object currencyName) {
+    Object currency,
+    Object currencyName,
+  ) {
     return '$currencyName ($currency) non è disponibile su questo server';
   }
 
@@ -1001,4 +1003,11 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get lnurl_copied_message => 'LNURL copiato negli appunti';
+
+  @override
+  String get qr_scanner_title => 'Scansiona QR';
+
+  @override
+  String get qr_scanner_instructions =>
+      'Punta la fotocamera sul codice QR\nper scansionare la fattura o l\'indirizzo';
 }

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -931,7 +931,9 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String currency_not_available_on_server(
-      Object currency, Object currencyName) {
+    Object currency,
+    Object currencyName,
+  ) {
     return '$currencyName ($currency) não está disponível neste servidor';
   }
 
@@ -987,4 +989,11 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get lnurl_copied_message =>
       'LNURL copiado para a área de transferência';
+
+  @override
+  String get qr_scanner_title => 'Escanear QR';
+
+  @override
+  String get qr_scanner_instructions =>
+      'Aponte a câmera para o código QR\npara escanear a fatura ou endereço';
 }

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -923,7 +923,9 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String currency_not_available_on_server(
-      Object currency, Object currencyName) {
+    Object currency,
+    Object currencyName,
+  ) {
     return '$currencyName ($currency) недоступна на этом сервере';
   }
 
@@ -978,4 +980,11 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get lnurl_copied_message => 'LNURL скопирован в буфер обмена';
+
+  @override
+  String get qr_scanner_title => 'Сканировать QR';
+
+  @override
+  String get qr_scanner_instructions =>
+      'Наведите камеру на QR-код\nчтобы сканировать счёт или адрес';
 }

--- a/lib/widgets/qr_scanner_widget.dart
+++ b/lib/widgets/qr_scanner_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
+import '../l10n/generated/app_localizations.dart';
 import '../theme/app_tokens.dart';
 
 class _QrScannerOverlayShape extends ShapeBorder {
@@ -253,7 +254,7 @@ class _QRScannerWidgetState extends State<QRScannerWidget> {
 
                     // Title
                     Text(
-                      'Escanear QR',
+                      AppLocalizations.of(context)!.qr_scanner_title,
                       style: TextStyle(
                         fontSize: 20,
                         fontWeight: FontWeight.w600,
@@ -299,7 +300,7 @@ class _QRScannerWidgetState extends State<QRScannerWidget> {
                       ),
                     ),
                     child: Text(
-                      'Point the camera at the QR code\nto scan the invoice or address',
+                      AppLocalizations.of(context)!.qr_scanner_instructions,
                       style: TextStyle(
                         fontSize: 14,
                         fontWeight: FontWeight.w400,


### PR DESCRIPTION
Adds qr_scanner_title and qr_scanner_instructions to all 7 locale files and updates QRScannerWidget to use AppLocalizations.
Closes #73 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Internationalization**
  * Added multi-language support for the QR scanner feature across German, English, Spanish, French, Italian, Portuguese, and Russian.
  * Updated the QR scanner interface to display localized titles and instructions based on user language settings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lachispame/lachispa/pull/103)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->