### PR TITLE
docs: replace obsolete <a name> anchor with <a id>

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -188,7 +188,7 @@ See root project LICENSE file.
 
 ---
 
-<a name="espanol-section"></a>
+<a id="espanol-section"></a>
 
 # Documentación de Docker - LaChispa
 


### PR DESCRIPTION
Replaces deprecated HTML name anchor with id attribute for consistent resolution across renderers.
Closes #65 