### PR TITLE
fix: update all port 80 references to 8080 after nginx-unprivileged switch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
 
             ```bash
             docker pull ghcr.io/${{ github.repository }}:${{ github.ref_name }}
-            docker run -p 7777:80 ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            docker run -p 7777:8080 ghcr.io/${{ github.repository }}:${{ github.ref_name }}
             ```
           files: |
             release-apks/*.apk

--- a/docker/README.md
+++ b/docker/README.md
@@ -81,7 +81,7 @@ The service includes Traefik labels for automatic discovery:
 labels:
   - "traefik.enable=true"
   - "traefik.http.routers.lachispa.rule=Host(`lachispa.local`)"
-  - "traefik.http.services.lachispa.loadbalancer.server.port=80"
+  - "traefik.http.services.lachispa.loadbalancer.server.port=8080"
 ```
 
 Ensure Traefik is running in your Docker environment.
@@ -273,7 +273,7 @@ El servicio incluye etiquetas de Traefik para descubrimiento automático:
 labels:
   - "traefik.enable=true"
   - "traefik.http.routers.lachispa.rule=Host(`lachispa.local`)"
-  - "traefik.http.services.lachispa.loadbalancer.server.port=80"
+  - "traefik.http.services.lachispa.loadbalancer.server.port=8080"
 ```
 
 Asegúrate de que Traefik esté ejecutándose en tu entorno Docker.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,13 +8,13 @@ services:
         - FLUTTER_WEB_RENDERER=html
     container_name: lachispa-web
     ports:
-      - "7777:80"
+      - "7777:8080"
     restart: unless-stopped
     environment:
       - NGINX_HOST=localhost
-      - NGINX_PORT=80
+      - NGINX_PORT=8080
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost/"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -27,7 +27,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.lachispa.rule=Host(`lachispa.local`)"
-      - "traefik.http.services.lachispa.loadbalancer.server.port=80"
+      - "traefik.http.services.lachispa.loadbalancer.server.port=8080"
     networks:
       - lachispa-network
 

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -34,7 +34,7 @@ http {
         image/svg+xml;
 
     server {
-        listen 80;
+        listen 8080;
         server_name localhost;
         root /usr/share/nginx/html;
         index index.html;


### PR DESCRIPTION
Updates nginx.conf listen directive, docker-compose ports/env/healthcheck/Traefik label, README docs, and release workflow to use port 8080 consistently with the nginx-unprivileged image
Closes #64