### PR TITLE
fix: add reentrancy guard and cancel timeout timer on payment confirmed

### DIFF
--- a/lib/screens/9receive_screen.dart
+++ b/lib/screens/9receive_screen.dart
@@ -38,6 +38,7 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
   final YadioService _yadioService = YadioService();
   final TransactionDetector _transactionDetector = TransactionDetector();
   bool _isGeneratingInvoice = false;
+  bool _isCheckingInvoiceStatus = false;
 
   Timer? _invoicePaymentTimer;
   Timer? _invoicePaymentTimeoutTimer;
@@ -1388,6 +1389,9 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
         return;
       }
 
+      if (_isCheckingInvoiceStatus) return;
+      _isCheckingInvoiceStatus = true;
+
       try {
         final isPaid = await _invoiceService.checkInvoiceStatus(
           serverUrl: serverUrl,
@@ -1397,6 +1401,8 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
 
         if (isPaid) {
           timer.cancel();
+          _invoicePaymentTimeoutTimer?.cancel();
+          _invoicePaymentTimeoutTimer = null;
 
           if (mounted) {
             _transactionDetector.triggerEventSpark('invoice_paid');
@@ -1430,6 +1436,8 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
         }
       } catch (_) {
         // Continue checking on temporary errors
+      } finally {
+        _isCheckingInvoiceStatus = false;
       }
     });
 


### PR DESCRIPTION
- Adds _isCheckingInvoiceStatus guard to prevent concurrent checkInvoiceStatus calls when network is slow
- Cancels _invoicePaymentTimeoutTimer when payment is confirmed to avoid spurious timeout snackbar after successful payment
- Keeps 5s polling interval unchanged
Closes #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved invoice payment monitoring reliability by preventing overlapping status checks and ensuring proper timer cleanup when payments are detected.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lachispame/lachispa/pull/106)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->