### PR TITLE
fix: clear invoice now removes from history instead of leaving pending transactions

### DIFF
--- a/lib/screens/7history_screen.dart
+++ b/lib/screens/7history_screen.dart
@@ -10,6 +10,7 @@ import '../services/wallet_service.dart';
 import '../models/transaction_info.dart';
 import '../l10n/generated/app_localizations.dart';
 import '../theme/app_tokens.dart';
+import '9receive_screen.dart';
 
 class HistoryScreen extends StatefulWidget {
   const HistoryScreen({super.key});
@@ -165,14 +166,20 @@ class _HistoryScreenState extends State<HistoryScreen> with TickerProviderStateM
   }
 
   List<TransactionInfo> get _filteredTransactions {
+    var filtered = _transactions.where((tx) =>
+        !(tx.isPending &&
+          tx.paymentHash != null &&
+          clearedInvoiceHashes.contains(tx.paymentHash))
+    ).toList();
+
     switch (_currentFilter) {
       case TransactionFilter.incoming:
-        return _transactions.where((tx) => tx.isIncoming).toList();
+        return filtered.where((tx) => tx.isIncoming).toList();
       case TransactionFilter.outgoing:
-        return _transactions.where((tx) => tx.isOutgoing).toList();
+        return filtered.where((tx) => tx.isOutgoing).toList();
       case TransactionFilter.all:
       default:
-        return _transactions;
+        return filtered;
     }
   }
 

--- a/lib/screens/9receive_screen.dart
+++ b/lib/screens/9receive_screen.dart
@@ -20,6 +20,8 @@ import '../theme/app_tokens.dart';
 import '7ln_address_screen.dart';
 import 'voucher_scan_screen.dart';
 
+final Set<String> clearedInvoiceHashes = {};
+
 class ReceiveScreen extends StatefulWidget {
   const ReceiveScreen({super.key});
 
@@ -28,6 +30,7 @@ class ReceiveScreen extends StatefulWidget {
 }
 
 class _ReceiveScreenState extends State<ReceiveScreen> {
+
   final _amountController = TextEditingController();
   final _noteController = TextEditingController();
   String _selectedCurrency = 'sats';
@@ -782,6 +785,12 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
   void _clearInvoice() {
     _invoicePaymentTimer?.cancel();
     _invoicePaymentTimeoutTimer?.cancel();
+
+    if (_generatedInvoice != null) {
+      final hash = _generatedInvoice!.paymentHash;
+      unawaited(_tryCancelInvoiceOnServer(hash));
+    }
+
     setState(() {
       _generatedInvoice = null;
     });
@@ -789,6 +798,29 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
       icon: Icons.check_circle,
       message: AppLocalizations.of(context)!.invoice_cleared_message,
     );
+  }
+
+  Future<void> _tryCancelInvoiceOnServer(String paymentHash) async {
+    try {
+      final walletProvider = context.read<WalletProvider>();
+      final authProvider = context.read<AuthProvider>();
+      final serverUrl = authProvider.sessionData?.serverUrl;
+      final wallet = walletProvider.primaryWallet;
+
+      if (serverUrl == null || wallet == null) return;
+
+      final cancelled = await _invoiceService.cancelInvoice(
+        serverUrl: serverUrl,
+        adminKey: wallet.inKey,
+        paymentHash: paymentHash,
+      );
+
+      if (!cancelled) {
+        clearedInvoiceHashes.add(paymentHash);
+      }
+    } catch (e) {
+      clearedInvoiceHashes.add(paymentHash);
+    }
   }
 
   void _showCopySheet(LNAddress? defaultAddress) {

--- a/lib/services/invoice_service.dart
+++ b/lib/services/invoice_service.dart
@@ -1757,6 +1757,49 @@ class InvoiceService {
     };
   }
 
+  Future<bool> cancelInvoice({
+    required String serverUrl,
+    required String adminKey,
+    required String paymentHash,
+  }) async {
+    try {
+      String baseUrl = serverUrl;
+      if (!baseUrl.startsWith('http')) {
+        baseUrl = 'https://$baseUrl';
+      }
+
+      final headers = {'X-API-KEY': adminKey};
+
+      final endpoints = [
+        '$baseUrl/api/v1/payments/$paymentHash',
+        '$baseUrl/api/v1/wallet/payment/$paymentHash',
+      ];
+
+      for (final endpoint in endpoints) {
+        try {
+          _debugLog('[INVOICE_SERVICE] Attempting to cancel invoice: $paymentHash');
+          final response = await _dio.delete(
+            endpoint,
+            options: Options(headers: headers),
+          );
+          if (response.statusCode == 200 || response.statusCode == 204) {
+            _debugLog('[INVOICE_SERVICE] Invoice cancelled successfully: $paymentHash');
+            return true;
+          }
+        } catch (e) {
+          _debugLog('[INVOICE_SERVICE] Cancel failed at $endpoint: $e');
+          continue;
+        }
+      }
+
+      _debugLog('[INVOICE_SERVICE] No endpoint succeeded for invoice cancellation: $paymentHash');
+      return false;
+    } catch (e) {
+      _debugLog('[INVOICE_SERVICE] Error cancelling invoice: $e');
+      return false;
+    }
+  }
+
   void dispose() {
     _dio.close();
   }


### PR DESCRIPTION
## Description

Fixes #107. When a user generates a Bolt11 invoice from the receive screen and presses "Clear invoice", the invoice remained visible in the transaction history because `_clearInvoice()` only cleared local UI state without cancelling the pending invoice on the LNBits server.

## Changes

### `lib/services/invoice_service.dart`
- Added `cancelInvoice()` method that attempts `DELETE /api/v1/payments/{paymentHash}` on multiple LNBits API endpoints

### `lib/screens/9receive_screen.dart`
- Added top-level `clearedInvoiceHashes: Set<String>` shared between screens
- `_clearInvoice()` now triggers async server-side cancellation
- `_tryCancelInvoiceOnServer()`: attempts cancellation on LNBits; falls back to local filtering if server doesn't support it

### `lib/screens/7history_screen.dart`
- `_filteredTransactions` excludes pending transactions whose `paymentHash` is in `clearedInvoiceHashes`

## Hybrid approach (Option D from issue)
1. Try to cancel the invoice on the LNBits server via DELETE endpoint
2. If server doesn't support cancellation, add the payment hash to a local set and filter it from history display


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invoice cancellation: Users can now cancel previously generated invoices directly from the receive screen
  * Updated transaction history: Filtering has been improved to correctly exclude cleared invoices across all transaction view modes

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lachispame/lachispa/pull/108)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->